### PR TITLE
Create DataCiteEndpoint when other endpoints are created (mostly)

### DIFF
--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -10,7 +10,7 @@ module HykuAddons
     end
 
     def datacite_endpoint
-      super || build_datacite_endpoint || NilDataCiteEndpoint.new
+      super || NilDataCiteEndpoint.new
     end
   end
 end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -60,6 +60,12 @@ module HykuAddons
                                             datacite_endpoint_attributes: %i[mode prefix username password])
           end
       end
+
+      ::CreateAccount.class_eval do
+        def create_account_inline
+          CreateAccountInlineJob.perform_now(account) && account.create_datacite_endpoint
+        end
+      end
     end
   end
 end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+FactoryBot.define do
+  factory :datacite_endpoint do
+    options { Hash.new(mode: 'test', prefix: '10.1234', username: 'user123', password: 'pass123') }
+  end
+end
+
+FactoryBot.modify do
+  factory :account do
+    sequence(:cname) { |_n| srand }
+    solr_endpoint
+    redis_endpoint
+    fcrepo_endpoint
+    datacite_endpoint
+  end
+end

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -63,9 +63,9 @@ RSpec.describe HykuAddons::AccountBehavior do
     end
 
     context 'with missing endpoint' do
-      it 'returns a blank DataCiteEndpoint' do
+      it 'returns a NilDataCiteEndpoint' do
         account.datacite_endpoint = nil
-        expect(account.datacite_endpoint).to be_kind_of DataCiteEndpoint
+        expect(account.datacite_endpoint).to be_kind_of NilDataCiteEndpoint
         expect(account.datacite_endpoint.persisted?).to eq false
         account.switch do
           expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq nil

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,6 +10,9 @@ require File.expand_path('internal_test_hyku/config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
+require 'factory_bot_rails'
+FactoryBot.definition_file_paths = [File.expand_path("spec/factories", HykuAddons::Engine.root)]
+FactoryBot.find_definitions
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are


### PR DESCRIPTION
When I tried to deploy this to AH Demo it couldn't load the app and I think it couldn't even run the migrations because datacite_endpoint didn't exist in the DB yet.  I think this was maybe a chicken/egg problem.  This change should help with that and make it more consistent with the other endpoints.  Testing setup was also improved in the process.