### PR TITLE
Add explicit log level to development/production

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,4 +3,3 @@
 Rails.application.configure do
   config.log_level = :debug
 end
-

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.log_level = :debug
+end
+

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -3,5 +3,3 @@
 Rails.application.configure do
   config.log_level = :error
 end
-
-

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Rails.application.configure do
+  config.log_level = :error
+end
+
+


### PR DESCRIPTION
So as to not spam the production logs with info messages, change `production` to `error`. 