### PR TITLE
REPO-1104: Fixed the bug of clearing the notes while updating blank n…

### DIFF
--- a/app/actors/hyku_addons/actors/note_field_actor.rb
+++ b/app/actors/hyku_addons/actors/note_field_actor.rb
@@ -24,7 +24,7 @@ module HykuAddons
                 Array(process_note_hash(env.attributes[:note]).to_json)
               end
           else
-            env.attributes[:note] = []
+            env.attributes[:note] = env.curation_concern.note
           end
         end
 

--- a/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
@@ -69,5 +69,25 @@ RSpec.describe HykuAddons::Actors::NoteFieldActor do
         expect(note_content_ary).to include(attributes[:note])
       end
     end
+    context "when the note attribute is not present" do
+      before do
+        allow(terminator).to receive(:update).with(env)
+      end
+
+      let(:attributes) { { note: [] } }
+
+      it "retains the previous note if note attributes are not present " do
+        expect(work.note).to be_present
+        expect(work.note.count).to eq(1)
+
+        middleware.update(env)
+
+        expect(work.note.count).to eq(1)
+        note_content_ary = work.note.map do |note|
+          JSON.parse(note)["note"]
+        end
+        expect(note_content_ary).to include('first note')
+      end
+    end
   end
 end


### PR DESCRIPTION
As part of the Addition of the note tab in the deposit form, we had a bug. For a work with existing notes, if we try adding blank notes to the form. It will remove the existing notes.