### PR TITLE
Sets default licence to false

### DIFF
--- a/config/authorities/licenses-PACIFIC.yml
+++ b/config/authorities/licenses-PACIFIC.yml
@@ -43,4 +43,4 @@ terms:
     active: true
   - id: https://commons.pacificu.edu/rights
     term: Default
-    active: true
+    active: false


### PR DESCRIPTION
Sets default licence to false so that it does not show up on the deposit form but is still an option and displayed by the API