### PR TITLE
REPO-1104: Added note column and tab for adding notes in deposit form

### DIFF
--- a/app/actors/hyku_addons/actors/note_field_actor.rb
+++ b/app/actors/hyku_addons/actors/note_field_actor.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+module HykuAddons
+  module Actors
+    class NoteFieldActor < Hyrax::Actors::AbstractActor
+      attr_accessor :email
+
+      def create(env)
+        serialize_note_field(env) && next_actor.create(env)
+      end
+
+      def update(env)
+        serialize_note_field(env) && next_actor.update(env)
+      end
+
+      private
+
+        def serialize_note_field(env)
+          if env.attributes[:note].present?
+            @email = env.user.email
+            if env.curation_concern.note.present?
+              new_note_value = env.curation_concern.note + Array(process_note_hash(env.attributes[:note]).to_json)
+            else
+              new_note_value = Array(process_note_hash(env.attributes[:note]).to_json)
+            end
+            env.attributes[:note] = new_note_value
+          end
+        end
+
+        def process_note_hash(note)
+          { email: email, timestamp: Time.zone.now.to_s, note: note }
+        end
+    end
+  end
+end

--- a/app/actors/hyku_addons/actors/note_field_actor.rb
+++ b/app/actors/hyku_addons/actors/note_field_actor.rb
@@ -17,12 +17,14 @@ module HykuAddons
         def serialize_note_field(env)
           if env.attributes[:note].present?
             @email = env.user.email
-            if env.curation_concern.note.present?
-              new_note_value = env.curation_concern.note + Array(process_note_hash(env.attributes[:note]).to_json)
-            else
-              new_note_value = Array(process_note_hash(env.attributes[:note]).to_json)
-            end
-            env.attributes[:note] = new_note_value
+            env.attributes[:note] =
+              if env.curation_concern.note.present?
+                env.curation_concern.note + Array(process_note_hash(env.attributes[:note]).to_json)
+              else
+                Array(process_note_hash(env.attributes[:note]).to_json)
+              end
+          else
+            env.attributes[:note] = []
           end
         end
 

--- a/app/assets/stylesheets/hyku_addons/note_content.css
+++ b/app/assets/stylesheets/hyku_addons/note_content.css
@@ -1,0 +1,21 @@
+.note-content-container {
+  border: 2px solid #dedede;
+  background-color: #f1f1f1;
+  border-radius: 5px;
+  padding: 25px;
+  margin: 5px 0;
+}
+.container::after {
+  content: "";
+  clear: both;
+  display: table;
+}
+
+.note-timestamp {
+  float: right;
+  color: #aaa;
+}
+
+.note-body {
+  word-wrap: normal;
+}

--- a/app/forms/concerns/hyku_addons/work_form.rb
+++ b/app/forms/concerns/hyku_addons/work_form.rb
@@ -21,6 +21,7 @@ module HykuAddons
           permitted_params << event_fields
           permitted_params << current_he_institution_fields
           permitted_params << related_exhibition_fields
+          permitted_params << note
         end
       end
 
@@ -43,7 +44,7 @@ module HykuAddons
            page_display_order_number irb_number irb_status subject additional_links is_included_in buy_book challenged
            location outcome participant reading_level photo_caption photo_description degree longitude latitude alt_email
            alt_book_title table_of_contents prerequisites suggested_student_reviewers suggested_reviewers adapted_from audience
-           related_material] + hyrax_terms
+           related_material note] + hyrax_terms
       end
 
       def hyrax_terms
@@ -109,6 +110,10 @@ module HykuAddons
           related_exhibition_date: [:related_exhibition_date_year, :related_exhibition_date_month,
                                     :related_exhibition_date_day]
         ]
+      end
+
+      def note
+        [:note]
       end
     end
 

--- a/app/helpers/hyku_addons/helper_behavior.rb
+++ b/app/helpers/hyku_addons/helper_behavior.rb
@@ -7,5 +7,6 @@ module HykuAddons
     include HykuAddons::ContributorFieldHelper
     include HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper
     include HykuAddons::SimplifiedDepositFormHelper
+    include HykuAddons::NotesTabFormHelper
   end
 end

--- a/app/helpers/hyku_addons/notes_tab_form_helper.rb
+++ b/app/helpers/hyku_addons/notes_tab_form_helper.rb
@@ -1,15 +1,19 @@
+# frozen_string_literal: true
 module HykuAddons
   module NotesTabFormHelper
     def form_tabs_for(form:)
