### PR TITLE
Adds Singular add info to all worktype models

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -6,6 +6,7 @@ class Article < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   self.indexer = HykuAddons::ArticleIndexer
 

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -6,6 +6,7 @@ class Book < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
     index.as :stored_searchable, :facetable

--- a/app/models/book_contribution.rb
+++ b/app/models/book_contribution.rb
@@ -7,7 +7,7 @@ class BookContribution < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/book_contribution.rb
+++ b/app/models/book_contribution.rb
@@ -6,6 +6,8 @@ class BookContribution < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/concerns/hyku_addons/add_info_singular.rb
+++ b/app/models/concerns/hyku_addons/add_info_singular.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module AddInfoSingular
+    extend ActiveSupport::Concern
+
+    included do
+      property :add_info, predicate: ::RDF::Vocab::BIBO.term(:Note), multiple: false do |index|
+        index.as :stored_searchable
+      end
+    end
+  end
+end

--- a/app/models/concerns/hyku_addons/work_base.rb
+++ b/app/models/concerns/hyku_addons/work_base.rb
@@ -30,10 +30,6 @@ module HykuAddons
         index.as :stored_searchable
       end
 
-      property :add_info, predicate: ::RDF::Vocab::BIBO.term(:Note), multiple: false do |index|
-        index.as :stored_searchable
-      end
-
       # FIXME: Dates should be indexed as dates or at least _ssim not _tesim
       property :date_published, predicate: ::RDF::Vocab::DC.available, multiple: false do |index|
         index.as :stored_searchable

--- a/app/models/conference_item.rb
+++ b/app/models/conference_item.rb
@@ -6,6 +6,7 @@ class ConferenceItem < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
     index.as :stored_searchable, :facetable

--- a/app/models/dataset.rb
+++ b/app/models/dataset.rb
@@ -6,6 +6,7 @@ class Dataset < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :version, predicate: ::RDF::Vocab::SCHEMA.version do |index|
     index.as :stored_searchable

--- a/app/models/exhibition_item.rb
+++ b/app/models/exhibition_item.rb
@@ -6,6 +6,8 @@ class ExhibitionItem < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/exhibition_item.rb
+++ b/app/models/exhibition_item.rb
@@ -7,7 +7,7 @@ class ExhibitionItem < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :series_name, predicate: ::RDF::Vocab::BF2.subseriesOf do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/pacific_article.rb
+++ b/app/models/pacific_article.rb
@@ -9,6 +9,8 @@ class PacificArticle < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :journal_title, predicate: ::RDF::Vocab::BIBO.Journal, multiple: false do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/pacific_article.rb
+++ b/app/models/pacific_article.rb
@@ -10,7 +10,7 @@ class PacificArticle < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :journal_title, predicate: ::RDF::Vocab::BIBO.Journal, multiple: false do |index|
     index.as :stored_searchable, :facetable
   end

--- a/app/models/pacific_book.rb
+++ b/app/models/pacific_book.rb
@@ -6,6 +6,7 @@ class PacificBook < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
     index.as :stored_searchable

--- a/app/models/pacific_book_chapter.rb
+++ b/app/models/pacific_book_chapter.rb
@@ -9,6 +9,7 @@ class PacificBookChapter < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :book_title, predicate: ::RDF::Vocab::BIBO.term(:Proceedings), multiple: false do |index|
     index.as :stored_searchable, :facetable

--- a/app/models/pacific_image.rb
+++ b/app/models/pacific_image.rb
@@ -10,6 +10,7 @@ class PacificImage < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :additional_links, predicate: ::RDF::Vocab::SCHEMA.significantLinks, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/pacific_media.rb
+++ b/app/models/pacific_media.rb
@@ -9,6 +9,8 @@ class PacificMedia < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :additional_links, predicate: ::RDF::Vocab::SCHEMA.significantLinks, multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_media.rb
+++ b/app/models/pacific_media.rb
@@ -10,7 +10,7 @@ class PacificMedia < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :additional_links, predicate: ::RDF::Vocab::SCHEMA.significantLinks, multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_news_clipping.rb
+++ b/app/models/pacific_news_clipping.rb
@@ -10,7 +10,7 @@ class PacificNewsClipping < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :reading_level, predicate: ::RDF::Vocab::SCHEMA.proficiencyLevel, multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_news_clipping.rb
+++ b/app/models/pacific_news_clipping.rb
@@ -9,6 +9,8 @@ class PacificNewsClipping < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :reading_level, predicate: ::RDF::Vocab::SCHEMA.proficiencyLevel, multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_presentation.rb
+++ b/app/models/pacific_presentation.rb
@@ -10,7 +10,7 @@ class PacificPresentation < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_presentation.rb
+++ b/app/models/pacific_presentation.rb
@@ -9,6 +9,8 @@ class PacificPresentation < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_text_work.rb
+++ b/app/models/pacific_text_work.rb
@@ -9,6 +9,7 @@ class PacificTextWork < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :volume, predicate: ::RDF::Vocab::BIBO.volume do |index|
     index.as :stored_searchable

