### PR TITLE
AH-201: Adds UUID as argument to account creation task. 

### DIFF
--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -28,6 +28,7 @@ module HykuAddons
       validates :contact_email, :oai_admin_email,
                 format: { with: URI::MailTo::EMAIL_REGEXP },
                 allow_blank: true
+      validates :tenant, format: { with: /\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\z/ }
       validate :validate_email_format, :validate_contact_emails
     end
 

--- a/lib/tasks/account.rake
+++ b/lib/tasks/account.rake
@@ -3,8 +3,8 @@
 namespace :hyku do
   namespace :account do
     desc 'Create an account'
-    task :create, [:name, :admin_emails] => [:environment] do |_t, args|
-      account = Account.new(name: args[:name])
+    task :create, [:name, :uuid, :admin_emails] => [:environment] do |_t, args|
+      account = Account.new(name: args[:name], tenant: args[:uuid].presence)
       CreateAccount.new(account).save
       AccountElevator.switch!(account.cname)
       Array.wrap(args[:admin_emails]).each do |admin_email|

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -133,4 +133,41 @@ RSpec.describe HykuAddons::AccountBehavior do
       end
     end
   end
+
+  describe "valid?" do
+    before do
+      account.tenant = uuid
+      account.valid?
+    end
+
+    context "with no tenant UUID" do
+      let(:uuid) { nil }
+
+      it "sets a valid tenant UUID" do
+        expect(account.tenant).to be_present
+        expect(account.errors[:tenant]).to be_empty
+      end
+    end
+
+    context "with a valid tenant UUID" do
+      let(:uuid) { SecureRandom.uuid }
+
+      it "respects the existing tenant UUID" do
+        expect(account.tenant).to eq uuid
+        expect(account.errors[:tenant]).to be_empty
+      end
+    end
+
+    context "with an invalid tenant UUID" do
+      let(:uuid) { 'foo-bar' }
+
+      it "respects the existing tenant UUID" do
+        expect(account.tenant).to eq uuid
+      end
+
+      it "is invalid" do
+        expect(account.errors[:tenant]).not_to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
Also adds a validation on the tenant attribute of the account model now that it can be set externally