### PR TITLE
Speedup builds by running rspec in parallel

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
       ruby_version: << parameters.ruby_version >>
 
+    parallelism: 4
+
     environment:
       RAILS_VERSION: << parameters.rails_version >>
       DATABASE_NAME: circle_test


### PR DESCRIPTION
Note that this uses up all of our available concurrent containers so
other builds will block while one is running.  We can dial this back if
we find it is too much of a bottleneck.