### PR TITLE
Make sure that migrations don't fail when running

### DIFF
--- a/db/migrate/20200911164035_add_data_cite_endpoint_to_account.rb
+++ b/db/migrate/20200911164035_add_data_cite_endpoint_to_account.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 class AddDataCiteEndpointToAccount < ActiveRecord::Migration[5.2]
   def change
-    add_reference :accounts, :datacite_endpoint, index: true
+    add_reference :accounts, :datacite_endpoint, index: true unless column_exists?(:accounts, :datacite_endpoint_id)
   end
 end

--- a/db/migrate/20200929084240_add_parent_id_and_data_settings_column_to_account.rb
+++ b/db/migrate/20200929084240_add_parent_id_and_data_settings_column_to_account.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 class AddParentIdAndDataSettingsColumnToAccount < ActiveRecord::Migration[5.2]
   def change
-    add_reference :accounts, :parent, foreign_key: { to_table: :accounts }
-    add_column :accounts, :settings, :jsonb, default: {}
-    add_column :accounts, :data, :jsonb, default: {}
-    add_index  :accounts, :settings, using: :gin
-    add_index  :accounts, :data, using: :gin
+    add_reference :accounts, :parent, foreign_key: { to_table: :accounts } unless column_exists?(:accounts, :parent_id)
+    add_column :accounts, :settings, :jsonb, default: {} unless column_exists?(:accounts, :settings)
+    add_column :accounts, :data, :jsonb, default: {} unless column_exists?(:accounts, :data)
+    add_index  :accounts, :settings, using: :gin unless index_exists?(:accounts, :settings)
+    add_index  :accounts, :data, using: :gin unless index_exists?(:accounts, :data)
   end
 end

--- a/db/migrate/20210212137215_add_frontend_url_to_account.rb
+++ b/db/migrate/20210212137215_add_frontend_url_to_account.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 class AddFrontendUrlToAccount < ActiveRecord::Migration[5.2]
   def change
-    add_column :accounts, :frontend_url, :string, default: ''
-    add_index  :accounts, :frontend_url
+    add_column :accounts, :frontend_url, :string, default: '' unless column_exists?(:accounts, :frontend_url)
+    add_index  :accounts, :frontend_url unless index_exists?(:accounts, :frontend_url)
   end
 end


### PR DESCRIPTION
For some reason, these migrations are called even when they have been previously run. 