### PR TITLE
Revert "Change constant to class method to avoid warning logs"

### DIFF
--- a/app/presenters/concerns/hyku_addons/generic_work_presenter_behavior.rb
+++ b/app/presenters/concerns/hyku_addons/generic_work_presenter_behavior.rb
@@ -10,21 +10,17 @@ module HykuAddons
       include Hyrax::DOI::DOIPresenterBehavior
       include Hyrax::DOI::DataCiteDOIPresenterBehavior
 
-      def self.delegated_methods
-        [:volume, :pagination, :issn, :eissn, :contributor_display, :official_link, :series_name, :edition,
-         :event_title, :event_date, :event_location, :book_title, :journal_title,
-         :issue, :article_num, :isbn, :media, :related_exhibition, :related_exhibition_date,
-         :version, :version_number, :alternative_journal_title, :related_exhibition_venue,
-         :current_he_institution, :qualification_name, :qualification_level, :duration, :editor,
-         :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-         :abstract, :alternate_identifier, :related_identifier, :creator_display, :editor_display,
-         :library_of_congress_classification, :alt_title, :dewey,
-         :title, :date_created, :description, :export_as_ris].freeze
-      end
-
-      delegate(*delegated_methods, to: :solr_document)
-
+      DELEGATED_METHODS = [:volume, :pagination, :issn, :eissn, :contributor_display, :official_link, :series_name, :edition,
+                           :event_title, :event_date, :event_location, :book_title, :journal_title,
+                           :issue, :article_num, :isbn, :media, :related_exhibition, :related_exhibition_date,
+                           :version, :version_number, :alternative_journal_title, :related_exhibition_venue,
+                           :current_he_institution, :qualification_name, :qualification_level, :duration, :editor,
+                           :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                           :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                           :abstract, :alternate_identifier, :related_identifier, :creator_display, :editor_display,
+                           :library_of_congress_classification, :alt_title, :dewey,
+                           :title, :date_created, :description, :export_as_ris].freeze
+      delegate(*DELEGATED_METHODS, to: :solr_document)
       alias_method :isbns, :isbn
     end
 

--- a/app/presenters/hyrax/article_presenter.rb
+++ b/app/presenters/hyrax/article_presenter.rb
@@ -5,14 +5,12 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:volume, :pagination, :issn, :eissn, :contributor_display, :publisher, :official_link,
-       :journal_title, :issue, :article_num, :alternative_journal_title,
-       :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-       :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey,
-       :title, :date_created, :description].freeze
-    end
+    DELEGATED_METHODS = [:volume, :pagination, :issn, :eissn, :contributor_display, :publisher, :official_link,
+                         :journal_title, :issue, :article_num, :alternative_journal_title,
+                         :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey,
+                         :title, :date_created, :description].freeze
   end
 end

--- a/app/presenters/hyrax/book_contribution_presenter.rb
+++ b/app/presenters/hyrax/book_contribution_presenter.rb
@@ -6,14 +6,12 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:volume, :pagination, :issn, :eissn, :official_link,
-       :issue, :article_num, :alternative_journal_title,
-       :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-       :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey,
-       :title, :date_created, :description].freeze
-    end
+    DELEGATED_METHODS = [:volume, :pagination, :issn, :eissn, :official_link,
+                         :issue, :article_num, :alternative_journal_title,
+                         :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey,
+                         :title, :date_created, :description].freeze
   end
 end

--- a/app/presenters/hyrax/book_presenter.rb
+++ b/app/presenters/hyrax/book_presenter.rb
@@ -6,14 +6,12 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:volume, :pagination, :issn, :eissn, :official_link,
-       :issue, :article_num, :alternative_journal_title,
-       :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-       :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey,
-       :title, :date_created, :description].freeze
-    end
+    DELEGATED_METHODS = [:volume, :pagination, :issn, :eissn, :official_link,
+                         :issue, :article_num, :alternative_journal_title,
+                         :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey,
+                         :title, :date_created, :description].freeze
   end
 end

--- a/app/presenters/hyrax/conference_item_presenter.rb
+++ b/app/presenters/hyrax/conference_item_presenter.rb
@@ -1,19 +1,16 @@
 # frozen_string_literal: true
