### PR TITLE
Upgrade to ruby 2.7.2 base image to suppress deprecation warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Ripped off from Avalon
 # Base stage for building gems
-FROM        ruby:2.7.1-buster as bundle
+FROM        ruby:2.7.2-buster as bundle
 RUN         echo "deb http://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list \
          && apt-get update \
          && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
This is a different docker image than is used in CircleCI so skip ci on this PR.