### PR TITLE
Don't try to get connection if not connected

### DIFF
--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -140,7 +140,7 @@ module HykuAddons
       Flipflop::Facade.module_eval do
         def method_missing(method, *args)
           if method[-1] == "?"
-            return false unless ActiveRecord::Base.connection.table_exists?(:hyrax_features)
+            return false unless ActiveRecord::Base.connected? && ActiveRecord::Base.connection.table_exists?(:hyrax_features)
             Flipflop::FeatureSet.current.enabled?(method[0..-2].to_sym)
           else
             super


### PR DESCRIPTION
This avoids an error which is raised when running `DB_ADAPTER=nulldb bundle exec rake assets:precompile` in the AH Dockerfile when the database hasn't been setup yet.
The error happens because the override of `flipflop` I put in to deal with this problem isn't quite good enough.  This PR closes a hole.  See https://github.com/ubiquitypress/hyku_addons/blob/main/lib/hyku_addons/engine.rb#L135-L150

I'm going to raise this with Hyrax devs and see if it shouldn't be turned into a Proc in `GenericWorksController`