### PR TITLE
Handle creator and contributor multi-part fields for collections

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,6 +34,7 @@ Metrics/BlockLength:
     - 'app/models/concerns/hyku_addons/generic_work_overrides.rb'
     - 'app/models/concerns/hyku_addons/solr_document_behavior.rb'
     - 'app/models/concerns/hyku_addons/work_base.rb'
+    - 'app/forms/concerns/hyku_addons/collection_form_behavior.rb'
     - 'app/forms/concerns/hyku_addons/work_form.rb'
     - 'app/models/pacific_article.rb'
     - 'app/services/bolognese/writers/ris_writer_behavior.rb'

--- a/app/forms/concerns/hyku_addons/collection_form_behavior.rb
+++ b/app/forms/concerns/hyku_addons/collection_form_behavior.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+module HykuAddons
+  module CollectionFormBehavior
+    extend ActiveSupport::Concern
+
+    include HykuAddons::PersonOrOrganizationFormBehavior
+
+    # TODO: extract duplicate code (from JSONFieldsActor) out into a service class?
+    class_methods do
+      def model_attributes(form_params)
+        super.tap do |model_attributes|
+          [:creator, :contributor].each do |field|
+            if name_blank?(field, model_attributes[field].map(&:to_h)) || recursive_blank?(model_attributes[field].map(&:to_h))
+              model_attributes.delete(field)
+            else
+              model_attributes[field] = model_attributes[field].to_json
+            end
+            model_attributes[field] = Array(model_attributes[field]) if multiple?(field)
+          end
+        end
+      end
+
+      def name_blank?(field, obj)
+        return false unless field.in? [:creator, :contributor, :editor]
+        recursive_blank?(Array(obj).map { |o| o.reject { |k, _v| k == "#{field}_name_type" } })
+      end
+
+      def recursive_blank?(obj)
+        case obj
+        when Hash
+          obj.values.all? { |o| recursive_blank?(o) }
+        when Array
+          obj.all? { |o| recursive_blank?(o) }
+        else
+          obj.blank?
+        end
+      end
+    end
+  end
+end

--- a/app/forms/concerns/hyku_addons/person_or_organization_form_behavior.rb
+++ b/app/forms/concerns/hyku_addons/person_or_organization_form_behavior.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+module HykuAddons
+  module PersonOrOrganizationFormBehavior
+    extend ActiveSupport::Concern
+
+    # Helper methods for JSON fields
+    def creator_list
+      person_or_organization_list(:creator)
+    end
+
+    def contributor_list
+      person_or_organization_list(:contributor)
+    end
+
+    class_methods do
+      # Group all params here so save on boiler plate
+      def build_permitted_params
+        super.tap do |permitted_params|
+          permitted_params << creator_fields
+          permitted_params << contributor_fields
+        end
+      end
+
+      def creator_fields
+        {
+          creator: [:creator_organization_name, :creator_given_name, :creator_middle_name, :creator_family_name, :creator_name_type,
+                    :creator_orcid, :creator_isni, :creator_ror, :creator_grid, :creator_wikidata, :creator_suffix, :creator_institution,
+                    creator_institutional_relationship: []]
+        }
+      end
+
+      def contributor_fields
+        {
+          contributor: [:contributor_organization_name, :contributor_given_name, :contributor_middle_name, :contributor_family_name,
+                        :contributor_name_type, :contributor_orcid, :contributor_isni, :contributor_ror,
+                        :contributor_grid, :contributor_wikidata, :creator_suffix, :creator_institution, :contributor_type,
+                        contributor_institutional_relationship: []]
+        }
+      end
+    end
+
+    private
+
+      def person_or_organization_list(field)
+        # Return empty hash to ensure that it gets rendered at least once
+        return [{}] unless send(field)&.first.present?
+        JSON.parse(send(field).first)
+      end
+  end
+end

--- a/app/forms/concerns/hyku_addons/work_form.rb
+++ b/app/forms/concerns/hyku_addons/work_form.rb
@@ -3,14 +3,7 @@ module HykuAddons
   module WorkForm
     extend ActiveSupport::Concern
 
-    # Helper methods for JSON fields
-    def creator_list
-      person_or_organization_list(:creator)
-    end
-
-    def contributor_list
-      person_or_organization_list(:contributor)
-    end
+    include HykuAddons::PersonOrOrganizationFormBehavior
 
     def editor_list
       person_or_organization_list(:editor)
