### PR TITLE
Monkey-patch hydra-derivatives to fix pdf thumbnail generation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -147,3 +147,8 @@ RSpec/LetSetup:
 Performance/RedundantSortBy:
   Exclude:
     - 'app/renderers/hyrax/renderers/work_metadata_diff_renderer.rb'
+
+Naming/FileName:
+  Exclude:
+    - 'config/initializers/hydra-derivatives.rb'
+    - 'Gemfile'

--- a/config/initializers/hydra-derivatives.rb
+++ b/config/initializers/hydra-derivatives.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+# Monkey-patch hydra-derivatives until we're able to upgrade
+Hydra::Derivatives::Processors::Image.class_eval do
+  def create_resized_image
+    create_image do |xfrm|
+      if size
+        xfrm.combine_options do |i|
+          i.flatten
+          i.resize(size)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This can be removed when https://github.com/samvera/hydra-derivatives/pull/227 has been merged
and released in a hyrax we can use.