-
 module Hyrax
   class ConferenceItemPresenter < Hyrax::WorkShowPresenter
     include Hyrax::DOI::DOIPresenterBehavior
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:volume, :pagination, :issn, :eissn, :official_link,
-       :journal_title, :issue, :article_num, :alternative_journal_title,
-       :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-       :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey,
-       :title, :date_created, :description].freeze
-    end
+    DELEGATED_METHODS = [:volume, :pagination, :issn, :eissn, :official_link,
+                         :journal_title, :issue, :article_num, :alternative_journal_title,
+                         :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey,
+                         :title, :date_created, :description].freeze
   end
 end

--- a/app/presenters/hyrax/dataset_presenter.rb
+++ b/app/presenters/hyrax/dataset_presenter.rb
@@ -6,12 +6,10 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-       :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey,
-       :title, :date_created, :description].freeze
-    end
+    DELEGATED_METHODS = [:institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey,
+                         :title, :date_created, :description].freeze
   end
 end

--- a/app/presenters/hyrax/exhibition_item_presenter.rb
+++ b/app/presenters/hyrax/exhibition_item_presenter.rb
@@ -6,15 +6,13 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:version, :pagination, :issn, :eissn, :official_link,
-       :journal_title, :issue, :article_num, :alternative_journal_title,
-       :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
-       :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey,
-       :title, :date_created, :description, :related_exhibition, :related_exhibition_venue,
-       :place_of_publication].freeze
-    end
+    DELEGATED_METHODS = [:version, :pagination, :issn, :eissn, :official_link,
+                         :journal_title, :issue, :article_num, :alternative_journal_title,
+                         :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey,
+                         :title, :date_created, :description, :related_exhibition, :related_exhibition_venue,
+                         :place_of_publication].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_article_presenter.rb
+++ b/app/presenters/hyrax/pacific_article_presenter.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificArticle`
 module Hyrax
   class PacificArticlePresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract institution date_published pagination
-         issue page_display_order_number volume journal_title publisher issn source additional_links
-         isbn buy_book location official_link rights_holder license org_unit doi subject keyword refereed irb_status
-         irb_number add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract institution date_published pagination issue page_display_order_number
+                           volume journal_title publisher issn source additional_links isbn buy_book location official_link
+                           rights_holder license org_unit doi subject keyword refereed
+                           irb_status irb_number add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_book_chapter_presenter.rb
+++ b/app/presenters/hyrax/pacific_book_chapter_presenter.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificBookChapter`
 module Hyrax
   class PacificBookChapterPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator institution contributor abstract page_display_order_number official_link
-         date_published book_title pagination is_included_in volume publisher isbn issn additional_links rights_holder
-         license location org_unit doi subject keyword refereed add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator institution contributor abstract page_display_order_number official_link
+                           date_published book_title pagination is_included_in volume publisher isbn issn additional_links rights_holder license
+                           location org_unit doi subject keyword refereed add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_book_presenter.rb
+++ b/app/presenters/hyrax/pacific_book_presenter.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificBook`
 module Hyrax
   class PacificBookPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract institution date_published official_link
-         pagination is_included_in volume buy_book publisher isbn issn additional_links page_display_order_number
-         location rights_holder license org_unit doi subject keyword refereed add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract institution date_published official_link
+                           pagination is_included_in volume buy_book publisher isbn issn additional_links page_display_order_number
+                           location rights_holder license org_unit doi subject keyword refereed add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_image_presenter.rb
+++ b/app/presenters/hyrax/pacific_image_presenter.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificImage`
 module Hyrax
   class PacificImagePresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract institution date_published
-         is_included_in publisher additional_links isbn location page_display_order_number rights_holder
-         license org_unit doi subject keyword add_info official_link].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract institution date_published
+                           is_included_in publisher additional_links isbn location page_display_order_number
+                           rights_holder license org_unit doi subject keyword add_info official_link].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_media_presenter.rb
+++ b/app/presenters/hyrax/pacific_media_presenter.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificMedia`
 module Hyrax
   class PacificMediaPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor institution abstract
-         date_published duration version_number is_included_in page_display_order_number
-         publisher additional_links rights_holder rights_holder license location
-         org_unit official_link subject keyword refereed add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor institution abstract
+                           date_published duration version_number is_included_in page_display_order_number
+                           publisher additional_links rights_holder license location
+                           org_unit official_link subject keyword refereed add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_news_clipping_presenter.rb
+++ b/app/presenters/hyrax/pacific_news_clipping_presenter.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificNewsClipping`
 module Hyrax
   class PacificNewsClippingPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract official_link
