### PR TITLE
Add highlight colour to enabled features

### DIFF
--- a/app/assets/stylesheets/hyku_addons/dashboard.scss
+++ b/app/assets/stylesheets/hyku_addons/dashboard.scss
@@ -1,0 +1,4 @@
+.badge, td.status span.enabled {
+  background-color: #286090;
+  padding: 4px 7px 3px;
+}


### PR DESCRIPTION
This has been bugging me for a while; add a highlight colour to the enabled features. 

![image](https://user-images.githubusercontent.com/1199977/121156825-f5aab680-c840-11eb-93ad-90237387c588.png)
