### PR TITLE
Refactor simplfied_admin_set

### DIFF
--- a/app/forms/concerns/hyku_addons/work_form.rb
+++ b/app/forms/concerns/hyku_addons/work_form.rb
@@ -134,13 +134,19 @@ module HykuAddons
     end
 
     def initialize(model, current_ability, controller)
-      model.admin_set_id = controller.params['admin_set_id'] if Flipflop.enabled?(:simplified_admin_set_selection) && controller&.params&.dig('admin_set_id').present?
+      model.admin_set_id = controller.params['admin_set_id'] if simplfied_admin_set?(controller)
 
       super(model, current_ability, controller)
     end
 
     def editor_list
       person_or_organization_list(:editor)
+    end
+
+    protected
+
+    def simplfied_admin_set?(controller)
+      Flipflop.enabled?(:simplified_admin_set_selection) && controller&.params&.dig('admin_set_id').present?
     end
   end
 end

--- a/app/forms/concerns/hyku_addons/work_form.rb
+++ b/app/forms/concerns/hyku_addons/work_form.rb
@@ -145,8 +145,8 @@ module HykuAddons
 
     protected
 
-    def simplfied_admin_set?(controller)
-      Flipflop.enabled?(:simplified_admin_set_selection) && controller&.params&.dig('admin_set_id').present?
-    end
+      def simplfied_admin_set?(controller)
+        Flipflop.enabled?(:simplified_admin_set_selection) && controller&.params&.dig('admin_set_id').present?
+      end
   end
 end

--- a/app/helpers/hyku_addons/notes_tab_form_helper.rb
+++ b/app/helpers/hyku_addons/notes_tab_form_helper.rb
@@ -3,7 +3,7 @@ module HykuAddons
   module NotesTabFormHelper
     def form_tabs_for(form:)
       if Flipflop.enabled?(:notes_tab_form)
-        super + ['notes']
+        super + ["notes"]
       else
         super
       end

--- a/app/helpers/hyku_addons/simplified_admin_set_selection_work_form_helper.rb
+++ b/app/helpers/hyku_addons/simplified_admin_set_selection_work_form_helper.rb
@@ -2,14 +2,10 @@
 
 module HykuAddons
   module SimplifiedAdminSetSelectionWorkFormHelper
-    def form_tabs_for(form:)
-      if current_user&.has_role?(:admin, Site.instance)
-        super
-      elsif enabled? && permission?(form.model) && depositor?(form.depositor)
-        super - ["relationships"]
-      else
-        super
-      end
+    def simplified_admin_set_for_form?(form:)
+      return if current_user.has_role?(:admin, Site.instance)
+
+      enabled? && permission?(form.model) && depositor?(form.depositor)
     end
 
     def available_admin_sets

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -1,0 +1,36 @@
+<% # NOTE: This partial is being over written so that we can append the simplfied_admin_set css for hiding the relationship tab %>
+<%= simple_form_for [main_app, @form], html: { data: { behavior: 'work-form', 'param-key' => @form.model_name.param_key }, multipart: true } do |f| %>
+	<% # We need to hide the tab trigger so that no users can't (easily) access the relationships tab content. %>
+	<% # Doing this via the form_tabs_for monkey patch, removed the tab contents completely, but also removed the admin_set_id field %>
+	<% # which caused the JavaScript which toggles permissions available to the user to not properly find the correct work flow permissions options %>
+	<% if simplified_admin_set_for_form?(form: f.object) %>
+		<style>
+			a[aria-controls="relationships"] { display: none !important; }
+		</style>
+	<% end %>
+
+  <% if f.object.errors.any? %>
+    <div class="alert alert-danger alert-dismissable" role="alert">
+      <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+      <%= f.object.errors.full_messages_for(:base).send(SimpleForm.error_method) %>
+      <%= render 'form_in_works_error', f: f %>
+      <%= render 'form_ordered_members_error', f: f %>
+      <%= render 'form_collections_error', f: f %>
+      <%= render 'form_visibility_error', f: f %>
+    </div>
+  <% end %>
+  <% if Flipflop.batch_upload? && f.object.new_record? %>
+    <% provide :metadata_tab do %>
+      <p class="switch-upload-type">To create a separate work for each of the files, go to <%= link_to "Batch upload", hyrax.new_batch_upload_path %></p>
+    <% end %>
+  <% end %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
+<% end %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    <%# This causes the page to switch back to the default template if they've
+        previously visited the batch download page in this Turbolinks session %>
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'template-download')
+  });
+</script>

