### PR TITLE
REPO-1102 Redlands validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,7 @@ Metrics/ClassLength:
     - 'app/models/hyku_addons/csv_entry.rb'
     - 'app/services/bolognese/readers/base_work_reader.rb'
     - 'app/services/hyku_addons/validations/solr_entry_validation_service.rb'
+    - 'app/services/hyku_addons/validations/entry_validation_service.rb'
     - 'lib/hyku_addons/engine.rb'
 
 Metrics/LineLength:

--- a/app/helpers/bulkrax/entries_helper.rb
+++ b/app/helpers/bulkrax/entries_helper.rb
@@ -5,13 +5,13 @@ module Bulkrax
     def entry_error_coderay(v)
       if v.is_a? Hash
         change_description = "#{v[:path]}: #{v[:value]}"
-        label_klazz = case v[:op]&.to_s
+        label_klass = case v[:op]&.to_s
                       when 'add' then 'success'
                       when 'move' then 'info'
                       when 'remove' then 'danger'
                       else 'info'
                       end
-        content_tag :span, change_description, class: "label label-lg label-#{label_klazz} overflow-wrap-break"
+        content_tag :span, change_description, class: "label label-lg label-#{label_klass} overflow-wrap-break"
       else
         coderay(v, wrap: :page, css: :class, tab_width: 200, break_lines: true)
       end

--- a/app/jobs/hyku_addons/validate_csv_importer_entry_job.rb
+++ b/app/jobs/hyku_addons/validate_csv_importer_entry_job.rb
@@ -3,9 +3,9 @@
 module HykuAddons
   class ValidateCsvImporterEntryJob < ApplicationJob
     # non_tenant_job
-    def perform(account, entry, klazz = "HykuAddons::Validations::CsvEntryValidationService")
+    def perform(account, entry, klass = "HykuAddons::Validations::CsvEntryValidationService")
       AccountElevator.switch! account.cname
-      service = klazz.constantize.new(account, entry)
+      service = klass.constantize.new(account, entry)
       service.validate
     end
   end

--- a/app/jobs/hyku_addons/validate_csv_importer_entry_job.rb
+++ b/app/jobs/hyku_addons/validate_csv_importer_entry_job.rb
@@ -3,9 +3,9 @@
 module HykuAddons
   class ValidateCsvImporterEntryJob < ApplicationJob
     # non_tenant_job
-    def perform(account, entry)
+    def perform(account, entry, klazz = "HykuAddons::Validations::CsvEntryValidationService")
       AccountElevator.switch! account.cname
-      service = HykuAddons::Validations::CsvEntryValidationService.new(account, entry)
+      service = klazz.constantize.new(account, entry)
       service.validate
     end
   end

--- a/app/jobs/hyku_addons/validate_csv_importer_job.rb
+++ b/app/jobs/hyku_addons/validate_csv_importer_job.rb
@@ -3,11 +3,11 @@
 module HykuAddons
   class ValidateCsvImporterJob < ApplicationJob
     # non_tenant_job
-    def perform(account, importer, klazz)
+    def perform(account, importer, klass)
       AccountElevator.switch! account.cname
       importer.entries.each do |entry|
         next unless entry.is_a?
-        service = klazz.constantize.new(account, entry.becomes(Bulkrax::CsvEntry))
+        service = klass.constantize.new(account, entry.becomes(Bulkrax::CsvEntry))
         service.validate
       end
     end

--- a/app/jobs/hyku_addons/validate_csv_importer_job.rb
+++ b/app/jobs/hyku_addons/validate_csv_importer_job.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  class ValidateCsvImporterJob < ApplicationJob
+    # non_tenant_job
+    def perform(account, importer, klazz)
+      AccountElevator.switch! account.cname
+      importer.entries.each do |entry|
+        next unless entry.is_a?
+        service = klazz.constantize.new(account, entry.becomes(Bulkrax::CsvEntry))
+        service.validate
+      end
+    end
+  end
+end

--- a/app/models/hyku_addons/csv_entry.rb
+++ b/app/models/hyku_addons/csv_entry.rb
@@ -194,10 +194,10 @@ module HykuAddons
     end
 
     def hyrax_record
-      @hyrax_record ||= begin
-                          super
-                        rescue
-                        end || factory.find
+      begin
+        super
+      rescue
+      end || factory.find
     end
   end
 end

--- a/app/renderers/hyrax/renderers/work_metadata_diff_renderer.rb
+++ b/app/renderers/hyrax/renderers/work_metadata_diff_renderer.rb
@@ -81,7 +81,7 @@ module Hyrax
         end
 
         def diff_entry_html(diff_entry)
