### PR TITLE
Fix available worktypes error

### DIFF
--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -122,6 +122,17 @@ module HykuAddons
       end
     end
 
+    # NOTE: This issue only seems to present in development, and not consistently.
+    # Compact the available work types to remove `nil` and prevent an `Nil location provided. Can't build URI.` error
+    # when not all options are selected, thrown from `SelectTypePresenter#switch_to_new_work_path`
+    initializer 'hyku_addon.available_work_type_bug_fix' do
+      Hyrax::QuickClassificationQuery.class_eval do
+        def normalized_model_names
+          models.map { |name| concern_name_normalizer.call(name) if Site.first.available_works.include? name }.compact
+        end
+      end
+    end
+
     # Add migrations to parent app paths
     initializer 'hyku_addons.append_migrations' do |app|
       Hyku::Application.default_url_options[:host] = 'lvh.me:3000'

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -128,7 +128,7 @@ module HykuAddons
     initializer 'hyku_addon.available_work_type_bug_fix' do
       Hyrax::QuickClassificationQuery.class_eval do
         def normalized_model_names
-          models.map { |name| concern_name_normalizer.call(name) if Site.first.available_works.include? name }.compact
+          models.map { |name| concern_name_normalizer.call(name) if Site.first.available_works.include?(name) }.compact
         end
       end
     end


### PR DESCRIPTION
Resolve issue where by development environments _could_ present an error when not all worktypes were selected in the admin