### PR TITLE
Explicitly declare Hyrax dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -35,6 +35,7 @@ PATH
   remote: .
   specs:
     hyku_addons (0.1.0)
+      hyrax (~> 2.8)
       rails (~> 5.2.4, >= 5.2.4.3)
 
 GEM

--- a/hyku_addons.gemspec
+++ b/hyku_addons.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "rails", "~> 5.2.4", ">= 5.2.4.3"
 
+  spec.add_dependency 'hyrax', '~> 2.8'
+
   spec.add_development_dependency "bixby"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "rspec-rails"


### PR DESCRIPTION
It is not possible to declare Hyku as a dependency because it is not a gem.