-          label_klazz = case diff_entry[:op]&.to_s
+          label_klass = case diff_entry[:op]&.to_s
                         when 'add'
                           'success'
                         when 'move'
@@ -90,7 +90,7 @@ module Hyrax
                           'danger'
                         else 'info'
                         end
-          @view_context.content_tag :tr, class: "bg-#{label_klazz} overflow-wrap-break" do
+          @view_context.content_tag :tr, class: "bg-#{label_klass} overflow-wrap-break" do
             diff_entry_item(diff_entry[:path], diff_entry[:source_v], diff_entry[:dest_v])
           end
         end

--- a/app/services/hyku_addons/validations/importer_validation_service.rb
+++ b/app/services/hyku_addons/validations/importer_validation_service.rb
@@ -5,10 +5,10 @@ module HykuAddons
     class ImporterValidationService
       attr_reader :errors, :entry
 
-      def initialize(account, importer, klazz)
+      def initialize(account, importer, klass)
         @account = account
         @importer = importer
-        @klazz = klazz
+        @klass = klass
         raise ArgumentError, "You must pass a valid Account" unless @account.present?
         raise ArgumentError, "You must pass a valid HykuAddons::Importer" unless @importer.present?
         raise ArgumentError, "Validation can only be made against successfully imported items" unless @importer.status == "Complete"
@@ -19,7 +19,7 @@ module HykuAddons
         @importer.entries.find_each.map do |entry|
           next unless entry.is_a?(HykuAddons::CsvEntry)
 
-          @klazz.constantize.new(@account, entry)
+          @klass.constantize.new(@account, entry)
           s.validate
           [entry.identifier, s.errors]
         end.compact.to_h

--- a/app/services/hyku_addons/validations/importer_validation_service.rb
+++ b/app/services/hyku_addons/validations/importer_validation_service.rb
@@ -5,12 +5,10 @@ module HykuAddons
     class ImporterValidationService
       attr_reader :errors, :entry
 
-      def initialize(account, importer, source_service_options = {}, destination_service_options = {})
+      def initialize(account, importer, klazz)
         @account = account
         @importer = importer
-        @source_service_options = source_service_options
-        @destination_service_options = destination_service_options
-
+        @klazz = klazz
         raise ArgumentError, "You must pass a valid Account" unless @account.present?
         raise ArgumentError, "You must pass a valid HykuAddons::Importer" unless @importer.present?
         raise ArgumentError, "Validation can only be made against successfully imported items" unless @importer.status == "Complete"
@@ -21,18 +19,11 @@ module HykuAddons
         @importer.entries.find_each.map do |entry|
           next unless entry.is_a?(HykuAddons::CsvEntry)
 
-          s = EntryValidationService.new(@account, entry, @source_service_options, @destination_service_options)
+          @klazz.constantize.new(@account, entry)
           s.validate
           [entry.identifier, s.errors]
         end.compact.to_h
       end
-
-      protected
-
-        def valid_endpoint_params?
-          mandatory_keys = %i[base_url username password]
-          @source_service_options.assert_valid_keys(mandatory_keys) && @destination_service_options.assert_valid_keys(mandatory_keys)
-        end
     end
   end
 end

--- a/app/services/hyku_addons/validations/redlands_entry_validation_service.rb
+++ b/app/services/hyku_addons/validations/redlands_entry_validation_service.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module HykuAddons
+  module Validations
+    class RedlandsEntryValidationService < CsvEntryValidationService
+
+      EXCLUDED_FIELDS = %i[
+        admin_set calc_url create_openurl csvfile ctmtime depositor document_type id
+      ].freeze
+
+      RENAMED_FIELDS = {
+        doi_tesim: 'official_link'
+      }.with_indifferent_access.freeze
+
+      EXCLUDED_FIELDS_WITH_VALUES = {
+        edit_access_group_ssim: ["admin"]
+      }.with_indifferent_access.freeze
+
+      SEPARATOR_CHAR = "|"
+    end
+  end
+end

--- a/app/services/hyku_addons/validations/redlands_entry_validation_service.rb
+++ b/app/services/hyku_addons/validations/redlands_entry_validation_service.rb
@@ -2,20 +2,19 @@
 module HykuAddons
   module Validations
     class RedlandsEntryValidationService < CsvEntryValidationService
