### PR TITLE
AccountBehavior being dropped from engine

### DIFF
--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -39,6 +39,40 @@ module HykuAddons
       def self.private_settings
         PRIVATE_SETTINGS
       end
+
+      # @return [Account] a placeholder account using the default connections configured by the application
+      def self.single_tenant_default
+        Account.new do |a|
+          a.build_solr_endpoint
+          a.build_fcrepo_endpoint
+          a.build_redis_endpoint
+          a.build_datacite_endpoint
+        end
+      end
+
+      # Make all the account specific connections active
+      def switch!
+        solr_endpoint.switch!
+        fcrepo_endpoint.switch!
+        redis_endpoint.switch!
+        datacite_endpoint.switch!
+        Settings.switch!(name: locale_name, settings: settings)
+        switch_host!(cname)
+      end
+
+      def reset!
+        SolrEndpoint.reset!
+        FcrepoEndpoint.reset!
+        RedisEndpoint.reset!
+        DataCiteEndpoint.reset!
+        Settings.switch!
+        switch_host!(nil)
+      end
+
+      def switch_host!(cname)
+        Rails.application.routes.default_url_options[:host] = cname
+        Hyrax::Engine.routes.default_url_options[:host] = cname
+      end
     end
 
     def datacite_endpoint

--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -13,6 +13,7 @@ module HykuAddons
 
     PRIVATE_SETTINGS = %w[smtp_settings].freeze
 
+    # rubocop:disable Metrics/BlockLength
     included do
       belongs_to :datacite_endpoint, dependent: :delete
       has_many :children, class_name: "Account", foreign_key: "parent_id", dependent: :destroy, inverse_of: :parent
@@ -74,6 +75,7 @@ module HykuAddons
         Hyrax::Engine.routes.default_url_options[:host] = cname
       end
     end
+    # rubocop:enable Metrics/BlockLength
 
     def datacite_endpoint
       super || NilDataCiteEndpoint.new

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -1,6 +1,15 @@
 # frozen_string_literal: true
 
 RSpec.describe Account, type: :model do
+  describe "The injected methods" do
+    subject(:account) { described_class.create(name: 'example', tenant: 'example', cname: 'example.com') }
+
+    it { described_class.respond_to?(:single_tenant_default) }
+    it { account.respond_to?(:switch!) }
+    it { account.respond_to?(:switch_host!) }
+    it { account.respond_to?(:reset!) }
+  end
+
   describe 'Settings' do
     let!(:account) { described_class.create(name: 'example', tenant: 'example', cname: 'example.com') }
 


### PR DESCRIPTION
AccountBehavior seems to be dropped from the engine, so thereby loses the ability to call certain functions on the Account model. 

This is possibly by I am seeing issues with Hyrax DOI update actors being called as randomly the Account will forget that it is required to call those actors. 

I am super unsure about this, but the specs all seem to pass locally. 
