### PR TITLE
Use rspec mocks instead of flipflop test mode

### DIFF
--- a/spec/jobs/import_mode_spec.rb
+++ b/spec/jobs/import_mode_spec.rb
@@ -8,8 +8,7 @@ RSpec.describe HykuAddons::ImportMode, perform_enqueued_jobs: true do
       block.call
     end
 
-    test_strategy = Flipflop::FeatureSet.current.test!
-    test_strategy.switch!(:import_mode, import_mode)
+    allow(Flipflop).to receive(:enabled?).with(:import_mode).and_return(import_mode)
   end
 
   let(:job) do


### PR DESCRIPTION
Hoping this clears up failing feature tests, but I think the failures are related to another underlying test setup issue that has plagued other tests before the changes in #202 .