### PR TITLE
Don't allow signup for superadmin dashboard (global tenant)

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -3,7 +3,7 @@
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= current_account.allow_signup == "true" ? (link_to t(".sign_up"), new_registration_path(resource_name)) : ' ' %><br />
+  <%= !Account.global_tenant? && current_account.allow_signup == "true" ? (link_to t(".sign_up"), new_registration_path(resource_name)) : ' ' %><br />
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' %>


### PR DESCRIPTION
I was getting an error about `allow_signup` not being defined on the
global tenant account.  I don't remember seeing this in a deployed
instance so it might be a local issue but restricting user registrations
for the superadmin dashboard seems like a good idea regardless.