### PR TITLE
Admin collection required fields

### DIFF
--- a/app/assets/javascripts/hyku_addons/change_toggleable_listener.js
+++ b/app/assets/javascripts/hyku_addons/change_toggleable_listener.js
@@ -20,7 +20,6 @@ class ChangeToggleableListener {
     this.groupAttributeName = "data-toggleable-group"
     this.groupSelector = `[${this.groupAttributeName}]`
     this.controlSelector = "[data-toggleable-control]"
-    this.requiredSelector = "[data-required]"
     this.eventName = "toggleable_group"
     this.afterHiddenAttributeName = "data-after-toggleable-hidden"
 
@@ -71,7 +70,7 @@ class ChangeToggleableListener {
   }
 
   toggleRequiredChildren(parent, eventName) {
-    parent.find(this.requiredSelector).each(function(){
+    parent.find("[data-required='true']").each(function(){
       $("body").trigger(eventName, [$(this)])
     }, this)
   }

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -29,7 +29,7 @@
 		<div data-toggleable-group="Organisational">
 			<% # TODO: workout why setting the name fields as required causes the deposit form to not register the meta data was entered %>
 			<% [
-				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: f.required?(:creator) } } },
+				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: f.object.required?(:creator) } } },
 				{ f: f, field_type: :text, field_slug: :creator_ror },
 				{ f: f, field_type: :text, field_slug: :creator_grid },
 				{ f: f, field_type: :text, field_slug: :creator_wikidata }
@@ -42,8 +42,8 @@
 		<div data-toggleable-group="Personal">
 			<% creator_inst_rel_options = HykuAddons::InstitutionalRelationshipService.new(model: f.object.model.class).select_active_options %>
 			<% personal_fields = [
-				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: f.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
-				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: f.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
+				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: f.object.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
+				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: f.object.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
 				{ field_type: :text, field_slug: :creator_orcid },
 				{ field_type: :select, field_slug: :creator_institutional_relationship, select_options: creator_inst_rel_options, field_args: { multiple: true } }] %>
 			<% personal_fields = add_pacific_creator_personal_fields(personal_fields) if template.include? "pacific" %>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,6 +1,5 @@
 <% template = f.object.model.class.to_s.underscore %>
 <% types = HykuAddons::NameTypeService.new.select_active_options.flatten.uniq! %>
-<% required = f.object.class != Hyrax::Forms::CollectionForm %>
 
 <% f.object.creator_list.each do |hash| %>
 	<div
@@ -30,7 +29,7 @@
 		<div data-toggleable-group="Organisational">
 			<% # TODO: workout why setting the name fields as required causes the deposit form to not register the meta data was entered %>
 			<% [
-				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: required } } },
+				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: f.required?(:creator) } } },
 				{ f: f, field_type: :text, field_slug: :creator_ror },
 				{ f: f, field_type: :text, field_slug: :creator_grid },
 				{ f: f, field_type: :text, field_slug: :creator_wikidata }
@@ -43,8 +42,8 @@
 		<div data-toggleable-group="Personal">
 			<% creator_inst_rel_options = HykuAddons::InstitutionalRelationshipService.new(model: f.object.model.class).select_active_options %>
 			<% personal_fields = [
-				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: required, required_group: :creator_name, on_blur: :toggle_required_group } } },
-				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: required, required_group: :creator_name, on_blur: :toggle_required_group } } },
+				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: f.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
+				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: f.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
 				{ field_type: :text, field_slug: :creator_orcid },
 				{ field_type: :select, field_slug: :creator_institutional_relationship, select_options: creator_inst_rel_options, field_args: { multiple: true } }] %>
 			<% personal_fields = add_pacific_creator_personal_fields(personal_fields) if template.include? "pacific" %>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -1,5 +1,6 @@
 <% template = f.object.model.class.to_s.underscore %>
 <% types = HykuAddons::NameTypeService.new.select_active_options.flatten.uniq! %>
+<% required = f.object.class != Hyrax::Forms::CollectionForm %>
 
 <% f.object.creator_list.each do |hash| %>
 	<div
@@ -29,7 +30,7 @@
 		<div data-toggleable-group="Organisational">
 			<% # TODO: workout why setting the name fields as required causes the deposit form to not register the meta data was entered %>
 			<% [
-				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: true } } },
+				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: required } } },
 				{ f: f, field_type: :text, field_slug: :creator_ror },
 				{ f: f, field_type: :text, field_slug: :creator_grid },
 				{ f: f, field_type: :text, field_slug: :creator_wikidata }
@@ -42,8 +43,8 @@
 		<div data-toggleable-group="Personal">
 			<% creator_inst_rel_options = HykuAddons::InstitutionalRelationshipService.new(model: f.object.model.class).select_active_options %>
 			<% personal_fields = [
-				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: true, required_group: :creator_name, on_blur: :toggle_required_group } } },
-				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: true, required_group: :creator_name, on_blur: :toggle_required_group } } },
+				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: required, required_group: :creator_name, on_blur: :toggle_required_group } } },
+				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: required, required_group: :creator_name, on_blur: :toggle_required_group } } },
 				{ field_type: :text, field_slug: :creator_orcid },
 				{ field_type: :select, field_slug: :creator_institutional_relationship, select_options: creator_inst_rel_options, field_args: { multiple: true } }] %>
 			<% personal_fields = add_pacific_creator_personal_fields(personal_fields) if template.include? "pacific" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,7 +32,7 @@ en:
         help_text: The person or group responsible for the work. Usually this is the author of the content.
       creator_organization_name:
         label: Creator organisation name
-        placeholder:
+        placeholder: The British Library
         help_text: Please enter the organisation's name.
       creator_ror:
         label: Creator organisation ROR


### PR DESCRIPTION
Fix an issue with the JS where by all data-required fields were marked as required, even if the attribute was set to `false`.