### PR TITLE
REPO-1193 Per tenant smtp settings

### DIFF
--- a/app/lib/hyku_addons/per_tenant_smtp_interceptor.rb
+++ b/app/lib/hyku_addons/per_tenant_smtp_interceptor.rb
@@ -3,15 +3,12 @@
 module HykuAddons
   class PerTenantSmtpInterceptor
     def self.delivering_email(message)
-      account = Account.find_by(tenant: Apartment::Tenant.current)
-      account.switch!
+      Account.find_by(tenant: Apartment::Tenant.current)&.switch!
+      return unless (mailer_settings = Settings.action_mailer.presence)
 
-      mailer_settings = Settings.action_mailer.smtp_settings
-      return unless mailer_settings.present?
-      message.from = mailer_settings.from if mailer_settings.from
-
+      message.from = mailer_settings.from if mailer_settings.from.present?
       dynamic_settings = Settings.action_mailer.smtp_settings
-      message.delivery_method.settings.merge!(dynamic_settings) if dynamic_settings
+      message.delivery_method.settings.merge!(dynamic_settings) if dynamic_settings.present?
     end
   end
 end

--- a/app/lib/hyku_addons/per_tenant_smtp_interceptor.rb
+++ b/app/lib/hyku_addons/per_tenant_smtp_interceptor.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  class PerTenantSmtpInterceptor
+    def self.delivering_email(message)
+      account = Account.find_by(tenant: Apartment::Tenant.current)
+      account.switch!
+
+      mailer_settings = Settings.action_mailer.smtp_settings
+      return unless mailer_settings.present?
+      message.from = mailer_settings.from if mailer_settings.from
+
+      dynamic_settings = Settings.action_mailer.smtp_settings
+      message.delivery_method.settings.merge!(dynamic_settings) if dynamic_settings
+    end
+  end
+end

--- a/config/initializers/mailer_interceptors.rb
+++ b/config/initializers/mailer_interceptors.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+ActionMailer::Base.register_interceptor "HykuAddons::PerTenantSmtpInterceptor"

--- a/spec/fixtures/settings/test-TEST.yml
+++ b/spec/fixtures/settings/test-TEST.yml
@@ -1,1 +1,8 @@
 google_analytics_id: 'yml-id'
+action_mailer:
+  from: 'test@test.edu'
+  smtp_settings:
+    address: 'test.edu'
+    user_name: username
+    password: password
+    domain: 'test.custom_domain.com'

--- a/spec/mailers/per_tenant_smtp_mailers.rb
+++ b/spec/mailers/per_tenant_smtp_mailers.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Hyrax::ContactMailer, type: :feature do
+  let(:contact_form) do
+    Hyrax::ContactForm.new(
+      email: 'test@example.com',
+      category: 'Test',
+      subject: 'Test',
+      name: 'Test Tester',
+      message: 'This is a test'
+    )
+  end
+
+  describe "reset_password_instructions" do
+    context "with per tenant SMTP" do
+      let!(:account) { Account.create(name: 'test', tenant: 'test', cname: 'test.lvh.me') }
+      let(:mail) { described_class.contact(contact_form) }
+
+      before do
+        allow(Settings).to receive(:tenant_settings_filename).with('test').and_return(HykuAddons::Engine.root.join('spec', 'fixtures', 'settings', 'test-TEST.yml'))
+        account.switch!
+      end
+
+      it "renders the body" do
+        expect(mail.from).to eq "test@test.edu"
+      end
+    end
+  end
+end

--- a/spec/mailers/per_tenant_smtp_mailers.rb
+++ b/spec/mailers/per_tenant_smtp_mailers.rb
@@ -12,19 +12,27 @@ RSpec.describe Hyrax::ContactMailer, type: :feature do
       message: 'This is a test'
     )
   end
+  let(:mail_from) { "test@test.edu" }
 
   describe "reset_password_instructions" do
     context "with per tenant SMTP" do
-      let!(:account) { Account.create(name: 'test', tenant: 'test', cname: 'test.lvh.me') }
+      let!(:account) { Account.create(name: 'test', tenant: 'test', cname: 'test.lvh.me', locale_name: 'test') }
       let(:mail) { described_class.contact(contact_form) }
 
       before do
         allow(Settings).to receive(:tenant_settings_filename).with('test').and_return(HykuAddons::Engine.root.join('spec', 'fixtures', 'settings', 'test-TEST.yml'))
         account.switch!
+        allow(Site).to receive(:contact_email).and_return('me@example.com')
+        mail.deliver
       end
 
-      it "renders the body" do
-        expect(mail.from).to eq "test@test.edu"
+      it "replaces the email headers" do
+        expect(mail.from).to eq ["test@test.edu"]
+        settings = mail.delivery_method.settings
+        expect(settings[:address]).to eq "test.edu"
+        expect(settings[:user_name]).to eq "username"
+        expect(settings[:password]).to eq "password"
+        expect(settings[:domain]).to eq "test.custom_domain.com"
       end
     end
   end


### PR DESCRIPTION
Allows setting SMTP configurations per-tenant. Uses the Settings API to overwrite Rails' ActionMailer config in a per message way, instead of overwriting the full configuration of ActionMailer to avoid changing the mailer config of other tenants.