@@ -21,8 +14,6 @@ module HykuAddons
       def build_permitted_params
         super.tap do |permitted_params|
           permitted_params << common_fields
-          permitted_params << creator_fields
-          permitted_params << contributor_fields
           permitted_params << date_published_fields
           permitted_params << date_accepted_fields
           permitted_params << date_submitted_fields
@@ -69,23 +60,6 @@ module HykuAddons
            library_of_congress_classification add_info issn isbn eissn version_number series_name book_title pagination
            publisher place_of_publication journal_title alternative_journal_title volume edition issue article_num
            qualification_name qualification_level]
-      end
-
-      def creator_fields
-        {
-          creator: [:creator_organization_name, :creator_given_name, :creator_middle_name, :creator_family_name, :creator_name_type,
-                    :creator_orcid, :creator_isni, :creator_ror, :creator_grid, :creator_wikidata, :creator_suffix, :creator_institution,
-                    creator_institutional_relationship: []]
-        }
-      end
-
-      def contributor_fields
-        {
-          contributor: [:contributor_organization_name, :contributor_given_name, :contributor_middle_name, :contributor_family_name,
-                        :contributor_name_type, :contributor_orcid, :contributor_isni, :contributor_ror,
-                        :contributor_grid, :contributor_wikidata, :creator_suffix, :creator_institution, :contributor_type,
-                        contributor_institutional_relationship: []]
-        }
       end
 
       def date_accepted_fields
@@ -139,13 +113,5 @@ module HykuAddons
         ]
       end
     end
-
-    private
-
-      def person_or_organization_list(field)
-        # Return empty hash to ensure that it gets rendered at least once
-        return [{}] unless send(field)&.first.present?
-        JSON.parse(send(field).first)
-      end
   end
 end

--- a/app/presenters/concerns/hyku_addons/collection_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku_addons/collection_presenter_behavior.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module CollectionPresenterBehavior
+    extend ActiveSupport::Concern
+
+    include HykuAddons::PersonOrOrganizationPresenterBehavior
+
+    delegate :contributor_display, :creator_display, to: :solr_document
+  end
+end

--- a/app/presenters/concerns/hyku_addons/generic_work_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku_addons/generic_work_presenter_behavior.rb
@@ -4,6 +4,8 @@ module HykuAddons
   module GenericWorkPresenterBehavior
     extend ActiveSupport::Concern
 
+    include HykuAddons::PersonOrOrganizationPresenterBehavior
+
     included do
       include Hyrax::DOI::DOIPresenterBehavior
       include Hyrax::DOI::DataCiteDOIPresenterBehavior
@@ -22,93 +24,8 @@ module HykuAddons
       alias_method :isbns, :isbn
     end
 
-    def creator_list
-      @creator_list ||= person_or_organization_list(:creator)
-    end
-
     def editor_list
       @editor_list ||= person_or_organization_list(:editor)
     end
