### PR TITLE
Allow per-tenant settings by recreating Settings on switch!

### DIFF
--- a/app/services/settings.rb
+++ b/app/services/settings.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+class Settings
+  def self.switch!(name: nil, settings: {})
+    settings_files = Config.setting_files(Rails.root.join('config'), Rails.env)
+    settings_files += [tenant_settings_filename(name)] if name
+    config = Config.load_files(settings_files)
+    config.add_source!(Config::Sources::EnvSource.new(ENV, prefix: tenant_settings_prefix(name))) if name
+    config.add_source!(settings)
+    config.reload!
+    Thread.current[:settings] = config
+    reload_hyrax_config!
+    config
+  end
+
+  # Disable rubocop because Settings will return nil for an undefined method
+  # instead of raising an exception and we want to mirror that behavior
+  # rubocop:disable Style/MethodMissing
+  def self.method_missing(method_id)
+    switch! if Thread.current[:settings].blank?
+    Thread.current[:settings].send(method_id)
+  end
+  # rubocop:enable Style/MethodMissing
+
+  def self.respond_to_missing?(method_name, include_all)
+    super
+  end
+
+  def self.tenant_settings_filename(name)
+    Rails.root.join('config', 'settings', "#{Rails.env}-#{name.upcase}.yml")
+  end
+
+  def self.tenant_settings_prefix(name)
+    [Config.env_prefix, name.upcase].compact.join(Config.env_separator)
+  end
+
+  # Reload all hyrax configuration that reads from Settings
+  # TODO: Figure out a better way to do this
+  def self.reload_hyrax_config!
+    Hyrax.config do |config|
+      # DO NOT reload the redis_namespace because this is already handled by redis_endpoint.switch!
+      config.contact_email = Settings.contact_email
+      config.analytics = Settings.google_analytics_id.present?
+      config.google_analytics_id = Settings.google_analytics_id
+      config.fits_path = Settings.fits_path
+      config.geonames_username = Settings.geonames_username
+    end
+  end
+end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Account, type: :model do
     context 'with a settings.yml override' do
       before do
         account.update(locale_name: 'test')
-        allow(account).to receive(:tenant_settings_filename).with('test').and_return(HykuAddons::Engine.root.join('spec', 'fixtures', 'settings', 'test-TEST.yml'))
+        allow(Settings).to receive(:tenant_settings_filename).with('test').and_return(HykuAddons::Engine.root.join('spec', 'fixtures', 'settings', 'test-TEST.yml'))
       end
 
       it 'loads settings' do
@@ -80,7 +80,7 @@ RSpec.describe Account, type: :model do
     describe 'tenant_settings_filename' do
       it 'returns a standardized filename' do
         account.switch!
-        expect(account.tenant_settings_filename('test')).to eq Rails.root.join('config', 'settings', 'test-TEST.yml')
+        expect(Settings.tenant_settings_filename('test')).to eq Rails.root.join('config', 'settings', 'test-TEST.yml')
       end
     end
 


### PR DESCRIPTION
This is a bit more complicated due to the fact that the config gem
removes and sets the Settings constant when reloading from files. This
isn't thread safe as all threads share the same constant. I was also
seeing one thread trying to access Settings when another had just
removed it leading to NameErrors.

My approach to dealing with this is to remove the Settings constant in
an initializer then access the configuration through a Settings
singleton. The Settings class delegates all calls to configuration
stored in the current thread which is created avoiding setting the
Settings constant.

Duplicate of work done in https://github.com/samvera/hyku/pull/1713 so
this can be removed once that PR has been merged and we've updated to
use that version of hyku.