### PR TITLE
REPO-1275: Include email header envelope-from when sending emails

### DIFF
--- a/app/lib/hyku_addons/per_tenant_smtp_interceptor.rb
+++ b/app/lib/hyku_addons/per_tenant_smtp_interceptor.rb
@@ -14,6 +14,7 @@ module HykuAddons
         message.from = mailer_settings.from
         message.reply_to = mailer_settings.from
         message.return_path = mailer_settings.from
+        message.smtp_envelope_from = mailer_settings.from
       end
 
       data = (HykuAddons::PerTenantSmtpInterceptor.available_smtp_fields - ['from']).map do |key|

--- a/spec/mailers/per_tenant_smtp_mailers_spec.rb
+++ b/spec/mailers/per_tenant_smtp_mailers_spec.rb
@@ -33,6 +33,12 @@ RSpec.describe Hyrax::ContactMailer, clean: true, multitenant: true do
 
       before do
         allow(Site).to receive(:contact_email).and_return('me@example.com')
+
+        Settings.instance_eval do
+          def smtp_settings; end
+        end
+
+        allow(Settings).to receive(:smtp_settings).and_return(OpenStruct.new(smtp_settings))
         allow(Apartment::Tenant).to receive(:switch!).with(account.tenant) do |&block|
           block&.call
         end
@@ -44,14 +50,15 @@ RSpec.describe Hyrax::ContactMailer, clean: true, multitenant: true do
       end
 
       it "replaces the email headers" do
-        # expect(mail.from).to eq ["test@test.edu"]
-        # expect(mail.reply_to).to eq ["test@test.edu"]
-        # expect(mail.return_path).to eq "test@test.edu"
-        # settings = mail.delivery_method.settings.with_indifferent_access
-        # expect(settings[:address]).to eq "test.edu"
-        # expect(settings[:user_name]).to eq "username"
-        # expect(settings[:password]).to eq "password"
-        # expect(settings[:domain]).to eq "test.custom_domain.com"
+        expect(mail.from).to eq ["test@test.edu"]
+        expect(mail.reply_to).to eq ["test@test.edu"]
+        expect(mail.return_path).to eq "test@test.edu"
+        expect(mail.smtp_envelope_from).to eq "test@test.edu"
+        settings = mail.delivery_method.settings.with_indifferent_access
+        expect(settings[:address]).to eq "test.edu"
+        expect(settings[:user_name]).to eq "username"
+        expect(settings[:password]).to eq "password"
+        expect(settings[:domain]).to eq "test.custom_domain.com"
       end
     end
   end


### PR DESCRIPTION
Ensures `envelope-from` matches the value from the `from` header.

Also finally fixes the issue that its test execution made the rest fail