### PR TITLE
Default to allowing signups

### DIFF
--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -24,6 +24,7 @@ module HykuAddons
       after_initialize :set_jsonb_help_texts_default_keys, :set_jsonb_work_unwanted_fields_default_keys
       after_initialize :set_jsonb_required_json_property_default_keys, :set_jsonb_html_required_default_keys
       after_initialize :set_jsonb_metadata_labels_default_keys, :set_jsonb_licence_list_default_keys
+      after_initialize :set_jsonb_allow_signup_default
       before_save :remove_settings_hash_key_with_nil_value
       validates :gtm_id, format: { with: /GTM-[A-Z0-9]{4,7}/, message: "Invalid GTM ID" }, allow_blank: true
       validates :contact_email, :oai_admin_email,
@@ -99,6 +100,11 @@ module HykuAddons
         self.licence_list = {
           name: nil, value: nil
         }
+      end
+
+      def set_jsonb_allow_signup_default
+        return if settings['allow_signup'].present?
+        self.allow_signup = 'true'
       end
 
       def remove_settings_hash_key_with_nil_value

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= current_account.settings['allow_signup'] == "true" ? (link_to t(".sign_up"), new_registration_path(resource_name)) : ' ' %><br />
+  <%= current_account.allow_signup == "true" ? (link_to t(".sign_up"), new_registration_path(resource_name)) : ' ' %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -52,12 +52,12 @@ module HykuAddons
 
       Hyku::RegistrationsController.class_eval do
         def new
-          return super if current_account.settings['allow_signup'] == "true"
+          return super if current_account.allow_signup == "true"
           redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
         end
 
         def create
-          return super if current_account.settings['allow_signup'] == "true"
+          return super if current_account.allow_signup == "true"
           redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
         end
 

--- a/spec/features/sign_up_settings_spec.rb
+++ b/spec/features/sign_up_settings_spec.rb
@@ -32,10 +32,16 @@ RSpec.describe "Sign Up", type: :feature do
 
   context 'with account signup diabled' do
     it 'does not allow a user to create an account' do
-      account.settings['allow_signup'] = "false"
+      account.allow_signup = "false"
       account.save!
       visit '/users/sign_up'
       expect(page).to have_content("Account registration is disabled")
+    end
+  end
+
+  context 'default value' do
+    it 'defaults to true' do
+      expect(Account.new.allow_signup).to eq "true"
     end
   end
 end


### PR DESCRIPTION
Locally when I create a new account/tenant, I'd have to go into the rails console to enable signups.  I think it is reasonable to allow signups by default (since you need that to create the admin user to login right after creating the tenant) which can be disabled by the first admin if they want to.