### PR TITLE
Changes Test to match new API

### DIFF
--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -5,7 +5,7 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
 
   json.abstract work.try(:solr_document)&.dig('abstract_tesim')&.first
   json.adapted_from work.try(:adapted_from)
-  json.additional_info work.try(:solr_document)&.dig('add_info_tesim')
+  json.additional_info work.try(:add_info)
   json.additional_links work.try(:additional_links)
   json.admin_set_name work.admin_set.first
   json.advisor work.try(:advisor)

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -5,7 +5,7 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
 
   json.abstract work.try(:solr_document)&.dig('abstract_tesim')&.first
   json.adapted_from work.try(:adapted_from)
-  json.additional_info work.try(:add_info)
+  json.additional_info work.try(:solr_document)&.dig('add_info_tesim')
   json.additional_links work.try(:additional_links)
   json.admin_set_name work.admin_set.first
   json.advisor work.try(:advisor)

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
         get "/api/v1/tenant/#{account.tenant}/work/#{work.id}"
         expect(response.status).to eq(200)
         expect(json_response).to include("abstract" => nil,
-                                         "additional_info" => [],
+                                         "additional_info" => nil,
                                          "additional_links" => nil,
                                          "admin_set_name" => "",
                                          #  "alternative_journal_title" => nil,


### PR DESCRIPTION
Originally I believed that the Cache was the cause of add_info missing from the API response. However with testing, I found the add_info data was missing in the response with the original method, so instead of reverting the API change, I have changed the test to reflect the new API 