### PR TITLE
Test DOI minting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,6 @@ jobs:
 
       # Setup hyku_addons and hyrax-doi
       - run: bundle exec rails g hyku_addons:install
-      - run: bundle exec rails g hyrax:doi:add_to_work_type GenericWork --datacite
 
       - run: bundle exec rake app:db:create app:db:migrate app:zookeeper:upload
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,10 @@ Metrics/ClassLength:
   Exclude:
     - 'lib/hyku_addons/engine.rb'
 
+Metrics/LineLength:
+  Exclude:
+    - 'spec/jobs/register_doi_job_spec.rb'
+
 Metrics/ModuleLength:
   Exclude:
     - 'app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -965,6 +965,8 @@ GEM
       rdf-xsd (~> 3.1)
       sparql (~> 3.1)
       sxp (~> 1.1)
+    shoulda-matchers (4.5.0)
+      activesupport (>= 4.2.0)
     sidekiq (6.1.2)
       connection_pool (>= 2.2.2)
       rack (~> 2.0)
@@ -1138,6 +1140,7 @@ DEPENDENCIES
   scss_lint
   secure_headers
   selenium-webdriver
+  shoulda-matchers
   sidekiq
   simplecov
   solr_wrapper (~> 2.0)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ git submodule init
 git submodule update
 bundle install
 bundle exec rails g hyku_addons:install
