### PR TITLE
Add support for Creator/contributor JSON content

### DIFF
--- a/app/models/concerns/hyku_addons/solr_document_behavior.rb
+++ b/app/models/concerns/hyku_addons/solr_document_behavior.rb
@@ -22,13 +22,13 @@ module HykuAddons
       class_attribute :registered_attributes
       # Pre-seed registered attributes because they have already been created before this module is included
       self.registered_attributes = [:doi, :identifier, :based_near, :based_near_label, :related_url, :resource_type,
-                                    :edit_groups, :edit_people, :read_groups, :admin_set, :member_ids,
+                                    :edit_groups, :edit_people, :read_groups, :admin_set, :member_ids, :creator,
                                     :member_of_collection_ids, :description, :abstract, :title, :contributor, :subject,
                                     :publisher, :language, :keyword, :license, :source, :date_created, :rights_statement,
                                     :mime_type, :workflow_state, :human_readable_type, :representative_id, :rendering_ids,
                                     :thumbnail_id, :thumbnail_path, :label, :file_format, :suppressed?, :original_file_id,
                                     :date_modified, :date_uploaded, :create_date, :modified_date, :embargo_release_date,
-                                    :lease_expiration_date]
+                                    :lease_expiration_date, :add_info]
 
       attribute :file_size, SolrDocument::Solr::String, "file_size_lts"
       attribute :extent, SolrDocument::Solr::Array, solr_name('extent')

--- a/app/services/bolognese/readers/base_work_reader.rb
+++ b/app/services/bolognese/readers/base_work_reader.rb
@@ -37,7 +37,8 @@ module Bolognese
       def self.nested_attributes
         {
           "container" => %w[volume issue firstPage lastPage pagination]
-        } end
+        }
+      end
 
       # An array of methods that should be called after the inital attributes have been collected.
       # These methods should modify the `@reader_attributes` variable directly

--- a/app/services/bolognese/readers/base_work_reader.rb
+++ b/app/services/bolognese/readers/base_work_reader.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'bolognese'
+require "bolognese"
 
 # NOTE:
 # Parent class to work type class readers.
@@ -89,7 +89,7 @@ module Bolognese
         end
 
         def read_creator
-          return unless (value = @meta.fetch('creator', @meta.dig('creator_display'))).present?
+          return unless (value = @meta.fetch("creator", @meta.dig("creator_display"))).present?
 
           value = bologneseify_author_json(:creator, value.first)
 
@@ -97,7 +97,7 @@ module Bolognese
         end
 
         def read_contributor
-          return unless (value = @meta.fetch('contributor', @meta.dig('contributor_display'))).present?
+          return unless (value = @meta.fetch("contributor", @meta.dig("contributor_display"))).present?
 
           value = bologneseify_author_json(:contributor, value.first)
 
@@ -106,7 +106,7 @@ module Bolognese
 
         # For now editor is treated differently to creator/contributor
         def read_editor
-          return unless (value = @meta.fetch('editor_display', @meta.dig('editor'))).present?
+          return unless (value = @meta.fetch("editor_display", @meta.dig("editor"))).present?
 
           get_authors(value)
         end
@@ -134,7 +134,7 @@ module Bolognese
         end
 
         def read_doi
-          normalize_doi(meta_value('doi')&.first)
+          normalize_doi(meta_value("doi")&.first)
         end
 
         # This is a special method that adds some additional values to the meta object. As its not part of the

--- a/app/services/bolognese/readers/base_work_reader.rb
+++ b/app/services/bolognese/readers/base_work_reader.rb
@@ -37,8 +37,7 @@ module Bolognese
       def self.nested_attributes
         {
           "container" => %w[volume issue firstPage lastPage pagination]
-        }
-      end
+        } end
 
       # An array of methods that should be called after the inital attributes have been collected.
       # These methods should modify the `@reader_attributes` variable directly
@@ -67,18 +66,44 @@ module Bolognese
 
       protected
 
