### PR TITLE
hides to contributor role field for pacific work types

### DIFF
--- a/app/views/records/edit_fields/_contributor.html.erb
+++ b/app/views/records/edit_fields/_contributor.html.erb
@@ -67,7 +67,7 @@
 			select_options: HykuAddons::ContributorGroupService.new.select_active_options.flatten.uniq!,
 			field_args: { prompt: "Please Select..." }
 		} %>
-		<%= render "records/edit_fields/attribution_partials/select_field", field_options %>
+		<%= render "records/edit_fields/attribution_partials/select_field", field_options unless template.include? "pacific" %>
 
 		<div class="form-group">
 			<a href="#" class="text-danger form-group" data-turbolinks="false" data-on-click="remove_parent">


### PR DESCRIPTION
Hides contributor role for Pacific worktypes as per line 31 of [https://docs.google.com/spreadsheets/d/1wyBsV3E-Onwgvi1VPWRrRUJ3g6sk5QvhhFe1dKHM92k](url)