### PR TITLE
Catch error causing 500 on root admin user registration

### DIFF
--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -52,12 +52,12 @@ module HykuAddons
 
       Hyku::RegistrationsController.class_eval do
         def new
-          return super if current_account.allow_signup == "true"
+          return super if current_account&.allow_signup == "true"
           redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
         end
 
         def create
-          return super if current_account.allow_signup == "true"
+          return super if current_account&.allow_signup == "true"
           redirect_to root_path, alert: t(:'hyku.account.signup_disabled')
         end
 


### PR DESCRIPTION
On this page, http://lvh.me:3000/?locale=en, i'm getting 500 errors because the `current_account` is `nil`. 