### PR TITLE
Licence service fix

### DIFF
--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -53,7 +53,7 @@ json.keywords work.keyword
 json.language work.language
 #                                         "library_of_congress_classification" => nil,
 license = work.try(:license)
-license_hash = Hyrax::LicenseService.new.select_all_options.to_h
+license_hash = HykuAddons::LicenseService.new.select_all_options.to_h
 if license.present?
   json.license do
     json.array! license do |item|


### PR DESCRIPTION
Calls HykuAddons Licence service instead of Hyrax to attempt to fix pacific default licence not showing up in the API responses. 