### PR TITLE
Fix facet configuration

### DIFF
--- a/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
@@ -15,8 +15,8 @@ module HykuAddons
         config.add_facet_field solr_name('member_of_collections', :symbol), limit: 5, label: 'Collections'
         config.add_facet_field solr_name("institution", :facetable), limit: 5, label: 'Institution'
         config.add_facet_field solr_name("language", :facetable), limit: 5, label: 'Language'
-        config.add_facet_field solr_name("org_unit_sim", :facetable), limit: 5, label: 'Department'
-        config.add_facet_field solr_name("audience_sim", :facetable), limit: 5, label: 'OER Audience', if: proc { |context, _config, _opts| context.current_account&.settings&.dig("locale_name") == "redlands" }
+        config.add_facet_field solr_name("org_unit", :facetable), limit: 5, label: 'Department'
+        config.add_facet_field solr_name("audience", :facetable), limit: 5, label: 'OER Audience', if: proc { |context, _config, _opts| context.current_account&.settings&.dig("locale_name") == "redlands" }
         config.add_facet_field 'file_availability', query: {
           # TODO: use i18n
           available: { label: 'File available from this repository', fq: 'generic_type_sim:Work AND ({!join from=id to=file_set_ids_ssim}visibility_ssi:open)' },


### PR DESCRIPTION
`solr_name` will append `_sim` so there isn't any need to add it to the original string (or else it ends as `org_unit_sim_sim`.