-
-    def contributor_list
-      @contributor_list ||= person_or_organization_list(:contributor)
-    end
-
-    # TODO: Add view_context and use link_to and image_tag instead of <%== in the view
-    # TODO: Need to normalize ids in the work model in  order for these methods to work in all cases (and stay simple)
-    class PersonOrOrganization < Struct.new(:display_name, :orcid, :isni, :ror, :grid, :wikidata)
-      def orcid_url
-        "https://orcid.org/#{orcid.gsub(/[^a-z0-9X]/, '')}" if orcid.present?
-      end
-
-      def orcid_logo
-        orcid_logo_url = 'https://s3-eu-west-1.amazonaws.com/service-hyku-oar-importer/orcid_16x16.png'
-        "<img src='#{orcid_logo_url}' alt='ORCID' height='16' width='16' class='img-responsive' />"
-      end
-
-      def orcid_link
-        "<a href='#{orcid_url}' target='_blank'>#{orcid_logo}</a>" if orcid.present?
-      end
-
-      def isni_url
-        "https://isni.org/isni/#{isni.gsub(/[^a-z0-9X]/, '')}" if isni.present?
-      end
-
-      def isni_logo
-        isni_logo_url = 'https://s3-eu-west-1.amazonaws.com/service-hyku-oar-importer/logo_xml_isni-16.gif'
-        "<img src='#{isni_logo_url}' alt='ISNI' height='16' width='16' class='img-responsive' />"
-      end
-
-      def isni_link
-        "<a href='#{isni_url}' target='_blank'>#{isni_logo}</a>" if isni.present?
-      end
-
-      def ror_url
-        "https://ror.org/#{ror}" if ror.present?
-      end
-
-      def ror_logo
-        '<img src=" " alt="ROR" class="img-responseive" sytyle="float:left;">'
-      end
-
-      def ror_link
-        "<a href='#{ror_url}' target='_blank'>#{ror_logo}</a>" if ror.present?
-      end
-
-      def grid_url
-        "https://grid.ac/institutes/#{grid}" if grid.present?
-      end
-
-      def grid_logo
-        '<img src=" " alt="GRID" class="img-responseive" sytyle="float:left;">'
-      end
-
-      def grid_link
-        "<a href='#{grid_url}' target='_blank'>#{grid_logo}</a>" if grid.present?
-      end
-
-      def wikidata_url
-        "https://www.wikidata.org/entity/#{wikidata}" if wikidata.present?
-      end
-
-      def wikidata_logo
-        '<img src=" " alt="WIKIDATA" class="img-responseive" sytyle="float:left;">'
-      end
-
-      def wikidata_link
-        "<a href='#{wikidata_url}' target='_blank'>#{wikidata_logo}</a>" if wikidata.present?
-      end
-    end
-
-    private
-
-      def person_or_organization_list(field)
-        return [] unless send(field)&.first.present?
-
-        JSON.parse(send(field).first).collect do |hash|
-          name = hash.slice("#{field}_family_name", "#{field}_given_name", "#{field}_organization_name").values.map(&:presence).compact.join(', ')
-          PersonOrOrganization.new(name, hash["#{field}_orcid"], hash["#{field}_isni"], hash["#{field}_ror"], hash["#{field}_grid"], hash["#{field}_wikidata"])
-        end
-      end
   end
 end

--- a/app/presenters/concerns/hyku_addons/person_or_organization_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku_addons/person_or_organization_presenter_behavior.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module PersonOrOrganizationPresenterBehavior
+    extend ActiveSupport::Concern
+
+    def creator_list
+      @creator_list ||= person_or_organization_list(:creator)
+    end
+
+    def contributor_list
+      @contributor_list ||= person_or_organization_list(:contributor)
+    end
+
+    # TODO: Add view_context and use link_to and image_tag instead of <%== in the view
+    # TODO: Need to normalize ids in the work model in  order for these methods to work in all cases (and stay simple)
+    class PersonOrOrganization < Struct.new(:display_name, :orcid, :isni, :ror, :grid, :wikidata)
+      def orcid_url
+        "https://orcid.org/#{orcid.gsub(/[^a-z0-9X]/, '')}" if orcid.present?
+      end
+
+      def orcid_logo
+        orcid_logo_url = 'https://s3-eu-west-1.amazonaws.com/service-hyku-oar-importer/orcid_16x16.png'
+        "<img src='#{orcid_logo_url}' alt='ORCID' height='16' width='16' class='img-responsive' />"
+      end
+
+      def orcid_link
+        "<a href='#{orcid_url}' target='_blank'>#{orcid_logo}</a>" if orcid.present?
+      end
+
+      def isni_url
+        "https://isni.org/isni/#{isni.gsub(/[^a-z0-9X]/, '')}" if isni.present?
+      end
+
+      def isni_logo
+        isni_logo_url = 'https://s3-eu-west-1.amazonaws.com/service-hyku-oar-importer/logo_xml_isni-16.gif'
+        "<img src='#{isni_logo_url}' alt='ISNI' height='16' width='16' class='img-responsive' />"
+      end
+
+      def isni_link
+        "<a href='#{isni_url}' target='_blank'>#{isni_logo}</a>" if isni.present?
+      end
+
+      def ror_url
+        "https://ror.org/#{ror}" if ror.present?
+      end
+
+      def ror_logo
+        '<img src=" " alt="ROR" class="img-responseive" sytyle="float:left;">'
+      end
+
+      def ror_link
+        "<a href='#{ror_url}' target='_blank'>#{ror_logo}</a>" if ror.present?
+      end
+
+      def grid_url
+        "https://grid.ac/institutes/#{grid}" if grid.present?
+      end
+
+      def grid_logo
+        '<img src=" " alt="GRID" class="img-responseive" sytyle="float:left;">'
+      end
+
+      def grid_link
+        "<a href='#{grid_url}' target='_blank'>#{grid_logo}</a>" if grid.present?
+      end
+
+      def wikidata_url
+        "https://www.wikidata.org/entity/#{wikidata}" if wikidata.present?
+      end
+
+      def wikidata_logo
+        '<img src=" " alt="WIKIDATA" class="img-responseive" sytyle="float:left;">'
+      end
+
+      def wikidata_link
+        "<a href='#{wikidata_url}' target='_blank'>#{wikidata_logo}</a>" if wikidata.present?
+      end
+    end
+
+    private
+
+      def person_or_organization_list(field)
+        return [] unless send(field)&.first.present?
+
+        JSON.parse(send(field).first).collect do |hash|
+          name = hash.slice("#{field}_family_name", "#{field}_given_name", "#{field}_organization_name").values.map(&:presence).compact.join(', ')
+          PersonOrOrganization.new(name, hash["#{field}_orcid"], hash["#{field}_isni"], hash["#{field}_ror"], hash["#{field}_grid"], hash["#{field}_wikidata"])
+        end
+      end
+  end
+end

