### PR TITLE
Fix issue where by the server pid is not removed 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
       dockerfile: Dockerfile
       target: dev
     image: hyku_addons/dev:latest
-    command: bash -c "bundle exec rails server -b 0.0.0.0"
+    command: bash -c "rm -f spec/internal_test_hyku/tmp/pids/server.pid && bundle exec rails server -b 0.0.0.0"
     #env_file:
     #  - ./spec/internal_test_hyku/.env
     environment: &web_environment
@@ -187,7 +187,7 @@ services:
     environment:
       <<: *web_environment
       SETTINGS__MULTITENANCY__ADMIN_HOST: lvh.me
-      DISABLE_REDIS_CLUSTER: "true" 
+      DISABLE_REDIS_CLUSTER: "true"
       RAILS_ENV: test
       DATABASE_HOST: db-test
       SETTINGS__SOLR__URL: http://solr-test:8983/solr/


### PR DESCRIPTION
Depending on the situation and how the containers are started and stopped, it can happen that the server.pid is not removed and so prevents the web application container from starting normally. 

I don't believe this affects any other environment than `development`. 