-
-      EXCLUDED_FIELDS = %i[
+      @excluded_fields = %i[
         admin_set calc_url create_openurl csvfile ctmtime depositor document_type id
       ].freeze
 
-      RENAMED_FIELDS = {
+      @renamed_fields = {
         doi_tesim: 'official_link'
       }.with_indifferent_access.freeze
 
-      EXCLUDED_FIELDS_WITH_VALUES = {
+      @excluded_fields_with_value = {
         edit_access_group_ssim: ["admin"]
       }.with_indifferent_access.freeze
 
-      SEPARATOR_CHAR = "|"
+      @separator_char = "|"
     end
   end
 end

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -27,7 +27,6 @@ namespace :hyku do
 
       task :csv, [:tenant, :importer, :klazz] => [:environment] do |_t, args|
         account = load_account(args[:tenant])
-        debugger
         importer = Bulkrax::Importer.find(args[:importer])
 
         importer.entries.find_each.map do |entry|

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -25,13 +25,13 @@ namespace :hyku do
         end
       end
 
-      task :csv, [:tenant, :importer, :klazz] => [:environment] do |_t, args|
+      task :csv, [:tenant, :importer, :klass] => [:environment] do |_t, args|
         account = load_account(args[:tenant])
         importer = Bulkrax::Importer.find(args[:importer])
 
         importer.entries.find_each.map do |entry|
           next unless entry.is_a?(HykuAddons::CsvEntry)
-          HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry, args[:klazz])
+          HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry, args[:klass])
         end
       end
     end
@@ -55,12 +55,12 @@ namespace :hyku do
         HykuAddons::ValidateImporterEntryJob.perform_later(account, entry, source_cookie_options(args), destination_cookie_options(args))
       end
 
-      task :csv, [:tenant, :entry, :klazz] => [:environment] do |_t, args|
+      task :csv, [:tenant, :entry, :klass] => [:environment] do |_t, args|
         account = load_account(args[:tenant])
         entry = Bulkrax::Entry.find(args[:entry])
         exit(1) unless entry.is_a?(HykuAddons::CsvEntry)
 
-        HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry, args[:klazz])
+        HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry, args[:klass])
       end
     end
   end

--- a/lib/tasks/imports.rake
+++ b/lib/tasks/imports.rake
@@ -25,13 +25,14 @@ namespace :hyku do
         end
       end
 
-      task :csv, [:tenant, :importer] => [:environment] do |_t, args|
+      task :csv, [:tenant, :importer, :klazz] => [:environment] do |_t, args|
         account = load_account(args[:tenant])
+        debugger
         importer = Bulkrax::Importer.find(args[:importer])
 
         importer.entries.find_each.map do |entry|
           next unless entry.is_a?(HykuAddons::CsvEntry)
-          HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry)
+          HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry, args[:klazz])
         end
       end
     end
@@ -55,12 +56,12 @@ namespace :hyku do
         HykuAddons::ValidateImporterEntryJob.perform_later(account, entry, source_cookie_options(args), destination_cookie_options(args))
       end
 
-      task :csv, [:tenant, :entry] => [:environment] do |_t, args|
+      task :csv, [:tenant, :entry, :klazz] => [:environment] do |_t, args|
         account = load_account(args[:tenant])
         entry = Bulkrax::Entry.find(args[:entry])
         exit(1) unless entry.is_a?(HykuAddons::CsvEntry)
 
-        HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry)
+        HykuAddons::ValidateCsvImporterEntryJob.perform_later(account, entry, args[:klazz])
       end
     end
   end

--- a/spec/services/hyku_addons/validations/entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/entry_validation_service_spec.rb
@@ -187,12 +187,12 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       }
     end
     let(:excluded_fields) { [:bar] }
-    let(:excluded_fields_with_values) { { exclude: 'true', include: 'false' } }
+    let(:excluded_fields_with_value) { { exclude: 'true', include: 'false' } }
     let(:result) { service.send(:processable_fields, metadata) }
 
     before do
-      stub_const("HykuAddons::Validations::EntryValidationService::EXCLUDED_FIELDS", excluded_fields)
-      stub_const("HykuAddons::Validations::EntryValidationService::EXCLUDED_FIELDS_WITH_VALUES", excluded_fields_with_values)
+      allow(described_class).to receive(:excluded_fields).and_return(excluded_fields)
+      allow(described_class).to receive(:excluded_fields_with_value).and_return(excluded_fields_with_value)
     end
 
     it 'removes the excluded fields from the hash param based on EXCLUDED_FIELDS' do
@@ -219,7 +219,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
     let(:renamed_fields) { { foo: :fooz, bar: :barz } }
 
     before do
-      stub_const("HykuAddons::Validations::EntryValidationService::RENAMED_FIELDS", renamed_fields)
+      allow(described_class).to receive(:renamed_fields).and_return(renamed_fields)
     end
 
     it 'renames the fields using the RENAMED_FIELDS map' do