-      if true #Flipflop.enabled?(:notes_tab_form)
+      if Flipflop.enabled?(:notes_tab_form)
         super + ['notes']
       else
         super
       end
     end
 
-    def parse_note_content(note)
-      JSON.parse(note)
+    def sort_note_hash(note_attribute)
+      note_hash_ary = note_attribute.map do |note|
+        JSON.parse(note)
+      end
+      note_hash_ary.sort_by { |note_hash| DateTime.parse(note_hash["timestamp"]).to_i }
     end
   end
 end

--- a/app/helpers/hyku_addons/notes_tab_form_helper.rb
+++ b/app/helpers/hyku_addons/notes_tab_form_helper.rb
@@ -1,0 +1,15 @@
+module HykuAddons
+  module NotesTabFormHelper
+    def form_tabs_for(form:)
+      if true #Flipflop.enabled?(:notes_tab_form)
+        super + ['notes']
+      else
+        super
+      end
+    end
+
+    def parse_note_content(note)
+      JSON.parse(note)
+    end
+  end
+end

--- a/app/models/concerns/hyku_addons/work_base.rb
+++ b/app/models/concerns/hyku_addons/work_base.rb
@@ -76,6 +76,10 @@ module HykuAddons
         index.as :stored_searchable
       end
 
+      property :note, predicate: ::RDF::Vocab::MODS.note, multiple: true do |index|
+        index.as :stored_searchable
+      end
+
       # property :file_availability, predicate: ::RDF::Vocab::SCHEMA.ItemAvailability do |index|
       #   index.as :stored_searchable, :facetable
       # end

--- a/app/views/hyrax/base/_form_notes.html.erb
+++ b/app/views/hyrax/base/_form_notes.html.erb
@@ -1,0 +1,14 @@
+<div class="previous_notes">
+  <% curation_concern.note.each do |note_hash| %>
+    <% parsed_note_content = parse_note_content(note_hash) %>
+    <div class="note-content-container">
+      <p class="note-body"><%= parsed_note_content["note"].html_safe %></p>
+      <span class="note-timestamp">
+        <b><%= parsed_note_content["email"]%></b>
+        <%= Time.zone.parse(parsed_note_content["timestamp"]).utc %>
+      </span>
+    </div>
+  <% end %>
+</div>
+<br>
+<%= f.input :note, label: 'New Note', as: :text, input_html: { value: '', rows: '5' } %>

--- a/app/views/hyrax/base/_form_notes.html.erb
+++ b/app/views/hyrax/base/_form_notes.html.erb
@@ -1,11 +1,11 @@
 <div class="previous_notes">
-  <% curation_concern.note.each do |note_hash| %>
-    <% parsed_note_content = parse_note_content(note_hash) %>
+  <% sorted_hash_by_timestamp = sort_note_hash(curation_concern.note)%>
+  <% sorted_hash_by_timestamp.each do |note_hash| %>
     <div class="note-content-container">
-      <p class="note-body"><%= parsed_note_content["note"].html_safe %></p>
+      <p class="note-body"><%= note_hash["note"].html_safe %></p>
       <span class="note-timestamp">
-        <b><%= parsed_note_content["email"]%></b>
-        <%= Time.zone.parse(parsed_note_content["timestamp"]).utc %>
+        <b><%= note_hash["email"]%></b>
+        <%= Time.zone.parse(note_hash["timestamp"]).utc %>
       </span>
     </div>
   <% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -24,4 +24,8 @@ Flipflop.configure do
   feature :task_master,
           default: ENV["PUBSUB_SERVICEACCOUNT_KEY"].present? && !Rails.env.test?,
           description: "Send tenant repository stats to task master?"
+
+  feature :notes_tab_form,
+          default: false,
+          description: "Enables the Notes tab in the deposit form"
 end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -487,6 +487,8 @@ module HykuAddons
       CatalogController.include HykuAddons::CatalogControllerBehavior
       Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::ModelActor, HykuAddons::Actors::JSONFieldsActor
       Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::ModelActor, HykuAddons::Actors::DateFieldsActor
+      Hyrax::CurationConcern.actor_factory.insert_before Hyrax::Actors::ModelActor, HykuAddons::Actors::NoteFieldActor
+
       actors = [Hyrax::Actors::DefaultAdminSetActor, HykuAddons::Actors::MemberCollectionFromAdminSetActor]
       Hyrax::CurationConcern.actor_factory.insert_after(*actors)
 

