### PR TITLE
Hyku Addons changes to Hyrax-DOI

### DIFF
--- a/app/controllers/concerns/hyku_addons/doi_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/doi_controller_behavior.rb
@@ -39,7 +39,7 @@ module HykuAddons
       end
 
       def raw_response
-        response = Bolognese::Metadata.new(input: doi)
+        response = ::Bolognese::Metadata.new(input: doi)
 
         return response if response.string.present? && response.meta.present?
 

--- a/app/services/bolognese/readers/base_work_reader.rb
+++ b/app/services/bolognese/readers/base_work_reader.rb
@@ -92,8 +92,6 @@ module Bolognese
           get_authors(value)
         end
 
-      protected
-
         def read_title
           meta_value("title").collect { |r| { "title" => sanitize(r) } }
         end

--- a/app/services/bolognese/readers/base_work_reader.rb
+++ b/app/services/bolognese/readers/base_work_reader.rb
@@ -10,7 +10,7 @@ module Bolognese
   module Readers
     class BaseWorkReader < Bolognese::Metadata
       include HykuAddons::WorkFormNameable
-      include ::HykuAddons::Bolognese::JsonFieldReaders
+      include ::HykuAddons::Bolognese::JsonFieldsReader
 
       DEFAULT_RESOURCE_TYPE = "Work"
       DEFAULT_META_MODEL = "GenericWork"
@@ -84,7 +84,8 @@ module Bolognese
           get_authors(value)
         end
 
-        # For now editor is treated differently to creator/contributor
+        # For now editor is treated differently to creator/contributor because we don't have a specific example
+        # where this should be adjusted. This will likely change as a client provides a useful example.
         def read_editor
           return unless (value = @meta.fetch("editor_display", @meta.dig("editor"))).present?
 

--- a/app/services/bolognese/writers/hyrax_work_writer_behavior.rb
+++ b/app/services/bolognese/writers/hyrax_work_writer_behavior.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Override a the creator/contributor methods which would otherwise
+# return JSON to datacite when a DOI is minted.
+module Bolognese
+  module Writers
+    module HyraxWorkWriterBehavior
+      def creators
+        @_creators ||= get_authors(pluralize_and_process(:creator))
+      end
+
+      def contributors
+        @_contributors ||= get_authors(pluralize_and_process(:contributor))
+      end
+
+      protected
+
+        # Hyrax uses `creators` but hyku addons uses `creator` - probably not updated after v1.0,
+        # so because we are getting the value from Bolognese, we need to translate
+        # it, then tell the bologneseify_author_json method to remove `creator_`
+        # from the json keys, and pass it back to bolognese in order to finalize
+        def pluralize_and_process(type)
+          # Get the v2.0 pluralized `creators` and extract the hyku_addon json string.
+          # The meta value for the type key, could be nil, not set, or an array of hashes
+          data = (meta[type.to_s.pluralize] || [{}]).first.dig("name")
+
+          return if data.blank?
+
+          # Ensure we have the singularized `creator` string being used here as we are now processing hyku_addon data
+          bologneseify_author_json(type.to_s.singularize, data)
+        end
+    end
+  end
+end