-         date_published challenged location outcome participant reading_level
-         photo_caption photo_description pagination is_included_in additional_links
-         page_display_order_number rights_holder license doi subject keyword add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract official_link
+                           date_published challenged location outcome participant reading_level
+                           photo_caption photo_description pagination is_included_in additional_links
+                           page_display_order_number rights_holder license doi subject keyword add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_presentation_presenter.rb
+++ b/app/presenters/hyrax/pacific_presentation_presenter.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificPresentation`
 module Hyrax
   class PacificPresentationPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract page_display_order_number official_link
-         date_published pagination is_included_in volume publisher issn additional_links rights_holder license
-         org_unit doi subject keyword refereed add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract page_display_order_number official_link
+                           date_published pagination is_included_in volume publisher issn additional_links rights_holder license
+                           location org_unit doi subject keyword refereed add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_text_work_presenter.rb
+++ b/app/presenters/hyrax/pacific_text_work_presenter.rb
@@ -1,15 +1,16 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificTextWork`
 module Hyrax
   class PacificTextWorkPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract page_display_order_number official_link
-         date_published pagination is_included_in volume publisher issn source additional_links rights_holder license
-         location org_unit doi subject keyword refereed add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract page_display_order_number official_link
+                           date_published pagination is_included_in volume publisher issn source additional_links rights_holder license
+                           location org_unit doi subject keyword refereed add_info].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_thesis_or_dissertation_presenter.rb
+++ b/app/presenters/hyrax/pacific_thesis_or_dissertation_presenter.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificThesisOrDissertation`
 module Hyrax
   class PacificThesisOrDissertationPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      [:volume, :pagination, :issn, :official_link,
-       :journal_title, :issue, :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info,
-       :date_published, :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
-       :abstract, :alternate_identifier, :related_identifier, :creator_display,
-       :library_of_congress_classification, :alt_title, :dewey, :location, :page_display_order_number,
-       :title, :date_created, :description, :additional_links, :pagination, :degree].freeze
-    end
+    DELEGATED_METHODS = [:volume, :pagination, :issn, :official_link,
+                         :journal_title, :issue, :institution, :org_unit, :refereed, :funder, :fndr_project_ref, :add_info, :date_published,
+                         :date_accepted, :date_submitted, :project_name, :rights_holder, :place_of_publication,
+                         :abstract, :alternate_identifier, :related_identifier, :creator_display,
+                         :library_of_congress_classification, :alt_title, :dewey, :location, :page_display_order_number,
+                         :title, :date_created, :description, :additional_links, :pagination, :degree].freeze
   end
 end

--- a/app/presenters/hyrax/pacific_uncategorized_presenter.rb
+++ b/app/presenters/hyrax/pacific_uncategorized_presenter.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work PacificUncategorized`
 module Hyrax
   class PacificUncategorizedPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title alt_title resource_type creator contributor abstract page_display_order_number official_link
-         date_published duration version pagination is_included_in volume_number issue journal_title publisher isbn
-         issn additional_links rights_holder license location doi degree org_unit subject keyword refereed irb_status
-         irb_number add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title alt_title resource_type creator contributor abstract page_display_order_number official_link
+                           date_published duration version pagination is_included_in volume_number issue journal_title publisher isbn issn additional_links rights_holder license
+                           location doi degree org_unit subject keyword refereed irb_status irb_number add_info].freeze
   end
 end

--- a/app/presenters/hyrax/report_presenter.rb
+++ b/app/presenters/hyrax/report_presenter.rb
@@ -6,13 +6,11 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title resource_type creator_display alt_title contributor_display rendering_ids abstract
-         date_published institution org_unit project_name funder fndr_project_ref series_name
-         editor_display volume edition publisher place_of_publication isbn issn eissn date_accepted
-         date_submitted official_link related_url language license rights_statement rights_holder doi
-         alternate_identifier related_identifier refereed keyword dewey
-         library_of_congress_classification add_info pagination].freeze
-    end
+    DELEGATED_METHODS = %i[title resource_type creator_display alt_title contributor_display rendering_ids abstract
+                           date_published institution org_unit project_name funder fndr_project_ref series_name
+                           editor_display volume edition publisher place_of_publication isbn issn eissn date_accepted
+                           date_submitted official_link related_url language license rights_statement rights_holder doi
+                           alternate_identifier related_identifier refereed keyword dewey
+                           library_of_congress_classification add_info pagination].freeze
   end
 end