--- a/app/models/pacific_thesis_or_dissertation.rb
+++ b/app/models/pacific_thesis_or_dissertation.rb
@@ -9,6 +9,7 @@ class PacificThesisOrDissertation < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :pagination, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/pacific_uncategorized.rb
+++ b/app/models/pacific_uncategorized.rb
@@ -10,7 +10,7 @@ class PacificUncategorized < ActiveFedora::Base
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
   include ::HykuAddons::AddInfoSingular
-  
+
   property :additional_links, predicate: ::RDF::Vocab::SCHEMA.significantLinks, multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/pacific_uncategorized.rb
+++ b/app/models/pacific_uncategorized.rb
@@ -9,6 +9,8 @@ class PacificUncategorized < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
+  
   property :additional_links, predicate: ::RDF::Vocab::SCHEMA.significantLinks, multiple: false do |index|
     index.as :stored_searchable
   end

--- a/app/models/redlands_article.rb
+++ b/app/models/redlands_article.rb
@@ -8,6 +8,7 @@ class RedlandsArticle < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/redlands_book.rb
+++ b/app/models/redlands_book.rb
@@ -9,6 +9,7 @@ class RedlandsBook < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/redlands_chapters_and_book_section.rb
+++ b/app/models/redlands_chapters_and_book_section.rb
@@ -8,6 +8,7 @@ class RedlandsChaptersAndBookSection < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/redlands_conferences_reports_and_paper.rb
+++ b/app/models/redlands_conferences_reports_and_paper.rb
@@ -8,6 +8,7 @@ class RedlandsConferencesReportsAndPaper < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/redlands_media.rb
+++ b/app/models/redlands_media.rb
@@ -8,6 +8,7 @@ class RedlandsMedia < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/redlands_open_educational_resource.rb
+++ b/app/models/redlands_open_educational_resource.rb
@@ -8,6 +8,7 @@ class RedlandsOpenEducationalResource < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/redlands_student_work.rb
+++ b/app/models/redlands_student_work.rb
@@ -8,6 +8,7 @@ class RedlandsStudentWork < ActiveFedora::Base
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   property :alt_title, predicate: ::RDF::Vocab::DC.alternative, multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -6,9 +6,7 @@ class Report < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
-
-  self.indexer = ReportIndexer
-  validates :title, presence: { message: 'Your work must have a title.' }
+  include ::HykuAddons::AddInfoSingular
 
   property :pagination, predicate: ::RDF::Vocab::BIBO.numPages, multiple: false do |index|
     index.as :stored_searchable
@@ -51,6 +49,9 @@ class Report < ActiveFedora::Base
   end
 
   self.json_fields += %i[editor]
+  
+  self.indexer = ReportIndexer
+  validates :title, presence: { message: 'Your work must have a title.' }
 
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -49,7 +49,7 @@ class Report < ActiveFedora::Base
   end
 
   self.json_fields += %i[editor]
-  
+
   self.indexer = ReportIndexer
   validates :title, presence: { message: 'Your work must have a title.' }
 

--- a/app/models/thesis_or_dissertation.rb
+++ b/app/models/thesis_or_dissertation.rb
@@ -6,6 +6,7 @@ class ThesisOrDissertation < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   self.indexer = ThesisOrDissertationIndexer
 

--- a/app/models/time_based_media.rb
+++ b/app/models/time_based_media.rb
@@ -7,6 +7,7 @@ class TimeBasedMedia < ActiveFedora::Base
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
   include ::HykuAddons::AltTitleMultiple
+  include ::HykuAddons::AddInfoSingular
 
   property :media, predicate: ::RDF::Vocab::MODS.physicalForm do |index|
     index.as :stored_searchable

--- a/app/models/uva_work.rb
+++ b/app/models/uva_work.rb
@@ -6,6 +6,7 @@ class UvaWork < ActiveFedora::Base
   include Hyrax::DOI::DOIBehavior
   include Hyrax::DOI::DataCiteDOIBehavior
   include ::HykuAddons::WorkBase
+  include ::HykuAddons::AddInfoSingular
 
   self.indexer = UvaWorkIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/views/anschutz_works/edit_fields/_add_info.html.erb
+++ b/app/views/anschutz_works/edit_fields/_add_info.html.erb
@@ -1,1 +1,1 @@
-<%= f.input :add_info, as: :text, input_html: { rows: 7, cols: 80 }, required: f.object.required?(key) %>
+<%= f.input :add_info, as: :multi_value, input_html: { rows: 7, cols: 80, type: 'textarea' }, required: f.object.required?(key) %>


### PR DESCRIPTION
Anschutz wants add_info to be multiple so I am extracting add info out of `WorkBase` and into its own concern. This stops the redefinition of add_info for Anschutz throwning an error [https://sentry.io/organizations/ubiquity-press-ltd/issues/2468560766/](url)