-bundle exec rails g hyrax:doi:add_to_work_type GenericWork --datacite
 ```
 
 ### Docker

--- a/app/forms/concerns/hyku_addons/generic_work_form_overrides.rb
+++ b/app/forms/concerns/hyku_addons/generic_work_form_overrides.rb
@@ -15,6 +15,11 @@ module HykuAddons
                    rights_holder doi qualification_name qualification_level alternate_identifier related_identifier refereed keyword dewey
                    library_of_congress_classification add_info]
       self.required_fields = %i[title resource_type creator institution]
+
+      # Adds behaviors for hyrax-doi plugin.
+      include Hyrax::DOI::DOIFormBehavior
+      # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
+      include Hyrax::DOI::DataCiteDOIFormBehavior
     end
 
     class_methods do

--- a/app/models/concerns/hyku_addons/generic_work_overrides.rb
+++ b/app/models/concerns/hyku_addons/generic_work_overrides.rb
@@ -8,6 +8,11 @@ module HykuAddons
 
     # TODO: Review indexing and switch to mostly _ssim instead of _tesim
     included do
+      # Adds behaviors for hyrax-doi plugin.
+      include Hyrax::DOI::DOIBehavior
+      # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
+      include Hyrax::DOI::DataCiteDOIBehavior
+
       # From SharedMetadata
       property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
         index.as :stored_searchable

--- a/app/presenters/concerns/hyku_addons/generic_work_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku_addons/generic_work_presenter_behavior.rb
@@ -5,6 +5,11 @@ module HykuAddons
     extend ActiveSupport::Concern
 
     included do
+      # Adds behaviors for hyrax-doi plugin.
+      include Hyrax::DOI::DOIPresenterBehavior
+      # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
+      include Hyrax::DOI::DataCiteDOIPresenterBehavior
+
       DELEGATED_METHODS = [:volume, :pagination, :issn, :eissn, :official_link, :series_name, :edition,
                            :event_title, :event_date, :event_location, :book_title, :journal_title,
                            :issue, :article_num, :isbn, :media, :related_exhibition, :related_exhibition_date,

--- a/hyku_addons.gemspec
+++ b/hyku_addons.gemspec
@@ -42,5 +42,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pg"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency 'rspec_junit_formatter'
+  spec.add_development_dependency 'shoulda-matchers'
   spec.add_development_dependency 'webdrivers', '~> 4.0'
 end

--- a/lib/generators/hyku_addons/install_generator.rb
+++ b/lib/generators/hyku_addons/install_generator.rb
@@ -3,17 +3,16 @@ module HykuAddons
   class InstallGenerator < Rails::Generators::Base
     desc <<-EOS
       This generator makes the following changes to Hyku:
-        1. Installs and configures hyrax-doi
+        1. Injects work type overrides
+        2. Copies controlled vocabularies
+        3. Injects javascript
+        4. Injects helpers
     EOS
 
     source_root File.expand_path('templates', __dir__)
 
     def install_hyrax_doi
       generate 'hyrax:doi:install --datacite'
-      # Configure default_url_options
-      # Rails.application.routes.default_url_options[:host] = 'lvh.me:3000' ?
-
-      # generate 'hyrax:doi:add_to_work_type GenericWork --datacite'
     end
 
     def inject_overrides_into_curation_concerns

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'hyrax/doi/spec/shared_specs'
 
 RSpec.describe Hyrax::GenericWorkForm do
   let(:work) { GenericWork.new }
   let(:form) { described_class.new(work, nil, nil) }
+
+  it_behaves_like 'a DOI-enabled form'
+  it_behaves_like 'a DataCite DOI-enabled form'
 
   describe ".required_fields" do
     subject { form.required_fields }

--- a/spec/jobs/register_doi_job_spec.rb
+++ b/spec/jobs/register_doi_job_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+# Copied over from hyrax-doi as a sanity check that things are still working
+RSpec.describe Hyrax::DOI::RegisterDOIJob, type: :job do
+  let(:work) { create(:work, visibility: 'open', doi_status_when_public: 'findable') }
+  let(:prefix) { '10.1234' }
+  let(:suffix) { 'abcdef' }
+  let(:doi) { "#{prefix}/#{suffix}" }
+
+  before do
+    Rails.application.routes.default_url_options[:host] = 'example.com'
+    Hyrax.config.identifier_registrars = { datacite: Hyrax::DOI::DataCiteRegistrar }
+    Hyrax::DOI::DataCiteRegistrar.mode = :test
+    Hyrax::DOI::DataCiteRegistrar.prefix = prefix
+    Hyrax::DOI::DataCiteRegistrar.username = 'username'
+    Hyrax::DOI::DataCiteRegistrar.password = 'password'
+
+    stub_request(:post, URI.join(Hyrax::DOI::DataCiteClient::TEST_BASE_URL, "dois"))
+      .with(headers: { "Content-Type" => "application/json" },
+            basic_auth: ['username', 'password'],
+            body: "{\"data\":{\"type\":\"dois\",\"attributes\":{\"prefix\":\"#{prefix}\"}}}")
+      .to_return(status: 201, body: "{\"data\":{\"id\":\"#{doi}\",\"type\":\"dois\",\"attributes\":{\"doi\":\"#{doi}\",\"prefix\":\"#{prefix}\",\"suffix\":\"#{suffix}\",\"identifiers\":[],\"alternateIdentifiers\":[],\"creators\":[],\"titles\":null,\"publisher\":null,\"container\":{},\"publicationYear\":null,\"subjects\":[],\"contributors\":[],\"dates\":[],\"language\":null,\"types\":{},\"relatedIdentifiers\":[],\"sizes\":[],\"formats\":[],\"version\":null,\"rightsList\":[],\"descriptions\":[],\"geoLocations\":[],\"fundingReferences\":[],\"xml\":null,\"url\":null,\"contentUrl\":null,\"metadataVersion\":0,\"schemaVersion\":null,\"source\":null,\"isActive\":false,\"state\":\"draft\",\"reason\":null,\"landingPage\":null,\"viewCount\":0,\"viewsOverTime\":[],\"downloadCount\":0,\"downloadsOverTime\":[],\"referenceCount\":0,\"citationCount\":0,\"citationsOverTime\":[],\"partCount\":0,\"partOfCount\":0,\"versionCount\":0,\"versionOfCount\":0,\"created\":\"2020-08-10T20:58:59.000Z\",\"registered\":null,\"published\":\"\",\"updated\":\"2020-08-10T20:58:59.000Z\"},\"relationships\":{\"client\":{\"data\":{\"id\":\"client-id\",\"type\":\"clients\"}},\"media\":{\"data\":{\"id\":\"#{doi}\",\"type\":\"media\"}},\"references\":{\"data\":[]},\"citations\":{\"data\":[]},\"parts\":{\"data\":[]},\"partOf\":{\"data\":[]},\"versions\":{\"data\":[]},\"versionOf\":{\"data\":[]}}}}")
+    stub_request(:put, URI.join(Hyrax::DOI::DataCiteClient::TEST_MDS_BASE_URL, "metadata/#{doi}"))
+      .with(headers: { 'Content-Type': 'application/xml;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 201, body: "OK (#{doi})")
+    stub_request(:put, URI.join(Hyrax::DOI::DataCiteClient::TEST_MDS_BASE_URL, "doi/#{doi}"))
+      .with(headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
+            basic_auth: ['username', 'password'])
+      .to_return(status: 201, body: "")
+  end
+
+  it 'mints a DOI' do
+    expect { described_class.perform_now(work, registrar: work.doi_registrar.presence, registrar_opts: work.doi_registrar_opts) }
+      .to change { work.doi }
+      .to eq [doi]
+  end
+end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'hyrax/doi/spec/shared_specs'
 
 RSpec.describe GenericWork do
   let(:work) { described_class.new }
   let(:fully_described_work) { build(:fully_described_work) }
+
+  it_behaves_like 'a DOI-enabled model'
+  it_behaves_like 'a DataCite DOI-enabled model'
 
   describe 'additional properties' do
     let(:additional_properties) do

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'hyrax/doi/spec/shared_specs'
 
 RSpec.describe SolrDocument do
   let(:document) { described_class.new }
@@ -18,6 +19,10 @@ RSpec.describe SolrDocument do
       :creator_display, :contributor_display, :editor_display
     ]
   end
+
+  let(:solr_document_class) { described_class }
+  it_behaves_like 'a DOI-enabled solr document'
+  it_behaves_like 'a DataCite DOI-enabled solr document'
 
   describe 'accessors' do
     it 'defines accessors' do

--- a/spec/presenters/generic_work_presenter_spec.rb
+++ b/spec/presenters/generic_work_presenter_spec.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'hyrax/doi/spec/shared_specs'
 
 RSpec.describe Hyrax::GenericWorkPresenter do
   let(:presenter) { described_class.new(solr_document, nil, nil) }
+  let(:presenter_class) { described_class }
   let(:solr_document) { SolrDocument.new(work.to_solr) }
+  let(:solr_document_class) { SolrDocument }
   let(:work) { build(:generic_work) }
+
+  it_behaves_like 'a DOI-enabled presenter'
+  it_behaves_like 'a DataCite DOI-enabled presenter'
 
   let(:additional_properties) do
     [

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -55,6 +55,14 @@ end
 #
 # Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
+require 'shoulda-matchers'
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end
+
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
 begin


### PR DESCRIPTION
Use shared specs from `hyrax-doi` and explicitly include hyrax-doi mixin modules instead of running the install generator each time.