### PR TITLE
Require config to try and solve NameError issue

### DIFF
--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 require 'hyrax/doi/engine'
 require 'bolognese/metadata'
+require 'config'
 
 module HykuAddons
   class Engine < ::Rails::Engine


### PR DESCRIPTION
Seeing errors in production inside jobs like `uninitialized constant HykuAddons::Engine::Settings`.  This PR is an attempt to fix it.