### PR TITLE
Refactor hyrax-doi integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,9 @@ jobs:
       - samvera/install_solr_core:
           solr_config_path: 'spec/internal_test_hyku/solr/config'
 
-      # Setup hyrax-doi
-      - run: bundle exec rails g hyrax:doi:install --datacite
+      # Setup hyku_addons and hyrax-doi
+      - run: bundle exec rails g hyku_addons:install
       - run: bundle exec rails g hyrax:doi:add_to_work_type GenericWork --datacite
-        #- run: bundle exec rake app:hyku_addons:install:migrations
 
       - run: bundle exec rake app:db:create app:db:migrate app:zookeeper:upload
 

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ spec/internal_test_hyku/node_modules/
 spec/internal_test_hyku/yarn-error.log
 spec/internal_test_hyku/storage/
 spec/internal_test_hyku/tmp/
-db/migrate/*.hyrax.rb
 .byebug_history
 coverage/
 tmp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
 
 Metrics/BlockLength:
   Exclude:
+    - 'hyku_addons.gemspec'
     - 'lib/hyku_addons/engine.rb'
     - 'spec/**/*.rb'
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,12 +12,6 @@ gemspec
 # Git. Remember to move these dependencies to your gemspec before releasing
 # your gem to rubygems.org.
 
-# Had to specify these explicitly in the internal_test_hyku's Gemfile and pin stuff for bundler to resolve
-# I'm not sure if here is sufficient or if they actually have to be in Hyku's Gemfile
-gem 'hyrax-doi'
-gem 'maremma', '< 4.8'
-gem 'postrank-uri', '>= 1.0.24'
-
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 # gem 'mini_racer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,10 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     almond-rails (0.3.0)
       rails (>= 4.2)
+    ammeter (1.1.4)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-rails (>= 2.2)
     apartment (2.2.1)
       activerecord (>= 3.1.2, < 6.0)
       parallel (>= 0.7.1)
@@ -1075,6 +1079,7 @@ DEPENDENCIES
   active-fedora (>= 11.1.4)
   active_elastic_job!
   activerecord-nulldb-adapter
+  ammeter
   apartment
   aws-sdk-sqs
   bixby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,6 +39,9 @@ PATH
     hyku_addons (0.1.0)
       hyrax (~> 2.8)
       hyrax-doi
+      maremma (< 4.8)
+      postrank-uri (>= 1.0.24)
+      public_suffix (~> 2.0.2)
       rails (~> 5.2.4, >= 5.2.4.3)
 
 GEM
@@ -1098,7 +1101,6 @@ DEPENDENCIES
   honeybadger (~> 3.0)
   hyku_addons!
   hyrax (~> 2.9)
-  hyrax-doi
   i18n-debug
   i18n-tasks
   is_it_working
@@ -1106,11 +1108,9 @@ DEPENDENCIES
   jquery-rails
   listen (>= 3.0.5, < 3.2)
   lograge
-  maremma (< 4.8)
   mods (~> 2.4)
   parser (~> 2.5.3)
   pg
-  postrank-uri (>= 1.0.24)
   puma (~> 3.12)
   rack-test (= 0.7.0)
   rails (~> 5.2.4, >= 5.2.4.3)

--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ When behavior that is tested in Hyku changes, copy the relevant test files from 
 
 ## Development
 
+Check out the code then initialize the internal test hyku application:
+```
+git submodule init
+git submodule update
+bundle install
+bundle exec rails g hyku_addons:install
+bundle exec rake app:hyku_addons:install:migrations
+bundle exec rails g hyrax:doi:add_to_work_type GenericWork --datacite
+```
+
 ### Docker
 
 Running a docker development environment is possible by running:

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ git submodule init
 git submodule update
 bundle install
 bundle exec rails g hyku_addons:install