--- a/spec/features/simplified_admin_set_deposit_form_spec.rb
+++ b/spec/features/simplified_admin_set_deposit_form_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+include Warden::Test::Helpers
+
+# NOTE: If you generated more than one work, you have to set "js: true"
+RSpec.feature "Simplfied AdminSet deposit form", js: true do
+  let(:user) { create(:user) }
+  let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+  let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+  let(:workflow) do
+    Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template)
+  end
+  let(:work_type) { "book" }
+  let(:human_work_type_name) { I18n.t("hyrax.select_type.#{work_type}.name") }
+
+  before do
+    allow(Flipflop).to receive(:enabled?).and_call_original
+    allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(true)
+
+    # Create a single action that can be taken
+    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+  end
+
+  context "when the user is depositing" do
+    before do
+      # Grant the user access to deposit into the admin set.
+      Hyrax::PermissionTemplateAccess.create!(
+        permission_template_id: permission_template.id,
+        agent_type: 'user',
+        agent_id: user.user_key,
+        access: 'deposit'
+      )
+      login_as user
+    end
+
+    scenario "it doesn't show the relationships tab", js: true do
+      visit '/dashboard'
+      click_link "Works"
+      click_link "Add new work"
+
+      choose "payload_concern", option: work_type.to_s.camelize
+      click_button "Create work"
+
+      expect(page).not_to have_selector("a[aria-controls='relationships']")
+    end
+  end
+
+  context "when the user is managing" do
+    let(:work) { create(:work, title: ["Moomin"], depositor: user.user_key) }
+    let(:admin_user) { create(:admin) }
+    let(:main_app) { Rails.application.routes.url_helpers }
+
+    before do
+      login_as admin_user
+    end
+
+    scenario "it shows the relationships tab", js: true do
+      visit main_app.edit_hyrax_generic_work_path(work)
+
+      expect(page).to have_selector("a[aria-controls='relationships']")
+    end
+  end
+end

--- a/spec/helpers/simplified_admin_set_selection_work_form_helper_spec.rb
+++ b/spec/helpers/simplified_admin_set_selection_work_form_helper_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper do
     allow(controller).to receive(:current_user) { user }
   end
 
-  describe "#form_tabs_for" do
+  describe "#simplified_admin_set_for_form?" do
     context "when the user is an admin and the feature is enabled" do
       before do
         user.add_role(:admin, Site.instance)
@@ -26,7 +26,7 @@ RSpec.describe HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper do
       end
 
       it "shows the tab" do
-        expect(helper.form_tabs_for(form: form)).to include("relationships")
+        expect(helper.simplified_admin_set_for_form?(form: form)).to be_falsey
       end
     end
 
@@ -36,7 +36,7 @@ RSpec.describe HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper do
       end
 
       it "includes relationships" do
-        expect(helper.form_tabs_for(form: form)).to include("relationships")
+        expect(helper.simplified_admin_set_for_form?(form: form)).to be_falsey
       end
     end
 
@@ -48,7 +48,7 @@ RSpec.describe HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper do
       end
 
       it "includes relationships" do
-        expect(helper.form_tabs_for(form: form)).not_to include("relationships")
+        expect(helper.simplified_admin_set_for_form?(form: form)).to be_truthy
       end
     end
 
@@ -60,7 +60,7 @@ RSpec.describe HykuAddons::SimplifiedAdminSetSelectionWorkFormHelper do
       end
 
       it "includes relationships" do
-        expect(helper.form_tabs_for(form: form)).to include("relationships")
+        expect(helper.simplified_admin_set_for_form?(form: form)).to be_falsey
       end
     end
   end


### PR DESCRIPTION
Do not remove the relationships tab fields, just the trigger to view them, otherwise visibility options set in the workflow will not be respected. 

Fixes https://ubiquitypress.atlassian.net/browse/REPO-1348