### PR TITLE
Class fields are too new for Uglifier

### DIFF
--- a/app/assets/javascripts/hyku_addons/change_toggleable_listener.js
+++ b/app/assets/javascripts/hyku_addons/change_toggleable_listener.js
@@ -15,15 +15,15 @@
 //  </div>
 
 class ChangeToggleableListener {
-  parentSelector = "[data-toggleable]"
-  groupAttributeName = "data-toggleable-group"
-  groupSelector = `[${this.groupAttributeName}]`
-  controlSelector = "[data-toggleable-control]"
-  requiredSelector = "[data-required]"
-  eventName = "toggleable_group"
-  afterHiddenAttributeName = "data-after-toggleable-hidden"
-
   constructor(){
+    this.parentSelector = "[data-toggleable]"
+    this.groupAttributeName = "data-toggleable-group"
+    this.groupSelector = `[${this.groupAttributeName}]`
+    this.controlSelector = "[data-toggleable-control]"
+    this.requiredSelector = "[data-required]"
+    this.eventName = "toggleable_group"
+    this.afterHiddenAttributeName = "data-after-toggleable-hidden"
+
     this.onLoad()
     this.registerListeners()
   }

--- a/app/assets/javascripts/hyku_addons/cloneable_listener.js
+++ b/app/assets/javascripts/hyku_addons/cloneable_listener.js
@@ -10,11 +10,11 @@
 // </div>
 
 class CloneableListener {
-  cloneableAttributeName = "data-cloneable"
-  cloneableSelector = `[${this.cloneableAttributeName}]`
-  afterEventsDataAttributeName = "data-after-clone"
-
   constructor(){
+    this.cloneableAttributeName = "data-cloneable"
+    this.cloneableSelector = `[${this.cloneableAttributeName}]`
+    this.afterEventsDataAttributeName = "data-after-clone"
+
     this.registerListeners()
   }
 

--- a/app/assets/javascripts/hyku_addons/input_clearable_listener.js
+++ b/app/assets/javascripts/hyku_addons/input_clearable_listener.js
@@ -2,9 +2,9 @@
 // $("body").trigger("clear_inputs", [$(el)])
 
 class InputClearableListener {
-  eventName = "clear_inputs"
-
   constructor(){
+    this.eventName = "clear_inputs"
+
     this.registerListeners()
   }
 

--- a/app/assets/javascripts/hyku_addons/required_field_listener.js
+++ b/app/assets/javascripts/hyku_addons/required_field_listener.js
@@ -2,12 +2,12 @@
 // <input type="text" value="" data-required>
 
 class RequiredFieldListener {
-  setEventName = "set_required"
-  unsetEventName = "unset_required"
-  requiredTagClass = "required-tag"
-  requiredTagSelector = `.${this.requiredTagClass}`
-
   constructor(){
+    this.setEventName = "set_required"
+    this.unsetEventName = "unset_required"
+    this.requiredTagClass = "required-tag"
+    this.requiredTagSelector = `.${this.requiredTagClass}`
+
     this.registerListeners()
   }
 

--- a/app/assets/javascripts/hyku_addons/required_group_field_listener.js
+++ b/app/assets/javascripts/hyku_addons/required_group_field_listener.js
@@ -4,10 +4,10 @@
 // <input name="last_name" type="text" value="" data-required="true" data-required-group="user_name" data-on-blur-event="toggle_required_group">
 
 class RequiredGroupFieldListener {
-  eventName = "toggle_required_group"
-  groupAttributeName = "data-required-group"
-
   constructor(){
+    this.eventName = "toggle_required_group"
+    this.groupAttributeName = "data-required-group"
+
     this.registerListeners()
   }
 


### PR DESCRIPTION
I was seeing errors when trying to precompile assets for production environment (`RAILS_ENV=production bundle exec rake app:assets:precompile` in the docker container).
>Uglifier::Error: Unexpected token: operator (=)
--
 87160     funder_name.css('border-color', '#ccc');
 87161   }
 87162 }
 87163 ;
 87164 // Example:
 87165 // $("body").trigger("clear_inputs", [$(el)])
 87166 
 87167 class InputClearableListener {
    =>   eventName = "clear_inputs"
 87169 
 87170   constructor(){
 87171     this.registerListeners()
 87172   }
 87173 
 87174   registerListeners(){
 87175     $("body").on(this.eventName, this.onEvent.bind(this))
 87176   }

It looks like these compile if moved into the constructor.