-bundle exec rake app:hyku_addons:install:migrations
 bundle exec rails g hyrax:doi:add_to_work_type GenericWork --datacite
 ```
 

--- a/app/models/datacite_endpoint.rb
+++ b/app/models/datacite_endpoint.rb
@@ -8,6 +8,7 @@ class DataCiteEndpoint < ::Endpoint
     Hyrax::DOI::DataCiteRegistrar.prefix = prefix
     Hyrax::DOI::DataCiteRegistrar.username = username
     Hyrax::DOI::DataCiteRegistrar.password = password
+    Rails.application.routes.default_url_options[:host] = account.cname
   end
 
   # No special handling just destroy this record
@@ -20,6 +21,7 @@ class DataCiteEndpoint < ::Endpoint
     Hyrax::DOI::DataCiteRegistrar.prefix = nil
     Hyrax::DOI::DataCiteRegistrar.username = nil
     Hyrax::DOI::DataCiteRegistrar.password = nil
+    Rails.application.routes.default_url_options[:host] = nil
   end
 
   def ping

--- a/app/models/nil_datacite_endpoint.rb
+++ b/app/models/nil_datacite_endpoint.rb
@@ -5,6 +5,7 @@ class NilDataCiteEndpoint < NilEndpoint
     Hyrax::DOI::DataCiteRegistrar.prefix = nil
     Hyrax::DOI::DataCiteRegistrar.username = nil
     Hyrax::DOI::DataCiteRegistrar.password = nil
+    Rails.application.routes.default_url_options[:host] = nil
   end
 
   def mode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       REDIS_HOST: redis
       SECRET_KEY_BASE: asdf
       SETTINGS__ACTIVE_JOB__QUEUE_ADAPTER: sidekiq
-      SETTINGS__BULKRAX__ENABLED: "false"
+      SETTINGS__BULKRAX__ENABLED: "true"
       SETTINGS__FITS_PATH: /opt/fits/fits.sh
       # Comment out these 5 for single tenancy / Uncomment for multi
       SETTINGS__MULTITENANCY__ADMIN_HOST: lvh.me

--- a/hyku_addons.gemspec
+++ b/hyku_addons.gemspec
@@ -35,6 +35,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'postrank-uri', '>= 1.0.24'
   spec.add_dependency 'public_suffix', '~> 2.0.2'
 
+  spec.add_development_dependency 'ammeter'
   spec.add_development_dependency "bixby"
   spec.add_development_dependency "pg"
   spec.add_development_dependency "rspec-rails"

--- a/hyku_addons.gemspec
+++ b/hyku_addons.gemspec
@@ -30,6 +30,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'hyrax', '~> 2.8'
   spec.add_dependency 'hyrax-doi'
+  # Pins to help bundler resolve
+  spec.add_dependency 'maremma', '< 4.8'
+  spec.add_dependency 'postrank-uri', '>= 1.0.24'
+  spec.add_dependency 'public_suffix', '~> 2.0.2'
 
   spec.add_development_dependency "bixby"
   spec.add_development_dependency "pg"

--- a/lib/generators/hyku_addons/install_generator.rb
+++ b/lib/generators/hyku_addons/install_generator.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+module HykuAddons
+  class InstallGenerator < Rails::Generators::Base
+    desc <<-EOS
+      This generator makes the following changes to Hyku:
+        1. Installs and configures hyrax-doi
+    EOS
+
+    source_root File.expand_path('templates', __dir__)
+
+    def install_hyrax_doi
+      generate 'hyrax:doi:install --datacite'
+      # Configure default_url_options
+      # Rails.application.routes.default_url_options[:host] = 'lvh.me:3000' ?
+
+      # generate 'hyrax:doi:add_to_work_type GenericWork --datacite'
+    end
+  end
+end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -11,14 +11,11 @@ module HykuAddons
       end
     end
 
-    config.after_initialize do
-      # Prepend our views so they have precedence
-      ActionController::Base.prepend_view_path(paths['app/views'].existent)
-      # Append our locales so they have precedence
-      I18n.load_path += Dir[HykuAddons::Engine.root.join('config', 'locales', '*.{rb,yml}')]
+    initializer 'hyku_additions.class_overrides_for_hyrax-doi' do
+      require 'hyrax/search_state'
 
       # Cannot do prepend here because it causes it to get loaded before AcitveRecord breaking things
-      ::Account.class_eval do
+      Account.class_eval do
         include HykuAddons::AccountBehavior
 
         # @return [Account] a placeholder account using the default connections configured by the application
@@ -48,7 +45,7 @@ module HykuAddons
       end
 
       # Using a concern doesn't actually override the original method so inlining it here
-      ::Proprietor::AccountsController.class_eval do
+      Proprietor::AccountsController.class_eval do
         private
 
           # Never trust parameters from the scary internet, only allow the allowed list through.
@@ -61,11 +58,18 @@ module HykuAddons
           end
       end
 
-      ::CreateAccount.class_eval do
+      CreateAccount.class_eval do
         def create_account_inline
           CreateAccountInlineJob.perform_now(account) && account.create_datacite_endpoint
         end
       end
+    end
+
+    config.after_initialize do
+      # Prepend our views so they have precedence
+      ActionController::Base.prepend_view_path(paths['app/views'].existent)
+      # Append our locales so they have precedence
+      I18n.load_path += Dir[HykuAddons::Engine.root.join('config', 'locales', '*.{rb,yml}')]
     end
   end
 end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
+require 'hyrax/doi/engine'
+
 module HykuAddons
   class Engine < ::Rails::Engine
     isolate_namespace HykuAddons
 
-    # Automount this engine
-    # Only do this because this is just for us and we don't need to allow control over the mount to the application
-    initializer 'hyku_additions.routes' do |app|
-      app.routes.append do
-        mount HykuAddons::Engine, at: '/'
-      end
-    end
+    # # Automount this engine
+    # # Only do this because this is just for us and we don't need to allow control over the mount to the application
+    # initializer 'hyku_additions.routes' do |app|
+    #   app.routes.append do
+    #     mount HykuAddons::Engine, at: '/'
+    #   end
+    # end
 
     initializer 'hyku_additions.class_overrides_for_hyrax-doi' do
       require 'hyrax/search_state'
@@ -70,6 +72,24 @@ module HykuAddons
       ActionController::Base.prepend_view_path(paths['app/views'].existent)
       # Append our locales so they have precedence
       I18n.load_path += Dir[HykuAddons::Engine.root.join('config', 'locales', '*.{rb,yml}')]
+    end
+
+    ## In engine development mode (ENGINE_ROOT defined) handle specific generators as app-only by setting destintation_root appropriately
+    initializer 'hyku_addons.app_generators' do
+      if defined?(ENGINE_ROOT)
+        APP_GENERATORS = ['HykuAddons::InstallGenerator', 'Hyrax::DOI::InstallGenerator', 'Hyrax::DOI::AddToWorkTypeGenerator'].freeze
+
+        Rails::Generators::Base.class_eval do
+          def initialize(args, options, config)
+            # Force the destination root to be the rails application and not this engine when doing development
+            # See https://github.com/rails/rails/blob/fb852668dff2786a4cfb30ad923830da9eed2476/railties/lib/rails/commands/generate/generate_command.rb#L26
+            # and https://github.com/rails/rails/blob/9d44519afc5290eab8479db851f09653cf0a916f/railties/lib/rails/command.rb#L75-L82
+
+            config[:destination_root] = Pathname.new(File.expand_path("../..", APP_PATH)) if self.class.name.in?(APP_GENERATORS)
+            super
+          end
+        end
+      end
     end
   end
 end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -13,8 +13,19 @@ module HykuAddons
     #   end
     # end
 
+    config.before_initialize do
+      # Eager load required for overrides in the initializer below
+      # There is probably a better solution for this but I don't think it is worth the time
+      # tinkering with it since this works and doesn't cause too much of a slowdown
+      if Rails.env == 'development' # Only do this for development environment for now
+        Rails.application.configure do
+          config.eager_load = true
+        end
+      end
+    end
+
     initializer 'hyku_additions.class_overrides_for_hyrax-doi' do
-      require 'hyrax/search_state'
+      require_dependency 'hyrax/search_state'
 
       # Cannot do prepend here because it causes it to get loaded before AcitveRecord breaking things
       Account.class_eval do

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+require 'rails_helper'
+# Generators are not automatically loaded by Rails
+require 'generators/hyku_addons/install_generator'
+
+RSpec.describe HykuAddons::InstallGenerator, type: :generator do
+  # Tell the generator where to put its output (what it thinks of as Rails.root)
+  destination HykuAddons::Engine.root.join("tmp", "generator_testing")
+
+  before do
+    # This will wipe the destination root dir
+    prepare_destination
+  end
+
+  it 'runs' do
+    run_generator
+  end
+end

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe HykuAddons::AccountBehavior do
       expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq '10.1234'
       expect(Hyrax::DOI::DataCiteRegistrar.username).to eq 'user123'
       expect(Hyrax::DOI::DataCiteRegistrar.password).to eq 'pass123'
+      expect(Rails.application.routes.default_url_options[:host]).to eq account.cname
     end
   end
 
@@ -31,6 +32,7 @@ RSpec.describe HykuAddons::AccountBehavior do
     let!(:previous_datacite_prefix) { Hyrax::DOI::DataCiteRegistrar.prefix }
     let!(:previous_datacite_username) { Hyrax::DOI::DataCiteRegistrar.username }
     let!(:previous_datacite_password) { Hyrax::DOI::DataCiteRegistrar.password }
+    let!(:previous_account_cname) { account.cname }
 
     before do
       account.build_solr_endpoint(url: 'http://example.com/solr/')
@@ -49,6 +51,7 @@ RSpec.describe HykuAddons::AccountBehavior do
         expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq '10.1234'
         expect(Hyrax::DOI::DataCiteRegistrar.username).to eq 'user123'
         expect(Hyrax::DOI::DataCiteRegistrar.password).to eq 'pass123'
+        expect(Rails.application.routes.default_url_options[:host]).to eq account.cname
       end
     end
 
@@ -60,6 +63,7 @@ RSpec.describe HykuAddons::AccountBehavior do
       expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq previous_datacite_prefix
       expect(Hyrax::DOI::DataCiteRegistrar.username).to eq previous_datacite_username
       expect(Hyrax::DOI::DataCiteRegistrar.password).to eq previous_datacite_password
+      expect(Rails.application.routes.default_url_options[:host]).to eq previous_account_cname
     end
 
     context 'with missing endpoint' do
@@ -72,6 +76,7 @@ RSpec.describe HykuAddons::AccountBehavior do
           expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq nil
           expect(Hyrax::DOI::DataCiteRegistrar.password).to eq nil
           expect(Hyrax::DOI::DataCiteRegistrar.username).to eq nil
+          expect(Rails.application.routes.default_url_options[:host]).to eq nil
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,9 @@ require 'factory_bot_rails'
 FactoryBot.definition_file_paths = [File.expand_path("spec/factories", HykuAddons::Engine.root)]
 FactoryBot.find_definitions
 
+# For testing generators
+require 'ammeter/init'
+
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
- Add hyku_addons:install generator
- Mark specific generators as app-only instead of operating on the engine
- Force `eager_load` in development environment to deal with autoloading issue
- Switch rails `default_url_options` so url the DOI resolves to is correct