### PR TITLE
Hotfix/on edit grouped require issue redux

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,7 +68,7 @@ PATH
   specs:
     hyku_addons (0.1.0)
       blacklight_oai_provider (~> 6.1)
-      bolognese (~> 1.9.7)
+      bolognese (~> 1.9, >= 1.9.7)
       config (>= 3.0)
       google-cloud-pubsub (~> 2.6.1)
       google-cloud-storage (~> 1.31)

--- a/app/assets/javascripts/hyku_addons/change_toggleable_listener.js
+++ b/app/assets/javascripts/hyku_addons/change_toggleable_listener.js
@@ -29,7 +29,7 @@ class ChangeToggleableListener {
 
   onLoad(){
     // Can't seen to get this to work via triggering the change event
-    $(this.controlSelector).each($.proxy(function(i, el){
+    $(this.controlSelector).each($.proxy(function(_i, el){
       this.toggleSelectGroup($(el))
     }, this))
   }
@@ -54,7 +54,7 @@ class ChangeToggleableListener {
     let afterHiddenEventName = target.attr(this.afterHiddenAttributeName)
 
     // Hide all elements and unset required attributes by default
-    parent.find(this.groupSelector).not(selectedElement).each($.proxy(function(i, group){
+    parent.find(this.groupSelector).not(selectedElement).each($.proxy(function(_i, group){
       $(group).hide()
       this.toggleRequiredChildren($(group), "unset_required")
 

--- a/app/assets/javascripts/hyku_addons/eventable.js
+++ b/app/assets/javascripts/hyku_addons/eventable.js
@@ -22,7 +22,7 @@ class Eventable {
       $("body").trigger(eventName, [$(this)])
     })
 
-    $("body").on("blur", "[data-on-blur]", function(event){
+    $("body").on("blur", "[data-on-blur]", function(_event){
       let eventName = $(this).data("on-blur")
       $("body").trigger(eventName, [$(this)])
     })

--- a/app/assets/javascripts/hyku_addons/required_field_listener.js
+++ b/app/assets/javascripts/hyku_addons/required_field_listener.js
@@ -16,12 +16,12 @@ class RequiredFieldListener {
     $("body").on(this.unsetEventName, this.onUnsetEvent.bind(this))
   }
 
-  onSetEvent(event, target){
+  onSetEvent(_event, target){
     this.toggleRequired($(target), true)
     this.addRequiredLabel($(target))
   }
 
-  onUnsetEvent(event, target){
+  onUnsetEvent(_event, target){
     this.toggleRequired($(target), false)
     this.removeRequiredLabel($(target))
   }

--- a/app/assets/javascripts/hyku_addons/required_group_field_listener.js
+++ b/app/assets/javascripts/hyku_addons/required_group_field_listener.js
@@ -22,11 +22,12 @@ class RequiredGroupFieldListener {
     $(`[${this.groupAttributeName}]`).trigger("blur")
   }
 
-  onEvent(event, target){
+  onEvent(_event, target){
     let group = $(`[${this.groupAttributeName}=${target.attr(this.groupAttributeName)}]`)
 
-    group.not(target).each($.proxy(function(i, el){
-      let eventName = $(target).val().length ? "unset_required" : "set_required"
+    group.not(target).each($.proxy(function(_i, el){
+      // If the element is hidden, we need to unset required or the form will break
+      let eventName = $(target).val().length || $(target).is(":hidden") ? "unset_required" : "set_required"
 
       $("body").trigger(eventName, [el])
     }))

--- a/app/assets/javascripts/hyku_addons/required_group_field_listener.js
+++ b/app/assets/javascripts/hyku_addons/required_group_field_listener.js
@@ -13,21 +13,15 @@ class RequiredGroupFieldListener {
 
   registerListeners(){
     $("body").on(this.eventName, this.onEvent.bind(this))
-
-    // When the page events have finished being registered, listen and perform an after action
-    $("body").on("after-register-events", this.afterRegisterEvents.bind(this))
   }
 
-  afterRegisterEvents(){
-    $(`[${this.groupAttributeName}]`).trigger("blur")
-  }
-
+  // This event callback looks at individual required groups, if one item has been updated,
+  // then the other can have its required tag removed.
   onEvent(_event, target){
     let group = $(`[${this.groupAttributeName}=${target.attr(this.groupAttributeName)}]`)
 
     group.not(target).each($.proxy(function(_i, el){
-      // If the element is hidden, we need to unset required or the form will break
-      let eventName = $(target).val().length || $(target).is(":hidden") ? "unset_required" : "set_required"
+      let eventName = $(target).val().length ? "unset_required" : "set_required"
 
       $("body").trigger(eventName, [el])
     }))


### PR DESCRIPTION
When editing an existing work (on any work type), removing a legacy multiple field would trigger the form validate and find hidden required fields on the "required_group" inputs. 

The after register hook, wa running `on-blur`, which seemed to be reading required attributes, even if the group was hidden. I can't see any noticeable issue caused by removing this additional action and there is nothing from the original commit that might lead me to understand why I added it and what issue it originally solved. 