--- a/app/views/records/show_fields/_creator.html.erb
+++ b/app/views/records/show_fields/_creator.html.erb
@@ -1,0 +1,1 @@
+<%= @presenter.attribute_to_html(:creator, render_as: :linked_name, values: @presenter.creator_list, search_field: 'creator_display_ssim', html_dl: true) %>

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -237,6 +237,8 @@ module HykuAddons
       WorkIndexer.include HykuAddons::WorkIndexerBehavior
       Hyrax::GenericWorkForm.include HykuAddons::GenericWorkFormOverrides
       Hyrax::ImageForm.include HykuAddons::ImageFormOverrides
+      Hyrax::Forms::CollectionForm.include HykuAddons::CollectionFormBehavior
+      Hyrax::CollectionPresenter.include HykuAddons::CollectionPresenterBehavior
       SolrDocument.include HykuAddons::SolrDocumentBehavior
       SolrDocument.include HykuAddons::SolrDocumentRis
       Hyrax::GenericWorkPresenter.include HykuAddons::GenericWorkPresenterBehavior

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create a Collection', js: false, clean: true do
+  let(:user_attributes) do
+    { email: 'test@example.com' }
+  end
+  let(:user) do
+    User.new(user_attributes) { |u| u.save(validate: false) }
+  end
+  let(:collection_type) { Hyrax::CollectionType.create(title: 'test_collection_type') }
+
+  before do
+    collection_type
+    login_as user
+  end
+
+  it 'creates a collection without creator or contributor' do
+    visit '/dashboard'
+    click_link "Collections"
+    click_link "New Collection"
+
+    # Title
+    fill_in('Title', with: 'My Test Collection')
+
+    click_button 'Save'
+
+    visit page.current_path.sub('/edit', '')
+
+    expect(page).to have_content('My Test Collection')
+    expect(page).not_to have_content('Creator')
+    expect(page).not_to have_content('Contributor')
+  end
+
+  it 'creates a collection with creator' do
+    visit '/dashboard'
+    click_link "Collections"
+    click_link "New Collection"
+
+    # Title
+    fill_in('Title', with: 'My Test Collection')
+
+    # Creator
+    select('Personal', from: 'collection_creator__creator_name_type')
+    fill_in('collection_creator__creator_family_name', with: 'Hawking')
+    fill_in('collection_creator__creator_given_name', with: 'Stephen')
+    fill_in('collection_creator__creator_orcid', with: '0000-0002-9079-593X')
+    select('Staff member', from: 'collection_creator__creator_institutional_relationship')
+    fill_in('collection_creator__creator_isni', with: '0000 0001 2103 4996')
+
+    click_button 'Save'
+
+    visit page.current_path.sub('/edit', '')
+
+    # Title
+    expect(page).to have_content('My Test Collection')
+
+    # Creator
+    expect(page).to have_content('Hawking, Stephen')
+    expect(page).to have_link('', href: 'https://orcid.org/000000029079593X')
+    expect(page).to have_link('', href: 'https://isni.org/isni/0000000121034996')
+
+    expect(page).not_to have_content('Contributor')
+  end
+end


### PR DESCRIPTION
Collection has creator and contributor fields which were matching the edit partials (e.g. `records/edit_fields/_creator.html.erb`) causing a NoMethodError on `creator_list`.  Looking at Hyku 1, these fields should be multi-part JSON fields like for works so I made them work that way.

Fixes AH-169.