### PR TITLE
Run single container because spin up time is much greater than the time it takes to run rspec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,6 @@ jobs:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
       ruby_version: << parameters.ruby_version >>
 
-    parallelism: 4
-
     environment:
       RAILS_VERSION: << parameters.rails_version >>
       DATABASE_NAME: circle_test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ jobs:
     parameters:
       parallelism:
         type: integer
-        default: 4
+        default: 1
     docker:
       - image: cimg/base:stable
     steps:


### PR DESCRIPTION
This saves circleci resources so we can run tests in parallel.