### PR TITLE
Improve hyku superadmin create rake task to allow passing arguments

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,7 @@ Metrics/BlockLength:
     - 'app/services/bolognese/writers/ris_writer_behavior.rb'
     - 'hyku_addons.gemspec'
     - 'lib/hyku_addons/engine.rb'
+    - 'lib/tasks/*.rake'
     - 'spec/**/*.rb'
 
 Metrics/MethodLength:

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+namespace :hyku_addons do
+  namespace :superadmin do
+    desc 'Create a superadmin user'
+    task :create, [:email, :password] => [:environment] do |_cmd, args|
+      puts 'Creating a superadmin user.'
+      user = create_or_prompt_to_create_user(args)
+      user.add_role(:superadmin)
+      puts "User (#{user.user_key}) created and granted superadministrator privileges"
+    end
+
+    def create_or_prompt_to_create_user(args)
+      User.find_or_create_by!(email: args.email || prompt_for_email) do |u|
+        puts 'User not found. Enter a password to create the user.'
+        u.password = args.password || prompt_for_password
+      end
+    rescue StandardError => e
+      puts e
+      retry
+    end
+
+    def prompt_for_email
+      print 'Email: '
+      $stdin.gets.chomp
+    end
+
+    def prompt_for_password
+      begin
+        system 'stty -echo'
+        print 'Password (must be 8+ characters): '
+        password = $stdin.gets.chomp
+        puts "\n"
+      ensure
+        system 'stty echo'
+      end
+      password
+    end
+  end
+end


### PR DESCRIPTION
This can be turned into a PR to upstream hyku but putting this in the `hyku_addons` namespace for now.

Use this `bundle exec rake hyku_addons:superadmin:create[email,password]`  If you skip the arguments it fallback to prompting for them.