--- a/app/services/hyku_addons/bolognese/json_field_readers.rb
+++ b/app/services/hyku_addons/bolognese/json_field_readers.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module Bolognese
+    module JsonFieldReaders
+      extend ActiveSupport::Concern
+
+      # Prepare the json to be parsed through Bolognese get_authors method
+      # Bologese wants a hash with `givenName` not `creator_given_name` etc
+      #
+      # NOTE: The downcase is to counteract Bolognese titleizing the values
+      def bologneseify_author_json(type, json)
+        obj = JSON.parse(json)
+        transformed = Array.wrap(obj).map { |cr| cr.transform_keys { |k| k.downcase.gsub(/#{type}_/, "") }.deep_transform_keys { |k| k.camelize(:lower) } }
+
+        transformed.each do |t|
+          next unless t["orcid"].present?
+
+          t["nameIdentifier"] = {
+            "nameIdentifierScheme" => "orcid",
+            "__content__" => t["orcid"].downcase
+          }
+        end
+
+        transformed.compact
+
+      rescue JSON::ParserError
+        json
+      end
+    end
+  end
+end

--- a/app/services/hyku_addons/bolognese/json_fields_reader.rb
+++ b/app/services/hyku_addons/bolognese/json_fields_reader.rb
@@ -2,7 +2,7 @@
 
 module HykuAddons
   module Bolognese
-    module JsonFieldReaders
+    module JsonFieldsReader
       extend ActiveSupport::Concern
 
       # Prepare the json to be parsed through Bolognese get_authors method

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -532,7 +532,7 @@ module HykuAddons
       Hyrax::DOI::HyraxDOIController.include HykuAddons::DOIControllerBehavior
 
       Bolognese::Metadata.prepend Bolognese::Writers::HyraxWorkWriterBehavior
-      Bolognese::Metadata.include HykuAddons::Bolognese::JsonFieldReaders
+      Bolognese::Metadata.include HykuAddons::Bolognese::JsonFieldsReader
 
       ::ApplicationController.include HykuAddons::MultitenantLocaleControllerBehavior
       ::Hyku::API::V1::FilesController.include HykuAddons::FilesControllerBehavior

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -528,7 +528,12 @@ module HykuAddons
       Bolognese::Writers::RisWriter.include Bolognese::Writers::RisWriterBehavior
       Bolognese::Metadata.prepend Bolognese::Writers::HykuAddonsWorkFormFieldsWriter
       Hyrax::GenericWorksController.include HykuAddons::WorksControllerBehavior
+
       Hyrax::DOI::HyraxDOIController.include HykuAddons::DOIControllerBehavior
+
+      Bolognese::Metadata.prepend Bolognese::Writers::HyraxWorkWriterBehavior
+      Bolognese::Metadata.include HykuAddons::Bolognese::JsonFieldReaders
+
       ::ApplicationController.include HykuAddons::MultitenantLocaleControllerBehavior
       ::Hyku::API::V1::FilesController.include HykuAddons::FilesControllerBehavior
       ::Hyku::API::V1::HighlightsController.class_eval do

--- a/spec/features/doi_autofill_spec.rb
+++ b/spec/features/doi_autofill_spec.rb
@@ -30,19 +30,22 @@ RSpec.describe 'autofilling the form from DOI', js: true do
       click_on 'Additional fields'
 
       # expect form fields have been filled in
-      expect(page).to have_field("#{work_type}_title", with: 'Eating your own Dog Food')
-      expect(page).to have_field("#{work_type}_creator__creator_family_name", with: 'Fenner')
-      expect(page).to have_field("#{work_type}_creator__creator_given_name", with: 'Martin')
+      expect(page).to have_content("The following fields were auto-populated", wait: 30)
+      expect(page).to have_field("#{work_type}_title", with: 'Eating your own Dog Food', wait: 30)
+      expect(page).to have_field("#{work_type}_creator__creator_family_name", with: 'Fenner', wait: 30)
+      expect(page).to have_field("#{work_type}_creator__creator_given_name", with: 'Martin', wait: 30)
       expect(page).to have_field("#{work_type}_abstract", with: 'Eating your own dog food is a slang term to describe that an organization '\
                                                                 'should itself use the products and services it provides. For DataCite this '\
                                                                 'means that we should use DOIs with appropriate metadata and strategies for '\
-                                                                'long-term preservation for...')
-      expect(page).to have_field("#{work_type}_keyword", with: 'datacite')
-      expect(page).to have_field("#{work_type}_keyword", with: 'doi')
-      expect(page).to have_field("#{work_type}_keyword", with: 'metadata')
-      expect(page).to have_field("#{work_type}_publisher", with: 'DataCite')
-      expect(page).to have_field("#{work_type}_date_created", with: '2016')
-      expect(page).to have_field("#{work_type}_identifier", with: 'MS-49-3632-5083')
+                                                                'long-term preservation for...', wait: 30)
+      expect(page).to have_field("#{work_type}_keyword", with: 'datacite', wait: 30)
+      expect(page).to have_field("#{work_type}_keyword", with: 'doi', wait: 30)
+      expect(page).to have_field("#{work_type}_keyword", with: 'metadata', wait: 30)
+      expect(page).to have_field("#{work_type}_publisher", with: 'DataCite', wait: 30)
+
+      # We don't use these fields
+      # expect(page).to have_field("#{work_type}_date_created", with: '2016', wait: 30)
+      # expect(page).to have_field("#{work_type}_identifier", with: 'MS-49-3632-5083', wait: 30)
 
       # expect page to have forwarded to metadata tab
       # expect(URI.parse(page.current_url).fragment).to eq 'metadata'

--- a/spec/services/bolognese/readers/generic_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/generic_work_reader_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
     {
       creator_name_type: "Personal",
       creator_given_name: creator2_first_name,
-      creator_family_name: creator2_last_name,
+      creator_family_name: creator2_last_name
     }
   end
   let(:date_accepted) { "2018-01-02" }

--- a/spec/services/bolognese/readers/generic_work_reader_spec.rb
+++ b/spec/services/bolognese/readers/generic_work_reader_spec.rb
@@ -13,22 +13,20 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
   let(:creator1_last_name) { "Hageneuer" }
   let(:creator2_first_name) { "Johnny" }
   let(:creator2_last_name) { "Testing" }
+  let(:creator1_orcid) { "https://sandbox.orcid.org/0000-0003-0652-4625" }
   let(:creator1) do
     {
-      "nameType" => "Personal",
-      "name" => "#{creator1_last_name}, #{creator1_first_name}",
-      "givenName" => creator1_first_name,
-      "familyName" => creator1_last_name
+      creator_name_type: "Personal",
+      creator_given_name: creator1_first_name,
+      creator_family_name: creator1_last_name,
+      creator_orcid: creator1_orcid
     }
   end
   let(:creator2) do
     {
-      "name" => "#{creator2_last_name}, #{creator2_first_name}",
-      "givenName" => creator2_first_name,
-      "familyName" => creator2_last_name,
-      "nameIdentifiers" => [
-        { "nameIdentifier" => "12345678890", "nameIdentifierScheme" => "orcid" }
-      ]
+      creator_name_type: "Personal",
+      creator_given_name: creator2_first_name,
+      creator_family_name: creator2_last_name,
     }
   end
   let(:date_accepted) { "2018-01-02" }
@@ -76,7 +74,7 @@ RSpec.describe Bolognese::Readers::GenericWorkReader do
       title: [title],
       alt_title: [alt_title1],
       resource_type: [resource_type],
-      creator: [creator1.to_json],
+      creator: [[creator1].to_json],
       contributor: [contributor],
       publisher: [publisher],
       abstract: abstract,

--- a/spec/services/hyku_addons/i18n_multitenant_spec.rb
+++ b/spec/services/hyku_addons/i18n_multitenant_spec.rb
@@ -12,11 +12,7 @@ RSpec.describe HykuAddons::I18nMultitenant do
 
   describe ".set" do
     it "changes the locale" do
-      expect(I18n.locale).to eq(:en)
-
-      described_class.set(options)
-
-      expect(I18n.locale).to eq(:"en-TEST")
+      expect { described_class.set(options) }.to change { I18n.locale }.from(:en).to(:"en-TEST")
     end
   end
 


### PR DESCRIPTION
# Issues

1. initially my first work gave an error but that did not happen with my second work
2. if editing a work that was initially saved without DOI minting selected, and then selecting DOI minting options and saving, this does not mint a DOI (it should).
3. the JSON fields are not being translated to DataCite's format - esp Creator - so DataCite has something like this, which is wrong:

# Conclusions

1. Seems to be a configuration issues as its not replicatable.  
2. Outstanding
3. By overriding the Bolognese writer methods for creator/contrbutor, we need to be sending the correct data. 