### PR TITLE
Add tempory fix for cloneable tabs 

### DIFF
--- a/app/views/records/edit_fields/_contributor.html.erb
+++ b/app/views/records/edit_fields/_contributor.html.erb
@@ -26,37 +26,9 @@
 		} %>
 		<%= render "records/edit_fields/attribution_partials/select_field", field_options %>
 
-		<div data-toggleable-group="Organisational">
-			<% [
-				{ field_type: :text, field_slug: :contributor_organization_name },
-				{ field_type: :text, field_slug: :contributor_ror },
-				{ field_type: :text, field_slug: :contributor_grid },
-				{ field_type: :text, field_slug: :contributor_wikidata }
-			].each do |field| %>
-				<% options = { field_group: :contributor, template: template, hash: hash }.merge(field) %>
-				<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
-			<% end %>
-		</div>
-
-		<div data-toggleable-group="Personal">
-			<% personal_fields = [
-				{ field_type: :text, field_slug: :contributor_family_name },
-				{ field_type: :text, field_slug: :contributor_given_name },
-				{ field_type: :text, field_slug: :contributor_orcid },
-				{
-					field_type: :select,
-					field_slug: :contributor_institutional_relationship,
-					select_options: HykuAddons::ContributorInstitutionalRelationshipService.new(model: f.object.model.class).select_active_options.flatten.uniq!,
-					field_args: { multiple: true }
-				}
-			] %>
-			<% personal_fields = add_pacific_contributor_personal_fields(personal_fields) if template.include? "pacific" %>
-			<% personal_fields = add_uva_contributor_personal_fields(personal_fields) if template.include? "uva" %>
-			<% personal_fields.each do |field| %>
-				<% options = { field_group: :contributor, template: template, hash: hash }.merge(field) %>
-				<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
-			<% end %>
-		</div>
+		<% types.each do |type| %>
+			<%= render "records/edit_fields/contributor_#{type.downcase}", f: f, type: type, template: template, hash: hash %>
+		<% end %>
 
 		<% field_options = { field_slug: :contributor_isni, field_group: :contributor, template: template, hash: hash } %>
 		<%= render "records/edit_fields/attribution_partials/text_field", field_options %>

--- a/app/views/records/edit_fields/_contributor_organisational.html.erb
+++ b/app/views/records/edit_fields/_contributor_organisational.html.erb
@@ -1,0 +1,12 @@
+<div data-toggleable-group="<%= type %>">
+	<% [
+		{ field_type: :text, field_slug: :contributor_organization_name },
+		{ field_type: :text, field_slug: :contributor_ror },
+		{ field_type: :text, field_slug: :contributor_grid },
+		{ field_type: :text, field_slug: :contributor_wikidata }
+	].each do |field| %>
+		<% options = { field_group: :contributor, template: template, hash: hash }.merge(field) %>
+		<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
+	<% end %>
+</div>
+

--- a/app/views/records/edit_fields/_contributor_organizational.html.erb
+++ b/app/views/records/edit_fields/_contributor_organizational.html.erb
@@ -1,0 +1,4 @@
+<% # This is gross, but because the authorities have no unique ID, but instead an ID and title that are the same and %>
+<% # that change depending on the spelling, we need a way to ensure the partial is included and this is as good as I can think of. %>
+<% # The reason issue is that the ID of the authority needs to stay the same, even if the title changes %>
+<%= render "records/edit_fields/contributor_organisational", f: f, type: type, template: template, hash: hash %>

--- a/app/views/records/edit_fields/_contributor_personal.html.erb
+++ b/app/views/records/edit_fields/_contributor_personal.html.erb
@@ -1,0 +1,19 @@
+<div data-toggleable-group="<%= type %>">
+	<% personal_fields = [
+		{ field_type: :text, field_slug: :contributor_family_name },
+		{ field_type: :text, field_slug: :contributor_given_name },
+		{ field_type: :text, field_slug: :contributor_orcid },
+		{
+			field_type: :select,
+			field_slug: :contributor_institutional_relationship,
+			select_options: HykuAddons::ContributorInstitutionalRelationshipService.new(model: f.object.model.class).select_active_options.flatten.uniq!,
+			field_args: { multiple: true }
+		}
+	] %>
+	<% personal_fields = add_pacific_contributor_personal_fields(personal_fields) if template.include? "pacific" %>
+	<% personal_fields = add_uva_contributor_personal_fields(personal_fields) if template.include? "uva" %>
+	<% personal_fields.each do |field| %>
+		<% options = { field_group: :contributor, template: template, hash: hash }.merge(field) %>
+		<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
+	<% end %>
+</div>

--- a/app/views/records/edit_fields/_creator.html.erb
+++ b/app/views/records/edit_fields/_creator.html.erb
@@ -27,33 +27,11 @@
 		} %>
 		<%= render "records/edit_fields/attribution_partials/select_field", field_options %>
 
