### PR TITLE
Remove namespace from class name in engine

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,6 @@ jobs:
       rails_version:
         type: string
         default: 5.2.4.3
-      parallelism:
-        type: integer
-        default: 4
 
     executor:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
@@ -70,6 +67,7 @@ jobs:
       - samvera/install_solr_core:
           solr_config_path: 'spec/internal_test_hyku/solr/config'
 
+      # Setup hyku_addons and hyrax-doi
       - run: bundle exec rails g hyku_addons:install
 
       - run: bundle exec rake app:db:create app:db:migrate app:zookeeper:upload

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,9 @@ jobs:
       rails_version:
         type: string
         default: 5.2.4.3
+      parallelism:
+        type: integer
+        default: 4
 
     executor:
       name: 'samvera/ruby_fcrepo_solr_redis_postgres'
@@ -67,7 +70,6 @@ jobs:
       - samvera/install_solr_core:
           solr_config_path: 'spec/internal_test_hyku/solr/config'
 
-      # Setup hyku_addons and hyrax-doi
       - run: bundle exec rails g hyku_addons:install
 
       - run: bundle exec rake app:db:create app:db:migrate app:zookeeper:upload

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -510,8 +510,8 @@ module HykuAddons
       # Insert at the end of the actor chain
       Hyrax::CurationConcern.actor_factory.use HykuAddons::Actors::TaskMaster::WorkActor
 
-      # Remove the Hyrax Orcid JSON Actor as we have our own
-      Hyrax::CurationConcern.actor_factory.middlewares.delete(::Hyrax::Actors::Orcid::JSONFieldsActor)
+      # Remove the Hyrax Orcid JSON Actor as we have our own - this should not be namespaced
+      Hyrax::CurationConcern.actor_factory.middlewares.delete(Hyrax::Actors::Orcid::JSONFieldsActor)
       # Remove the Hyrax Orcid pipeline as its not required within HykuAddons
       ::Blacklight::Rendering::Pipeline.operations.delete(Hyrax::Orcid::Blacklight::Rendering::PipelineJsonExtractor)
 

--- a/spec/actors/hyrax/orcid/json_fields_actor_spec.rb
+++ b/spec/actors/hyrax/orcid/json_fields_actor_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::Actors::Orcid::JSONFieldsActor do
+  it "isn't included in the middleware stack" do
+    expect(Hyrax::CurationConcern.actor_factory.middlewares).not_to include(described_class)
+  end
+end

--- a/spec/services/blacklight/rendering/hyrax_orcid_pipeline_json_extractor_spec.rb
+++ b/spec/services/blacklight/rendering/hyrax_orcid_pipeline_json_extractor_spec.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::Orcid::Blacklight::Rendering::PipelineJsonExtractor do
+  it "isn't included in the middleware stack" do
+    expect(Blacklight::Rendering::Pipeline.operations).not_to include(described_class)
+  end
+end
+


### PR DESCRIPTION
 It seems to be causing it to be not removed from the middleware stack, meaning we have two JSON Field processing actors. 