--- a/app/presenters/hyrax/thesis_or_dissertation_presenter.rb
+++ b/app/presenters/hyrax/thesis_or_dissertation_presenter.rb
@@ -1,18 +1,15 @@
 # frozen_string_literal: true
-
 module Hyrax
   class ThesisOrDissertationPresenter < Hyrax::WorkShowPresenter
     include Hyrax::DOI::DOIPresenterBehavior
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title resource_type creator_display alt_title contributor_display rendering_ids abstract
-         date_published institution org_unit project_name funder fndr_project_ref version_number publisher
-         current_he_institution date_accepted date_submitted official_link related_url language license
-         rights_statement rights_holder doi qualification_name qualification_level alternate_identifier
-         related_identifier refereed keyword dewey library_of_congress_classification add_info
-         pagination].freeze
-    end
+    DELEGATED_METHODS = %i[title resource_type creator_display alt_title contributor_display rendering_ids abstract
+                           date_published institution org_unit project_name funder fndr_project_ref version_number publisher
+                           current_he_institution date_accepted date_submitted official_link related_url language license
+                           rights_statement rights_holder doi qualification_name qualification_level alternate_identifier
+                           related_identifier refereed keyword dewey library_of_congress_classification add_info
+                           pagination].freeze
   end
 end

--- a/app/presenters/hyrax/time_based_media_presenter.rb
+++ b/app/presenters/hyrax/time_based_media_presenter.rb
@@ -6,13 +6,11 @@ module Hyrax
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title resource_type creator alt_title contributor rendering_ids abstract date_published media
-         duration institution org_unit project_name funder fndr_project_ref event_title event_location event_date
-         editor publisher place_of_publication date_accepted date_submitted
-         official_link related_url related_exhibition related_exhibition_venue related_exhibition_date language
-         license rights_statement rights_holder doi alternate_identifier related_identifier refereed keyword
-         dewey library_of_congress_classification add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title resource_type creator alt_title contributor rendering_ids abstract date_published media
+                           duration institution org_unit project_name funder fndr_project_ref event_title event_location event_date
+                           editor publisher place_of_publication date_accepted date_submitted
+                           official_link related_url related_exhibition related_exhibition_venue related_exhibition_date language
+                           license rights_statement rights_holder doi alternate_identifier related_identifier refereed keyword
+                           dewey library_of_congress_classification add_info].freeze
   end
 end

--- a/app/presenters/hyrax/uva_work_presenter.rb
+++ b/app/presenters/hyrax/uva_work_presenter.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
-
+# Generated via
+#  `rails generate hyrax:work UvaWork`
 module Hyrax
   class UvaWorkPresenter < Hyrax::WorkShowPresenter
+    # Adds behaviors for hyrax-doi plugin.
     include Hyrax::DOI::DOIPresenterBehavior
+    # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
     include Hyrax::DOI::DataCiteDOIPresenterBehavior
     include ::HykuAddons::GenericWorkPresenterBehavior
 
-    def self.delegated_methods
-      %i[title resource_type creator abstract license keyword contributor language
-         publisher date_published related_url funder add_info].freeze
-    end
+    DELEGATED_METHODS = %i[title resource_type creator abstract license keyword contributor language
+                           publisher date_published related_url funder add_info].freeze
   end
 end

--- a/app/services/bolognese/readers/generic_work_reader.rb
+++ b/app/services/bolognese/readers/generic_work_reader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Use this with Bolognese like the following:
 #
-# json = Hyrax::GenericWorkPresenter.delegated_methods.collect { |m|
+# json = Hyrax::GenericWorkPresenter::DELEGATED_METHODS.collect { |m|
 #   [m, p.send(m)]
 # }.to_h.merge('has_model' => p.model.model_name).to_json
 # Bolognese::Readers::GenericWorkReader.new(input: json, from: 'generic_work')


### PR DESCRIPTION
Reverts ubiquitypress/hyku_addons#218

Apparently the change had the affect of preventing methods from being delegated properly. Will recommit when this is resolved. 