-		<div data-toggleable-group="Organisational">
-			<% # TODO: workout why setting the name fields as required causes the deposit form to not register the meta data was entered %>
-			<% [
-				{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: f.object.required?(:creator) } } },
-				{ f: f, field_type: :text, field_slug: :creator_ror },
-				{ f: f, field_type: :text, field_slug: :creator_grid },
-				{ f: f, field_type: :text, field_slug: :creator_wikidata }
-			].each do |field| %>
-				<% options = { field_group: :creator, template: template, hash: hash }.merge(field) %>
-				<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
-			<% end %>
-		</div>
-
-		<div data-toggleable-group="Personal">
-			<% creator_inst_rel_options = HykuAddons::InstitutionalRelationshipService.new(model: f.object.model.class).select_active_options %>
-			<% personal_fields = [
-				{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: f.object.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
-				{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: f.object.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
-				{ field_type: :text, field_slug: :creator_orcid },
-				{ field_type: :select, field_slug: :creator_institutional_relationship, select_options: creator_inst_rel_options, field_args: { multiple: true } }] %>
-			<% personal_fields = add_pacific_creator_personal_fields(personal_fields) if template.include? "pacific" %>
-			<% personal_fields = add_uva_creator_personal_fields(personal_fields) if template.include? "uva" %>
-			<% personal_fields.each do |field| %>
-				<% options = { field_group: :creator, template: template, hash: hash }.merge(field) %>
-				<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
-			<% end %>
-		</div>
+		<% # FIXME: This needs to be resolved as its not a long term or translatable solution %>
+		<% # Because we have no unique ID to use, we need to hack at getting the correct partial in place %>
+		<% types.each do |type| %>
+			<%= render "records/edit_fields/creator_#{type.downcase}", f: f, type: type, template: template, hash: hash %>
+		<% end %>
 
 		<% field_options = { field_slug: :creator_isni, required: false, field_group: :creator, template: template, hash: hash } %>
 		<%= render "records/edit_fields/attribution_partials/text_field", field_options %>

--- a/app/views/records/edit_fields/_creator_organisational.html.erb
+++ b/app/views/records/edit_fields/_creator_organisational.html.erb
@@ -1,0 +1,14 @@
+<div data-toggleable-group="<%= type %>">
+	<% # TODO: workout why setting the name fields as required causes the deposit form to not register the meta data was entered %>
+	<% [
+		{ f: f, field_type: :text, field_slug: :creator_organization_name, field_args: { data: { required: f.object.required?(:creator) } } },
+		{ f: f, field_type: :text, field_slug: :creator_ror },
+		{ f: f, field_type: :text, field_slug: :creator_grid },
+		{ f: f, field_type: :text, field_slug: :creator_wikidata }
+	].each do |field| %>
+		<% options = { field_group: :creator, template: template, hash: hash }.merge(field) %>
+		<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
+	<% end %>
+</div>
+
+

--- a/app/views/records/edit_fields/_creator_organizational.html.erb
+++ b/app/views/records/edit_fields/_creator_organizational.html.erb
@@ -1,0 +1,5 @@
+<% # This is gross, but because the authorities have no unique ID, but instead an ID and title that are the same and %>
+<% # that change depending on the spelling, we need a way to ensure the partial is included and this is as good as I can think of. %>
+<% # The reason issue is that the ID of the authority needs to stay the same, even if the title changes %>
+<%= render "records/edit_fields/creator_organisational",f: f, type: type, template: template, hash: hash %>
+

--- a/app/views/records/edit_fields/_creator_personal.html.erb
+++ b/app/views/records/edit_fields/_creator_personal.html.erb
@@ -1,0 +1,15 @@
+<div data-toggleable-group="<%= type %>">
+	<% creator_inst_rel_options = HykuAddons::InstitutionalRelationshipService.new(model: f.object.model.class).select_active_options %>
+	<% personal_fields = [
+		{ field_type: :text, field_slug: :creator_family_name, field_args: { data: { required: f.object.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
+		{ field_type: :text, field_slug: :creator_given_name, field_args: { data: { required: f.object.required?(:creator), required_group: :creator_name, on_blur: :toggle_required_group } } },
+		{ field_type: :text, field_slug: :creator_orcid },
+		{ field_type: :select, field_slug: :creator_institutional_relationship, select_options: creator_inst_rel_options, field_args: { multiple: true } }] %>
+	<% personal_fields = add_pacific_creator_personal_fields(personal_fields) if template.include? "pacific" %>
+	<% personal_fields = add_uva_creator_personal_fields(personal_fields) if template.include? "uva" %>
+	<% personal_fields.each do |field| %>
+		<% options = { field_group: :creator, template: template, hash: hash }.merge(field) %>
+		<%= render "records/edit_fields/attribution_partials/#{field[:field_type]}_field", options %>
+	<% end %>
+</div>
+


### PR DESCRIPTION
Cloneable dont have a unique ID from NameType authority, just a single value which is the title (they do have an ID but it was causing duplicate entries in the drop down in production). The real issue is the authority id's but that will take longer to address and this is close to the client deadline. We need to come back and fix this as its not a long term solution and completely not translatable. 