### PR TITLE
Fix an error when a work is saved with no matching collection.

### DIFF
--- a/app/views/records/edit_fields/_member_of_collection_id.html.erb
+++ b/app/views/records/edit_fields/_member_of_collection_id.html.erb
@@ -2,7 +2,9 @@
 	<% model = f.object.model.class.to_s.underscore %>
 	<% title = AdminSet.find(admin_set_id).title.first %>
 	<% collection_id = Collection.where(title: title).first&.id %>
-	<input type="hidden" name="<%= "#{model}[member_of_collections_attributes][0][id]" %>" value="<%= collection_id %>">
+	<% if collection_id.present? %>
+		<input type="hidden" name="<%= "#{model}[member_of_collections_attributes][0][id]" %>" value="<%= collection_id %>">
+	<% end %>
 <% else %>
 	<!-- AdminSet ID not found -->
 <% end %>


### PR DESCRIPTION
When using the simplified admin set workflow, when there is no matching collection, the page loaded the input but kept the value nil, but because the input was present, then save process crashed. 