### PR TITLE
Fix admin set creation from UI

### DIFF
--- a/app/forms/concerns/hyku_addons/collection_form_behavior.rb
+++ b/app/forms/concerns/hyku_addons/collection_form_behavior.rb
@@ -10,7 +10,7 @@ module HykuAddons
       def model_attributes(form_params)
         super.tap do |model_attributes|
           [:creator, :contributor].each do |field|
-            if name_blank?(field, model_attributes[field].map(&:to_h)) || recursive_blank?(model_attributes[field].map(&:to_h))
+            if name_blank?(field, model_attributes[field]&.map(&:to_h)) || recursive_blank?(model_attributes[field]&.map(&:to_h))
               model_attributes.delete(field)
             else
               model_attributes[field] = model_attributes[field].to_json

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -202,6 +202,14 @@ module HykuAddons
       end
     end
 
+    initializer 'hyku_addons.hyrax_admin_set_create_overrides' do
+      Hyrax::Admin::AdminSetsController.class_eval do
+        def create_admin_set
+          admin_set_create_service.call(admin_set: @admin_set, creating_user: nil)
+        end
+      end
+    end
+
     # Pre-existing Work type overrides
     config.after_initialize do
       # Avoid media pluralizing to medium

--- a/spec/features/create_admin_set_spec.rb
+++ b/spec/features/create_admin_set_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature 'Create an Admin Set', js: false, clean: true do
+  let(:user_attributes) do
+    { email: 'test@example.com' }
+  end
+  let(:user) do
+    User.new(user_attributes) { |u| u.save(validate: false) }
+  end
+
+  before do
+    Hyrax::CollectionTypes::CreateService.create_admin_set_type
+    login_as user
+  end
+
+  it 'creates an admin set' do
+    # Go directly to the admin sets new form
+    visit '/admin/admin_sets/new'
+
+    # Title
+    fill_in('Title', with: 'My Test Admin Set')
+
+    click_button 'Save'
+
+    visit page.current_path.sub('/edit', '')
+
+    expect(page).to have_content('My Test Admin Set')
+  end
+end


### PR DESCRIPTION
The changes to fix the creation/editing of collections caused admin set
creation/editing to fail due to the expectation that the json fields
were present but they aren't when using the admin set controller.
The admin set create service also automatically set the creating user's
email address as the creator which fails because it isn't in the JSON
format that the collection creator show field partial is expecting.  I
worked around this by disabling this automatic setting because I don't
believe the creator was ever rendered before.  This is a smell and
should probably be dealt with at another time.