--- a/spec/services/hyku_addons/validations/redlands_csv_entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/redlands_csv_entry_validation_service_spec.rb
@@ -44,27 +44,21 @@ RSpec.describe HykuAddons::Validations::RedlandsEntryValidationService, type: :m
 
   describe 'filter_out_excluded_fields' do
     let(:metadata) do
-      {
-        foo: :bar,
-        bar: :baz,
-        empty_string: "",
-        empty_string_array: [""],
-        exclude: 'true',
-        include: 'true'
-      }
+      described_class.excluded_fields
+                     .each_with_object("")
+                     .to_h.merge(foo: :bar)
     end
-    let(:excluded_fields) { [:bar] }
     let(:excluded_fields_with_values) { { exclude: 'true', include: 'false' } }
     let(:result) { service.send(:processable_fields, metadata) }
 
-    before do
-      stub_const("HykuAddons::Validations::RedlandsEntryValidationService::EXCLUDED_FIELDS", excluded_fields)
-      stub_const("HykuAddons::Validations::RedlandsEntryValidationService::EXCLUDED_FIELDS_WITH_VALUES", excluded_fields_with_values)
+    it 'keeps attrs not listed' do
+      expect(result.keys).to include(:foo)
     end
 
-    it 'removes the excluded fields from the hash param based on EXCLUDED_FIELDS' do
-      expect(result.keys).to include(:foo)
-      expect(result.keys).not_to include(:bar)
+    described_class.excluded_fields.each do |field|
+      it "removes #{field} from the list based on EXCLUDED_FIELDS" do
+        expect(result.keys).not_to include(:bar)
+      end
     end
   end
 end

--- a/spec/services/hyku_addons/validations/redlands_csv_entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/redlands_csv_entry_validation_service_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe HykuAddons::Validations::RedlandsEntryValidationService, type: :model do
+  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: 'Complete', id: 1, identifier: '123') }
+  let(:account) { create(:account, name: 'tenant', cname: 'example.com') }
+
+  let(:service) { described_class.new(account, entry) }
+
+  describe "initialize" do
+    context "with valid params" do
+      it "returns an instance" do
+        expect(service).to be_a(described_class)
+      end
+    end
+
+    context "with no account" do
+      let(:account) { nil }
+
+      it "raise an Argument Error" do
+        expect { service }.to raise_error(ArgumentError, "You must pass a valid Account")
+      end
+    end
+  end
+
+  # rubocop:disable RSpec/EmptyExampleGroup
+  describe "validate" do
+    context "with a correctly imported CSV file" do
+      let(:user) { create(:user, email: 'test@example.com') }
+      # let! is needed below to ensure that this user is created for file attachment because this is the depositor in the CSV fixtures
+      let(:depositor) { create(:user, email: 'batchuser@example.com') }
+      let(:importer) do
+        create(:bulkrax_importer_csv,
+               user: user,
+               field_mapping: Bulkrax.field_mappings["HykuAddons::CsvParser"],
+               parser_klass: "HykuAddons::CsvParser",
+               parser_fields: { 'import_file_path' => import_batch_file },
+               limit: 0)
+      end
+      let(:import_batch_file) { 'spec/fixtures/csv/pacific_articles.metadata.csv' }
+    end
+    # rubocop:enable RSpec/EmptyExampleGroup
+  end
+
+  describe 'filter_out_excluded_fields' do
+    let(:metadata) do
+      {
+        foo: :bar,
+        bar: :baz,
+        empty_string: "",
+        empty_string_array: [""],
+        exclude: 'true',
+        include: 'true'
+      }
+    end
+    let(:excluded_fields) { [:bar] }
+    let(:excluded_fields_with_values) { { exclude: 'true', include: 'false' } }
+    let(:result) { service.send(:processable_fields, metadata) }
+
+    before do
+      stub_const("HykuAddons::Validations::RedlandsEntryValidationService::EXCLUDED_FIELDS", excluded_fields)
+      stub_const("HykuAddons::Validations::RedlandsEntryValidationService::EXCLUDED_FIELDS_WITH_VALUES", excluded_fields_with_values)
+    end
+
+    it 'removes the excluded fields from the hash param based on EXCLUDED_FIELDS' do
+      expect(result.keys).to include(:foo)
+      expect(result.keys).not_to include(:bar)
+    end
+  end
+end


### PR DESCRIPTION
Generalizes CSV validators to allow selecting the configuration (ie, the customisations of the tenant) from the rake tasks.

Adds jobs to run Importers in bulk