--- a/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HykuAddons::Actors::NoteFieldActor do
+  let(:rand) { SecureRandom.uuid }
+  let(:attributes) { {} }
+  let(:user) { build(:user) }
+  let(:ability) { ::Ability.new(user) }
+  let(:work) { create(:generic_work) }
+  let(:env_class) { Hyrax::Actors::Environment }
+  let(:env) { env_class.new(work, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+
+  # let(:actor) { described_class.new(terminator) }
+
+  # This lets us use the middleware chain, rather than assuming its running and using the `create` method on the actor
+  let(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+    end
+
+    stack.build(terminator)
+  end
+
+  describe "#create" do
+    context "when the note attribute is present" do
+      let(:attributes) { { note: 'this is a note' } }
+
+      before do
+        allow(terminator).to receive(:create).with(env)
+        allow(middleware).to receive(:serialize_note_field).with(env_class)
+      end
+
+      it "call serialize_note_field method while creating work" do
+        middleware.create(env)
+        expect(middleware).to have_received(:serialize_note_field).with(env)
+      end
+
+      it "returns an ActiveTriples::Relation class for note attribute" do
+        middleware.create(env)
+        expect(work.note.class).to eq(ActiveTriples::Relation)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:generic_work) { create(:generic_work, title: ["Test Name #{rand}"], note: ['my first note']) }
+    let(:env) { env_class.new(generic_work, ability, attributes) }
+    let(:attributes) { { note: 'this is a new note' } }
+
+    context "when the note attribute is present" do
+      before do
+        allow(terminator).to receive(:update).with(env)
+      end
+
+      it "call the update method " do
+        middleware.update(env)
+        expect(terminator).to have_received(:update).with(env_class)
+      end
+    end
+  end
+end

--- a/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
@@ -12,8 +12,6 @@ RSpec.describe HykuAddons::Actors::NoteFieldActor do
   let(:env) { env_class.new(work, ability, attributes) }
   let(:terminator) { Hyrax::Actors::Terminator.new }
 
-  # let(:actor) { described_class.new(terminator) }
-
   # This lets us use the middleware chain, rather than assuming its running and using the `create` method on the actor
   let(:middleware) do
     stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|

--- a/spec/helpers/notes_tab_form_helper_spec.rb
+++ b/spec/helpers/notes_tab_form_helper_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
   end
 
   before do
-    allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(false)
-    allow(Flipflop).to receive(:enabled?).with(:simplified_deposit_form).and_return(false)
+    allow(Flipflop).to receive(:enabled?).and_call_original
     allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
     allow(controller).to receive(:current_user) { user }
   end

--- a/spec/helpers/notes_tab_form_helper_spec.rb
+++ b/spec/helpers/notes_tab_form_helper_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HykuAddons::NotesTabFormHelper do
+  include Devise::Test::ControllerHelpers
+
+  let(:user) { create(:user) }
+  let(:work) { GenericWork.new(title: ["Moomin"], depositor: user.user_key) }
+  let(:form) { Hyrax::GenericWorkForm.new(work, nil, nil) }
+  let(:helper) { _view }
+
+  before do
+    allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
+    allow(controller).to receive(:current_user) { user }
+  end
+
+  describe "#form_tabs_for" do
+    context "when the feature is enabled" do
+      before do
+        allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(true)
+      end
+
+      it "shows the notes tab" do
+        byebug
+        expect(helper.form_tabs_for(form: form)).to include("notes")
+      end
+    end
+
+    context "when the feature is disabled" do
+      before do
+        allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
+      end
+
+      it "doesn not show the notes tab" do
+        expect(helper.form_tabs_for(form: form)).not_to include("notes")
+      end
+    end
+  end
+
+  describe "#sort_note_hash" do
+    it "returns an array of note hashes in sorted order" do
+      sorted_note_hash = helper.sort_note_hash(note_hash)
+      expect(sorted_note_hash).to be_an(Array)
+      expect(sorted_note_hash.collect { |note_hash| note_hash["note"] }).to eq(
+        ["First Note", "Second Note", "Third Note"]
+      )
+    end
+  end
+
+  def note_hash
+    [
+      { timestamp: "2021-05-25 00:07:12 UTC", note: "First Note" }.to_json,
+      { timestamp: "2021-05-26 00:05:12 UTC", note: "Second Note" }.to_json,
+      { timestamp: "2021-05-27 00:05:12 UTC", note: "Third Note" }.to_json
+    ]
+  end
+end

--- a/spec/helpers/notes_tab_form_helper_spec.rb
+++ b/spec/helpers/notes_tab_form_helper_spec.rb
@@ -9,6 +9,13 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
   let(:work) { GenericWork.new(title: ["Moomin"], depositor: user.user_key) }
   let(:form) { Hyrax::GenericWorkForm.new(work, nil, nil) }
   let(:helper) { _view }
+  let(:note_hash) do
+    [
+      { timestamp: "2021-05-26 00:05:12 UTC", note: "Second Note" }.to_json,
+      { timestamp: "2021-05-25 00:07:12 UTC", note: "First Note" }.to_json,
+      { timestamp: "2021-05-27 00:05:12 UTC", note: "Third Note" }.to_json
+    ]
+  end
 
   before do
     allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(false)
@@ -48,13 +55,5 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
         ["First Note", "Second Note", "Third Note"]
       )
     end
-  end
-
-  def note_hash
-    [
-      { timestamp: "2021-05-25 00:07:12 UTC", note: "First Note" }.to_json,
-      { timestamp: "2021-05-26 00:05:12 UTC", note: "Second Note" }.to_json,
-      { timestamp: "2021-05-27 00:05:12 UTC", note: "Third Note" }.to_json
-    ]
   end
 end

--- a/spec/helpers/notes_tab_form_helper_spec.rb
+++ b/spec/helpers/notes_tab_form_helper_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
 
   before do
     allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(false)
+    allow(Flipflop).to receive(:enabled?).with(:simplified_deposit_form).and_return(false)
     allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
     allow(controller).to receive(:current_user) { user }
   end
@@ -27,7 +28,6 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
     context "when the feature is enabled" do
       before do
         allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(true)
-        allow(helper).to receive(:form_tabs_for).with(form: form).and_return(['notes'])
       end
 
       it "shows the notes tab" do
@@ -36,11 +36,6 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
     end
 
     context "when the feature is disabled" do
-      before do
-        allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
-        allow(helper).to receive(:form_tabs_for).with(form: form).and_return(['relationships'])
-      end
-
       it "doesn not show the notes tab" do
         expect(helper.form_tabs_for(form: form)).not_to include("notes")
       end

--- a/spec/helpers/notes_tab_form_helper_spec.rb
+++ b/spec/helpers/notes_tab_form_helper_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
   let(:helper) { _view }
 
   before do
+    allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(false)
     allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
     allow(controller).to receive(:current_user) { user }
   end
@@ -19,10 +20,10 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
     context "when the feature is enabled" do
       before do
         allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(true)
+        allow(helper).to receive(:form_tabs_for).with(form: form).and_return(['notes'])
       end
 
       it "shows the notes tab" do
-        byebug
         expect(helper.form_tabs_for(form: form)).to include("notes")
       end
     end
@@ -30,6 +31,7 @@ RSpec.describe HykuAddons::NotesTabFormHelper do
     context "when the feature is disabled" do
       before do
         allow(Flipflop).to receive(:enabled?).with(:notes_tab_form).and_return(false)
+        allow(helper).to receive(:form_tabs_for).with(form: form).and_return(['relationships'])
       end
 
       it "doesn not show the notes tab" do

--- a/spec/helpers/simplified_admin_set_selection_work_form_helper_spec.rb
+++ b/spec/helpers/simplified_admin_set_selection_work_form_helper_spec.rb
@@ -11,11 +11,8 @@ RSpec.describe HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper do
   let(:helper) { _view }
 
   before do
-    # NOTE:
-    # This seems to be required or the following error is received:
-    # Please stub a default value first if message might be received with other args as well.
+    allow(Flipflop).to receive(:enabled?).and_call_original
     allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(false)
-    allow(Flipflop).to receive(:enabled?).with(:simplified_deposit_form).and_return(false)
 
     allow(controller).to receive(:current_user) { user }
   end

--- a/spec/helpers/simplified_deposit_form_helper_spec.rb
+++ b/spec/helpers/simplified_deposit_form_helper_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe HykuAddons::SimplifiedDepositFormHelper do
     # NOTE:
     # This seems to be required or the following error is received:
     # Please stub a default value first if message might be received with other args as well.
-    allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(false)
+    allow(Flipflop).to receive(:enabled?).and_call_original
     allow(Flipflop).to receive(:enabled?).with(:simplified_deposit_form).and_return(false)
   end
 


### PR DESCRIPTION

Added notes tab in deposit form and the respective model actors for processing the note content for each model objects

![Screenshot from 2021-05-23 23-46-00](https://user-images.githubusercontent.com/3326678/119279051-1bb93f80-bc21-11eb-9ae2-e47b53d9619b.png)