### PR TITLE
Switch settings on account switch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,7 @@ PATH
   specs:
     hyku_addons (0.1.0)
       blacklight_oai_provider (~> 6.1)
+      config (>= 3.0)
       google-cloud-storage (~> 1.31)
       hyrax (~> 2.8)
       hyrax-doi
@@ -304,7 +305,7 @@ GEM
     coffee-script-source (1.12.2)
     colorize (0.8.1)
     concurrent-ruby (1.1.8)
-    config (2.2.3)
+    config (3.1.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
     connection_pool (2.2.3)
@@ -359,7 +360,7 @@ GEM
     dropbox_api (0.1.18)
       faraday (<= 1.0)
       oauth2 (~> 1.1)
-    dry-configurable (0.12.0)
+    dry-configurable (0.12.1)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5.0)
     dry-container (0.7.2)
@@ -374,7 +375,7 @@ GEM
       dry-equalizer (~> 0.2)
     dry-inflector (0.2.0)
     dry-initializer (3.0.4)
-    dry-logic (1.1.0)
+    dry-logic (1.2.0)
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.5, >= 0.5)
     dry-matcher (0.8.3)
@@ -383,7 +384,7 @@ GEM
       concurrent-ruby (~> 1.0)
       dry-core (~> 0.4, >= 0.4.4)
       dry-equalizer
-    dry-schema (1.6.1)
+    dry-schema (1.6.2)
       concurrent-ruby (~> 1.0)
       dry-configurable (~> 0.8, >= 0.8.3)
       dry-core (~> 0.5, >= 0.5)
@@ -399,7 +400,7 @@ GEM
       dry-events (>= 0.1.0)
       dry-matcher (>= 0.7.0)
       dry-monads (>= 0.4.0)
-    dry-types (1.5.0)
+    dry-types (1.5.1)
       concurrent-ruby (~> 1.0)
       dry-container (~> 0.3)
       dry-core (~> 0.5, >= 0.5)
@@ -1162,7 +1163,7 @@ DEPENDENCIES
   carrierwave-aws (~> 1.3)
   codemirror-rails
   coffee-rails (~> 4.2)
-  config (~> 2.2, >= 2.2.1)
+  config (>= 2.2.1, < 4.0)
   coveralls (~> 0.8, >= 0.8.23)
   database_cleaner
   devise

--- a/hyku_addons.gemspec
+++ b/hyku_addons.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rails", "~> 5.2.4", ">= 5.2.4.3"
 
   spec.add_dependency 'blacklight_oai_provider', '~> 6.1'
+  spec.add_dependency 'config', '>= 3.0'
   # TODO: make the gcloud dependency optional?
   spec.add_dependency 'google-cloud-storage', '~> 1.31'
   spec.add_dependency 'hyrax', '~> 2.8'

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -46,6 +46,7 @@ module HykuAddons
           datacite_endpoint.switch!
           switch_host!(cname)
           switch_settings!(name: locale_name, settings: settings)
+          reload_hyrax_config!
         end
 
         def reset!
@@ -55,6 +56,7 @@ module HykuAddons
           DataCiteEndpoint.reset!
           switch_host!(nil)
           switch_settings!
+          reload_hyrax_config!
         end
 
         def switch_host!(cname)
@@ -76,6 +78,19 @@ module HykuAddons
 
         def tenant_settings_filename(name)
           ::Rails.root.join('config', 'settings', "#{::Rails.env}-#{name.upcase}.yml")
+        end
+
+        # Reload all hyrax configuration that reads from Settings
+        # TODO: Figure out a better way to do this
+        def reload_hyrax_config!
+          Hyrax.config do |config|
+            config.contact_email = Settings.contact_email
+            config.analytics = Settings.google_analytics_id.present?
+            config.google_analytics_id = Settings.google_analytics_id
+            config.redis_namespace = Settings.redis.default_namespace
+            config.fits_path = Settings.fits_path
+            config.geonames_username = Settings.geonames_username
+          end
         end
       end
 

--- a/spec/fixtures/settings/test-TEST.yml
+++ b/spec/fixtures/settings/test-TEST.yml
@@ -1,0 +1,1 @@
+google_analytics_id: 'yml-id'

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+RSpec.describe Account, type: :model do
+  describe 'Settings' do
+    let!(:account) { described_class.create(name: 'example', tenant: 'example', cname: 'example.com') }
+
+    it 'loads settings' do
+      account.switch!
+      expect(Settings.google_analytics_id).to eq nil
+    end
+
+    context 'with a settings.yml override' do
+      before do
+        account.update(locale_name: 'test')
+        allow(account).to receive(:tenant_settings_filename).with('test').and_return(HykuAddons::Engine.root.join('spec', 'fixtures', 'settings', 'test-TEST.yml'))
+      end
+
+      it 'loads settings' do
+        account.switch!
+        expect(Settings.google_analytics_id).to eq 'yml-id'
+      end
+    end
+
+    context 'with environment variables' do
+      before do
+        ENV['SETTINGS__GOOGLE_ANALYTICS_ID'] = 'env-id'
+        ENV['SETTINGS__OTHER_SETTING'] = 'moomin'
+      end
+
+      after do
+        ENV.delete('SETTINGS__GOOGLE_ANALYTICS_ID')
+        ENV.delete('SETTINGS__OTHER_SETTING')
+      end
+
+      it 'loads settings' do
+        account.switch!
+        expect(Settings.google_analytics_id).to eq 'env-id'
+        expect(Settings.other_setting).to eq 'moomin'
+      end
+
+      context 'with locale_name' do
+        before do
+          account.update(locale_name: 'test')
+          ENV['SETTINGS__TEST__GOOGLE_ANALYTICS_ID'] = 'env-test-id'
+        end
+
+        after do
+          ENV.delete('SETTINGS__TEST__GOOGLE_ANALYTICS_ID')
+        end
+
+        it 'loads settings' do
+          account.switch!
+          expect(Settings.google_analytics_id).to eq 'env-test-id'
+        end
+
+        it 'still loads fallback settings' do
+          account.switch!
+          expect(Settings.other_setting).to eq 'moomin'
+        end
+      end
+    end
+
+    context 'with DB settings' do
+      before do
+        account.settings['google_analytics_id'] = 'db-id'
+        account.locale_name = 'test'
+        account.save
+      end
+
+      it 'loads settings' do
+        account.switch!
+        expect(Settings.google_analytics_id).to eq 'db-id'
+      end
+    end
+
+    describe 'tenant_settings_filename' do
+      it 'returns a standardized filename' do
+        account.switch!
+        expect(account.tenant_settings_filename('test')).to eq Rails.root.join('config', 'settings', 'test-TEST.yml')
+      end
+    end
+  end
+end


### PR DESCRIPTION
Reload rubyconfig Settings with any tenant specified settings or
settings overrides with the following precedence (lowest to highest):
settings.yml
settings/{environment}.yml
settings/{environment}.local.yml
settings/{environment}-{TENANT_LOCALE_NAME}.yml
current_account.settings
ENV["SETTINGS__#{SETTING_NAME}"]
ENV["SETTINGS__#{TENANT_LOCALE_NAME}__#{SETTING_NAME}"]

After this is in place we should probably centralize all reading of settings to `Settings` (with the exception of `locale_name` used here to load the settings).  So `current_account.allow_signups` would become `Settings.allow_signups`.

Closes https://ubiquitypress.atlassian.net/browse/REPO-1115 and https://ubiquitypress.atlassian.net/browse/REPO-1116