+        # Prepare the json to be parsed through Bolognese get_authors method
+        # Bologese wants a hash with `givenName` not `creator_given_name` etc
+        def bologneseify_author_json(type, json)
+          creators = JSON.parse(json)
+          transformed = Array.wrap(creators).map { |cr| cr.transform_keys { |k| k.gsub(/#{type}_/, "") }.deep_transform_keys { |k| k.camelize(:lower) } }
+
+          transformed.each do |creator|
+            next unless creator["orcid"].present?
+
+            creator["nameIdentifier"] = {
+              "nameIdentifierScheme" => "orcid",
+              "__content__" => creator["orcid"]
+            }
+          end
+
+          transformed.compact
+
+        rescue JSON::ParserError
+          json
+        end
+
         def read_creator
-          return unless (value = @meta.fetch('creator_display', @meta.dig('creator'))).present?
+          return unless (value = @meta.fetch('creator', @meta.dig('creator_display'))).present?
+
+          value = bologneseify_author_json(:creator, value.first)
 
           get_authors(value)
         end
 
         def read_contributor
-          return unless (value = @meta.fetch('contributor_display', @meta.dig('contributor'))).present?
+          return unless (value = @meta.fetch('contributor', @meta.dig('contributor_display'))).present?
+
+          value = bologneseify_author_json(:contributor, value.first)
 
           get_authors(value)
         end
 
+        # For now editor is treated differently to creator/contributor
         def read_editor
           return unless (value = @meta.fetch('editor_display', @meta.dig('editor'))).present?
 
@@ -127,12 +152,12 @@ module Bolognese
         # Avoid overriding a parent method publication_year
         def read_publication_year
           @publication_year ||= begin
-            date = meta_value("date_published") || meta_value("date_created")&.first || meta_value("date_uploaded")
-            Date.edtf(date.to_s).year
+                                  date = meta_value("date_published") || meta_value("date_created")&.first || meta_value("date_uploaded")
+                                  Date.edtf(date.to_s).year
 
-          rescue Date::Error, TypeError, NoMethodError
-            Time.zone.today.year
-          end
+                                rescue Date::Error, TypeError, NoMethodError
+                                  Time.zone.today.year
+                                end
         end
 
         def build_dates!
@@ -179,7 +204,7 @@ module Bolognese
           else
             value
           end
-        # Don't worry about methods that aren't in the form terms, just return the value and continue
+          # Don't worry about methods that aren't in the form terms, just return the value and continue
         rescue ActiveFedora::UnknownAttributeError
           value
         end

--- a/app/services/bolognese/writers/ris_writer_behavior.rb
+++ b/app/services/bolognese/writers/ris_writer_behavior.rb
@@ -55,7 +55,7 @@ module Bolognese
             "ED" => to_ris(meta.dig("editor")),
             "AB" => parse_attributes(descriptions, content: "description", first: true),
             "KW" => Array.wrap(subjects).map { |k| parse_attributes(k, content: "subject", first: true) }.presence,
-            "DA" => meta.dig('dates').find { |date| date["dateType"] == "Issued" }&.dig("date"),
+            "DA" => meta.dig("dates").find { |date| date["dateType"] == "Issued" }&.dig("date"),
             "PY" => publication_year,
             "PB" => publisher,
             "PP" => meta.dig("place_of_publication"),
@@ -89,7 +89,7 @@ module Bolognese
         end
 
         def secondary_titles
-          Array.wrap(parse_attributes(meta["alt_title"])) + Array.wrap(parse_attributes(meta['book_title']))
+          Array.wrap(parse_attributes(meta["alt_title"])) + Array.wrap(parse_attributes(meta["book_title"]))
         end
 
         # Legacy code ordered the values and returned
@@ -97,7 +97,7 @@ module Bolognese
           related_identifiers
             .select { |h| h["relatedIdentifier"].present? }
             .map { |h| [h["relatedIdentifierType"], h["relatedIdentifier"]] }.to_h
-            .slice('ISBN', 'ISSN', 'EISSN')
+            .slice("ISBN", "ISSN", "EISSN")
             .values.first
         end
 

--- a/app/services/bolognese/writers/ris_writer_behavior.rb
+++ b/app/services/bolognese/writers/ris_writer_behavior.rb
@@ -47,29 +47,29 @@ module Bolognese
       included do
         def ris
           hash = {
-            TY: calculate_resource_type(types),
-            T1: parse_attributes(titles, content: "title", first: true),
-            T2: secondary_titles,
-            AU: to_ris(creators),
-            DO: doi,
-            ED: to_ris(meta.dig("editor")),
-            AB: parse_attributes(descriptions, content: "description", first: true),
-            KW: Array.wrap(subjects).map { |k| parse_attributes(k, content: "subject", first: true) }.presence,
-            DA: meta.dig('dates').find { |date| date["dateType"] == "Issued" }&.dig("date"),
-            PY: publication_year,
-            PB: publisher,
-            PP: meta.dig("place_of_publication"),
-            EP: container.to_h["lastPage"],
-            SN: ordered_identifiers,
-            JO: meta.dig("journal_title"),
-            LA: meta.dig("language"),
-            N1: meta.dig("add_info"),
-            UR: meta.dig("official_link"),
-            IS: container.to_h["issue"],
-            VL: container.to_h["volume"],
-            SP: container.to_h["pagination"],
-            ER: ""
-          }
+            "TY" => calculate_resource_type(types),
+            "T1" => parse_attributes(titles, content: "title", first: true),
+            "T2" => secondary_titles,
+            "DO" => doi,
+            "AU" => to_ris(creators),
+            "ED" => to_ris(meta.dig("editor")),
+            "AB" => parse_attributes(descriptions, content: "description", first: true),
+            "KW" => Array.wrap(subjects).map { |k| parse_attributes(k, content: "subject", first: true) }.presence,
+            "DA" => meta.dig('dates').find { |date| date["dateType"] == "Issued" }&.dig("date"),
+            "PY" => publication_year,
+            "PB" => publisher,
+            "PP" => meta.dig("place_of_publication"),
+            "EP" => container.to_h["lastPage"],
+            "SN" => ordered_identifiers,
+            "JO" => meta.dig("journal_title"),
+            "LA" => meta.dig("language"),
+            "N1" => meta.dig("add_info"),
+            "UR" => meta.dig("official_link"),
+            "IS" => container.to_h["issue"],
+            "VL" => container.to_h["volume"],
+            "SP" => container.to_h["pagination"],
+            "ER" => ""
+          }.compare_by_identity
 
           expand_nested_and_prepare(hash)
         end
@@ -80,7 +80,8 @@ module Bolognese
             .compact
             .map do |k, v|
               if v.is_a?(Array)
-                v.map { |vi| "#{k}  - #{vi}" if vi.present? }.compact.join(RIS_DELIMITER)
+                # `dup` string for different object ID allowing duplicate keys in compare_by_identity hash
+                v.map { |vi| "#{k.dup}  - #{vi}" if vi.present? }.compact.join(RIS_DELIMITER)
               else
                 "#{k}  - #{v}"
               end

--- a/spec/models/concerns/hyku_addons/task_master/file_set_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/task_master/file_set_behavior_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe HykuAddons::TaskMaster::FileSetBehavior do
-  subject(:file_set) { create(:file_set, user: user, title: ['A Contained PDF FileSet'], label: 'filename.pdf') }
+  subject(:file_set) { create(:file_set, user: user, title: ["A Contained PDF FileSet"], label: "filename.pdf") }
   let(:user) { create(:user) }
   let(:work) { create(:task_master_work) }
   let(:account) { create(:account) }

--- a/spec/services/bolognese/readers/generic_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/generic_work_reader_spec.rb
@@ -9,8 +9,28 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
   let(:book_title) { "Book Title 1" }
   let(:contributor) { 'Elizabeth Portch' }
   let(:created_year) { "1945" }
-  let(:creator1) { 'Tove Jansson' }
-  let(:creator2) { 'Creator 2' }
+  let(:creator1_first_name) { "Sebastian" }
+  let(:creator1_last_name) { "Hageneuer" }
+  let(:creator2_first_name) { "Johnny" }
+  let(:creator2_last_name) { "Testing" }
+  let(:creator1) do
+    {
+      "nameType"=>"Personal",
+      "name"=>"#{creator1_last_name}, #{creator1_first_name}",
+      "givenName"=> creator1_first_name,
+      "familyName"=> creator1_last_name
+    }
+  end
+  let(:creator2) do
+    {
+      "name"=>"#{creator2_last_name}, #{creator2_first_name}",
+      "givenName"=> creator2_first_name,
+      "familyName"=> creator2_last_name,
+      "nameIdentifiers"=>[
+        {"nameIdentifier"=>"12345678890", "nameIdentifierScheme"=>"orcid"}
+      ]
+    }
+  end
   let(:date_accepted) { "2018-01-02" }
   let(:date_created) { "#{created_year}-01-01" }
   let(:date_published) { "#{published_year}-01-01" }
@@ -56,7 +76,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
       title: [title],
       alt_title: [alt_title1],
       resource_type: [resource_type],
-      creator: [creator1],
+      creator: [creator1.to_json],
       contributor: [contributor],
       publisher: [publisher],
       abstract: abstract,
@@ -99,7 +119,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
           expect(ris).to include("TY  - #{ris_resource_type_identifier}")
           expect(ris).to include("T1  - #{title}")
           expect(ris).to include("T2  - #{alt_title1}")
-          expect(ris).to include("AU  - #{creator1}")
+          expect(ris).to include("AU  - #{creator1_last_name}, #{creator1_first_name}")
           expect(ris).to include("ED  - #{editor}")
           expect(ris).to include("DO  - https://doi.org/#{doi}")
           expect(ris).to include("AB  - #{abstract}")
@@ -126,7 +146,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
             "alt_title" => [alt_title1, alt_title2, ""],
             "book_title" => book_title,
             "contributor" => [contributor],
-            "creator": [creator1, creator2, ""],
+            "creator" => [[creator1, creator2].to_json],
             "date_accepted" => date_accepted,
             "date_published" => date_published,
             "date_submitted" => date_submitted,
@@ -145,52 +165,52 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
             "official_link" => official_link,
             "org_unit" => [org_unit1, org_unit2],
             "pagination" => pagination,
-            "place_of_publication" => [place_of_publication1, place_of_publication2],
+            "place_of_publication" => [place_of_publication, place_of_publication2],
             "project_name" => [project_name1, project_name2],
             "publisher" => [publisher, ""],
-            "resource_type": ["Other", ""],
+            "resource_type" => ["Other", ""],
             "series_name" => [series_name, ""],
             "source" => [""],
-            "title": [title],
+            "title" => [title],
             "version_number" => [version_number, ""],
             "volume" => [volume, ""]
           }
         end
 
-        it "outputs correctly" do
-          ris = metadata.ris
+        context "outputs correctly" do
+          let(:ris) { metadata.ris }
 
-          expect(ris).to include("TY  - GEN")
-          expect(ris).to include("T1  - #{title}")
-          expect(ris).to include("T2  - #{alt_title1}")
-          expect(ris).to include("T2  - #{alt_title2}")
-          expect(ris).to include("T2  - #{book_title}")
-          expect(ris).to include("AU  - #{creator1}")
-          expect(ris).to include("AU  - #{creator2}")
-          expect(ris).to include("ED  - #{editor}")
-          expect(ris).to include("AB  - #{abstract}")
-          expect(ris).to include("DA  - #{date_published}")
-          expect(ris).to include("DO  - https://doi.org/#{doi}")
-          expect(ris).to include("JO  - #{journal_title}")
-          expect(ris).to include("LA  - #{language}")
-          expect(ris).to include("LA  - #{language2}")
-          expect(ris).to include("N1  - #{add_info}")
-          expect(ris).to include("KW  - #{keyword}")
-          expect(ris).to include("KW  - #{keyword2}")
-          expect(ris).to include("IS  - #{issue}")
-          expect(ris).to include("PB  - #{publisher}")
-          expect(ris).to include("PP  - #{place_of_publication1}")
-          expect(ris).to include("PP  - #{place_of_publication2}")
-          expect(ris).to include("PY  - #{published_year}")
-          expect(ris).to include("SN  - #{isbn}")
-          expect(ris).to include("SP  - #{pagination}")
-          expect(ris).to include("UR  - #{official_link}")
-          expect(ris).to include("VL  - #{volume}")
-          expect(ris).to include("ER  - ")
+          it { expect(ris).to include("TY  - GEN") }
+          it { expect(ris).to include("T1  - #{title}") }
+          it { expect(ris).to include("T2  - #{alt_title1}") }
+          it { expect(ris).to include("T2  - #{alt_title2}") }
+          it { expect(ris).to include("T2  - #{book_title}") }
+          it { expect(ris).to include("AU  - #{creator1_last_name}, #{creator1_first_name}") }
+          it { expect(ris).to include("AU  - #{creator2_last_name}, #{creator2_first_name}") }
+          it { expect(ris).to include("ED  - #{editor}") }
+          it { expect(ris).to include("AB  - #{abstract}") }
+          it { expect(ris).to include("DA  - #{date_published}") }
+          it { expect(ris).to include("DO  - https://doi.org/#{doi}") }
+          it { expect(ris).to include("JO  - #{journal_title}") }
+          it { expect(ris).to include("LA  - #{language}") }
+          it { expect(ris).to include("LA  - #{language2}") }
+          it { expect(ris).to include("N1  - #{add_info}") }
+          it { expect(ris).to include("KW  - #{keyword}") }
+          it { expect(ris).to include("KW  - #{keyword2}") }
+          it { expect(ris).to include("IS  - #{issue}") }
+          it { expect(ris).to include("PB  - #{publisher}") }
+          it { expect(ris).to include("PP  - #{place_of_publication}") }
+          it { expect(ris).to include("PP  - #{place_of_publication2}") }
+          it { expect(ris).to include("PY  - #{published_year}") }
+          it { expect(ris).to include("SN  - #{isbn}") }
+          it { expect(ris).to include("SP  - #{pagination}") }
+          it { expect(ris).to include("UR  - #{official_link}") }
+          it { expect(ris).to include("VL  - #{volume}") }
+          it { expect(ris).to include("ER  - ") }
 
           # Ensure the priority of the identifiers is being respected
-          expect(ris).not_to include(issn)
-          expect(ris).not_to include(eissn)
+          it { expect(ris).not_to include(issn) }
+          it { expect(ris).not_to include(eissn) }
         end
       end
     end
@@ -211,7 +231,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
 
       context 'it correctly populates the datacite XML' do
         it { expect(datacite_xml.xpath('/resource/titles/title[1]/text()').to_s).to eq title }
-        it { expect(datacite_xml.xpath('/resource/creators/creator[1]/creatorName/text()').to_s).to eq creator1 }
+        it { expect(datacite_xml.xpath('/resource/creators/creator[1]/creatorName/text()').to_s).to eq "#{creator1_last_name}, #{creator1_first_name}" }
         it { expect(datacite_xml.xpath('/resource/publisher/text()').to_s).to eq publisher }
         it { expect(datacite_xml.xpath('/resource/descriptions/description[1]/text()').to_s).to eq abstract }
         it { expect(datacite_xml.xpath('/resource/contributors/contributor[1]/contributorName/text()').to_s).to eq contributor }

--- a/spec/services/bolognese/readers/generic_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/generic_work_reader_spec.rb
@@ -2,12 +2,12 @@
 require "rails_helper"
 
 RSpec.describe Bolognese::Readers::GenericWorkReader do
-  let(:abstract) { 'Swedish comic about the adventures of the residents of Moominvalley.' }
+  let(:abstract) { "Swedish comic about the adventures of the residents of Moominvalley." }
   let(:add_info) { "Nothing to report" }
-  let(:alt_title1) { 'alt-title' }
-  let(:alt_title2) { 'alt-title-2' }
+  let(:alt_title1) { "alt-title" }
+  let(:alt_title2) { "alt-title-2" }
   let(:book_title) { "Book Title 1" }
-  let(:contributor) { 'Elizabeth Portch' }
+  let(:contributor) { "Elizabeth Portch" }
   let(:created_year) { "1945" }
   let(:creator1_first_name) { "Sebastian" }
   let(:creator1_last_name) { "Hageneuer" }
@@ -35,7 +35,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
   let(:date_created) { "#{created_year}-01-01" }
   let(:date_published) { "#{published_year}-01-01" }
   let(:date_submitted) { "2019-01-02" }
-  let(:doi) { '10.18130/v3-k4an-w022' }
+  let(:doi) { "10.18130/v3-k4an-w022" }
   let(:duration1) { "duration1" }
   let(:duration2) { "duration2" }
   let(:edition) { "1" }
@@ -48,8 +48,8 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
   let(:issue) { "6" }
   let(:issue) { 7 }
   let(:journal_title) { "Test Journal Title" }
-  let(:keyword) { 'Lighthouses' }
-  let(:keyword2) { 'Hippos' }
+  let(:keyword) { "Lighthouses" }
+  let(:keyword2) { "Hippos" }
   let(:language) { "Swedish" }
   let(:language2) { "English" }
   let(:official_link) { "http://test-url.com" }
@@ -62,11 +62,11 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
   let(:project_name1) { "Project name2" }
   let(:project_name2) { "The Chicken projectca" }
   let(:published_year) { "1946" }
-  let(:publisher) { 'Schildts' }
+  let(:publisher) { "Schildts" }
   let(:resource_type) { "Book" }
   let(:ris_resource_type_identifier) { "BOOK" }
   let(:series_name) { "Series name" }
-  let(:title) { 'Moomin' }
+  let(:title) { "Moomin" }
   let(:version_number) { "3" }
   let(:volume) { 2 }
 
@@ -215,88 +215,88 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
       end
     end
 
-    context 'datacite' do
+    context "datacite" do
       subject(:datacite_xml) { Nokogiri::XML(datacite_string, &:strict).remove_namespaces! }
       let(:datacite_string) { metadata.datacite }
 
-      it 'creates datacite XML' do
+      it "creates datacite XML" do
         expect(datacite_string).to be_a String
         expect(datacite_xml).to be_a Nokogiri::XML::Document
       end
 
-      it 'sets the DOI' do
+      it "sets the DOI" do
         url = "https://doi.org/#{doi}"
-        expect(datacite_xml.xpath('/resource/identifier[@identifierType="DOI"]/text()').to_s).to eq url
+        expect(datacite_xml.xpath("/resource/identifier[@identifierType="DOI"]/text()").to_s).to eq url
       end
 
-      context 'it correctly populates the datacite XML' do
-        it { expect(datacite_xml.xpath('/resource/titles/title[1]/text()').to_s).to eq title }
-        it { expect(datacite_xml.xpath('/resource/creators/creator[1]/creatorName/text()').to_s).to eq "#{creator1_last_name}, #{creator1_first_name}" }
-        it { expect(datacite_xml.xpath('/resource/publisher/text()').to_s).to eq publisher }
-        it { expect(datacite_xml.xpath('/resource/descriptions/description[1]/text()').to_s).to eq abstract }
-        it { expect(datacite_xml.xpath('/resource/contributors/contributor[1]/contributorName/text()').to_s).to eq contributor }
-        it { expect(datacite_xml.xpath('/resource/subjects/subject[1]/text()').to_s).to eq keyword }
-        it { expect(JSON.parse(datacite_xml.xpath('/resource/language/text()').to_s).first).to eq language }
+      context "it correctly populates the datacite XML" do
+        it { expect(datacite_xml.xpath("/resource/titles/title[1]/text()").to_s).to eq title }
+        it { expect(datacite_xml.xpath("/resource/creators/creator[1]/creatorName/text()").to_s).to eq "#{creator1_last_name}, #{creator1_first_name}" }
+        it { expect(datacite_xml.xpath("/resource/publisher/text()").to_s).to eq publisher }
+        it { expect(datacite_xml.xpath("/resource/descriptions/description[1]/text()").to_s).to eq abstract }
+        it { expect(datacite_xml.xpath("/resource/contributors/contributor[1]/contributorName/text()").to_s).to eq contributor }
+        it { expect(datacite_xml.xpath("/resource/subjects/subject[1]/text()").to_s).to eq keyword }
+        it { expect(JSON.parse(datacite_xml.xpath("/resource/language/text()").to_s).first).to eq language }
         it {
-          xpath = '/resource/relatedIdentifiers/relatedIdentifier[@relatedIdentifierType="ISBN"]/text()'
+          xpath = "/resource/relatedIdentifiers/relatedIdentifier[@relatedIdentifierType="ISBN"]/text()"
           expect(datacite_xml.xpath(xpath).to_s).to eq isbn
         }
       end
 
-      it 'sets the resource type' do
-        type = JSON.parse(datacite_xml.xpath('/resource/resourceType[@resourceTypeGeneral="Other"]/text()').to_s).first
+      it "sets the resource type" do
+        type = JSON.parse(datacite_xml.xpath("/resource/resourceType[@resourceTypeGeneral="Other"]/text()").to_s).first
         expect(type).to eq resource_type
       end
 
-      context 'publication year' do
-        let(:create_date) { '1945-01-01' }
-        let(:upload_date) { DateTime.parse('2009-12-25 11:30').iso8601 }
+      context "publication year" do
+        let(:create_date) { "1945-01-01" }
+        let(:upload_date) { DateTime.parse("2009-12-25 11:30").iso8601 }
 
-        it 'sets year from date_published by default' do
-          expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq published_year
+        it "sets year from date_published by default" do
+          expect(datacite_xml.xpath("/resource/publicationYear/text()").to_s).to eq published_year
         end
 
-        context 'with date_created' do
+        context "with date_created" do
           before do
             work.date_created = [create_date]
             work.date_uploaded = upload_date
             work.date_published = nil
           end
 
-          it 'sets year from date_created' do
-            expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq created_year
+          it "sets year from date_created" do
+            expect(datacite_xml.xpath("/resource/publicationYear/text()").to_s).to eq created_year
           end
 
-          context 'with only year' do
-            let(:create_date) { '1945' }
+          context "with only year" do
+            let(:create_date) { "1945" }
 
-            it 'sets year from date_created' do
-              expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq created_year
+            it "sets year from date_created" do
+              expect(datacite_xml.xpath("/resource/publicationYear/text()").to_s).to eq created_year
             end
           end
         end
 
-        context 'with date_uploaded' do
+        context "with date_uploaded" do
           before do
             work.date_created = []
             work.date_uploaded = upload_date
             work.date_published = nil
           end
 
-          it 'sets year from date_uploaded' do
-            expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq "2009"
+          it "sets year from date_uploaded" do
+            expect(datacite_xml.xpath("/resource/publicationYear/text()").to_s).to eq "2009"
           end
         end
 
-        context 'without either' do
+        context "without either" do
           before do
             work.date_created = []
             work.date_uploaded = nil
             work.date_published = nil
           end
 
-          it 'defaults to current year' do
-            expect(datacite_xml.xpath('/resource/publicationYear/text()').to_s).to eq Date.today.year.to_s
+          it "defaults to current year" do
+            expect(datacite_xml.xpath("/resource/publicationYear/text()").to_s).to eq Date.today.year.to_s
           end
         end
       end

--- a/spec/services/bolognese/readers/generic_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/generic_work_reader_spec.rb
@@ -15,19 +15,19 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
   let(:creator2_last_name) { "Testing" }
   let(:creator1) do
     {
-      "nameType"=>"Personal",
-      "name"=>"#{creator1_last_name}, #{creator1_first_name}",
-      "givenName"=> creator1_first_name,
-      "familyName"=> creator1_last_name
+      "nameType" => "Personal",
+      "name" => "#{creator1_last_name}, #{creator1_first_name}",
+      "givenName" => creator1_first_name,
+      "familyName" => creator1_last_name
     }
   end
   let(:creator2) do
     {
-      "name"=>"#{creator2_last_name}, #{creator2_first_name}",
-      "givenName"=> creator2_first_name,
-      "familyName"=> creator2_last_name,
-      "nameIdentifiers"=>[
-        {"nameIdentifier"=>"12345678890", "nameIdentifierScheme"=>"orcid"}
+      "name" => "#{creator2_last_name}, #{creator2_first_name}",
+      "givenName" => creator2_first_name,
+      "familyName" => creator2_last_name,
+      "nameIdentifiers" => [
+        { "nameIdentifier" => "12345678890", "nameIdentifierScheme" => "orcid" }
       ]
     }
   end


### PR DESCRIPTION
Currently the Bolognese GenericWorkReader uses the `display` for creator and contributor. This is preventing me from getting data out of the reader to use when exporting in the ORCID XML writer. The only writer that currently uses the generic work reader is the RISWriter, so that has been updated and the tests fixed.