### PR TITLE
Subclass AbstractActor instead of BaseActor

### DIFF
--- a/app/actors/hyku_addons/actors/date_fields_actor.rb
+++ b/app/actors/hyku_addons/actors/date_fields_actor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module HykuAddons
   module Actors
-    class DateFieldsActor < Hyrax::Actors::BaseActor
+    class DateFieldsActor < Hyrax::Actors::AbstractActor
       def create(env)
         serialize_date_fields(env) && next_actor.create(env)
       end

--- a/app/actors/hyku_addons/actors/json_fields_actor.rb
+++ b/app/actors/hyku_addons/actors/json_fields_actor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module HykuAddons
   module Actors
-    class JSONFieldsActor < Hyrax::Actors::BaseActor
+    class JSONFieldsActor < Hyrax::Actors::AbstractActor
       def create(env)
         jsonify_fields(env) && next_actor.create(env)
       end


### PR DESCRIPTION
...because BaseActor is meant for the work type actor and does the saving.