### PR TITLE
Hypothesis integration

### DIFF
--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,0 +1,58 @@
+<% if can?(:edit, file_set.id) || can?(:destroy, file_set.id) %>
+  <div class="btn-group">
+    <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
+      <span class="sr-only"><%= t('.press_to') %> </span>
+      <%= t('.header') %>
+      <span class="caret" aria-hidden="true"></span>
+    </button>
+
+    <ul role="menu" class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenu_<%= file_set.id %>">
+      <% if can?(:edit, file_set.id) %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.edit'), edit_polymorphic_path([main_app, file_set]),
+            { title: t('.edit_title', file_set: file_set), id: "file_edit" } %>
+        </li>
+
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.versions'),  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
+            { title: t('.versions_title'), id: "file_versions" } %>
+        </li>
+
+        <% if file_set.pdf? %>
+          <li role="menuitem" tabindex="-1">
+            <%= link_to t('.read_and_annotate'),  "#{HYPOTHESIS_URL}/viewer/web/viewer.html?#{hyrax.download_url(file_set.id)}",  { title: 'Annotate', id: "file_read" } %>
+          </li>
+        <% end %>
+      <% end %>
+
+      <% if can?(:destroy, file_set.id) %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.delete'), polymorphic_path([main_app, file_set]),
+            method: :delete, 
+            title: t('.delete_title', file_set: file_set),
+            id: "file_destroy",
+            data: { confirm: t('.delete_confirm', file_set: file_set, application_name: application_name) } %>
+        </li>
+      <% end %>
+      
+      <% if can?(:download, file_set.id) %>
+        <li role="menuitem" tabindex="-1">
+          <%= link_to t('.download'),
+                      hyrax.download_path(file_set),
+                      title: t('.download_title', file_set: file_set),
+                      target: "_blank",
+                      id: "file_download",
+                      data: { label: file_set.id } %>
+        </li>
+      <% end %>
+    </ul>
+  </div>
+<% elsif can?(:download, file_set.id)  %>
+  <%= link_to t('.download'),
+              hyrax.download_path(file_set),
+              class: 'btn btn-default btn-sm',
+              title: t('.download_title', file_set: file_set),
+              target: "_blank",
+              id: "file_download",
+              data: { label: file_set.id } %>
+<% end %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -41,7 +41,7 @@
 
         <% if file_set.pdf? %>
           <li role="menuitem" tabindex="-1">
-            <%= link_to t('.read_and_annotate'), "#{HYPOTHESIS_URL}/viewer/web/viewer.html?#{hyrax.download_url(file_set.id)}",  { title: 'Annotate', id: "file_read", target: "_blank" } %>
+            <%= link_to t('.read_and_annotate'), "https://via.hypothes.is/viewer/web/viewer.html?#{hyrax.download_url(file_set.id)}",  { title: t('.read_and_annotate'), id: "file_read", target: "_blank" } %>
           </li>
         <% end %>
       <% end %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:edit, file_set.id) || can?(:destroy, file_set.id) || can?(:download, file_set.id)  %>
+<% if can?(:edit, file_set.id) || can?(:destroy, file_set.id) || (Flipflop.enabled?(:annotation) && can?(:download, file_set.id)) %>
   <div class="btn-group">
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>
@@ -47,4 +47,11 @@
       <% end %>
     </ul>
   </div>
+<% elsif can?(:download, file_set.id) %>
+  <%= link_to t('.download'),
+    hyrax.download_path(file_set),
+    title: t('.download_title', file_set: file_set),
+    target: "_blank",
+    id: "file_download",
+    data: { label: file_set.id } %>
 <% end %>

--- a/app/views/hyrax/file_sets/_actions.html.erb
+++ b/app/views/hyrax/file_sets/_actions.html.erb
@@ -1,4 +1,4 @@
-<% if can?(:edit, file_set.id) || can?(:destroy, file_set.id) %>
+<% if can?(:edit, file_set.id) || can?(:destroy, file_set.id) || can?(:download, file_set.id)  %>
   <div class="btn-group">
     <button class="btn btn-default dropdown-toggle" data-toggle="dropdown" type="button" id="dropdownMenu_<%= file_set.id %>" aria-haspopup="true" aria-expanded="false">
       <span class="sr-only"><%= t('.press_to') %> </span>
@@ -17,12 +17,6 @@
           <%= link_to t('.versions'),  edit_polymorphic_path([main_app, file_set], anchor: 'versioning_display'),
             { title: t('.versions_title'), id: "file_versions" } %>
         </li>
-
-        <% if file_set.pdf? %>
-          <li role="menuitem" tabindex="-1">
-            <%= link_to t('.read_and_annotate'),  "#{HYPOTHESIS_URL}/viewer/web/viewer.html?#{hyrax.download_url(file_set.id)}",  { title: 'Annotate', id: "file_read" } %>
-          </li>
-        <% end %>
       <% end %>
 
       <% if can?(:destroy, file_set.id) %>
@@ -44,15 +38,13 @@
                       id: "file_download",
                       data: { label: file_set.id } %>
         </li>
+
+        <% if file_set.pdf? %>
+          <li role="menuitem" tabindex="-1">
+            <%= link_to t('.read_and_annotate'), "#{HYPOTHESIS_URL}/viewer/web/viewer.html?#{hyrax.download_url(file_set.id)}",  { title: 'Annotate', id: "file_read", target: "_blank" } %>
+          </li>
+        <% end %>
       <% end %>
     </ul>
   </div>
-<% elsif can?(:download, file_set.id)  %>
-  <%= link_to t('.download'),
-              hyrax.download_path(file_set),
-              class: 'btn btn-default btn-sm',
-              title: t('.download_title', file_set: file_set),
-              target: "_blank",
-              id: "file_download",
-              data: { label: file_set.id } %>
 <% end %>

--- a/config/features.rb
+++ b/config/features.rb
@@ -36,4 +36,8 @@ Flipflop.configure do
   feature :cross_tenant_shared_search,
           default: true,
           description: "Turns on cross tenant shared search."
+  
+  feature :annotation,
+          default: true,
+          description: "Turns on links to hypothes.is PDF viewer"
 end

--- a/config/initializers/hypothesis.rb
+++ b/config/initializers/hypothesis.rb
@@ -1,1 +1,0 @@
-HYPOTHESIS_URL = Rails.env.development? ? "http://localhost:8000".freeze : 'https://via.hypothes.is'.freeze 

--- a/config/initializers/hypothesis.rb
+++ b/config/initializers/hypothesis.rb
@@ -1,0 +1,1 @@
+HYPOTHESIS_URL = Rails.env.development? ? "http://localhost:8000".freeze : 'https://via.hypothes.is'.freeze 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -219,6 +219,9 @@ en:
         item_count: Items
     controls:
       shared_search: Shared search
+    file_sets:
+      actions:
+        read_and_annotate: Read and annotate
   bulkrax:
     validation_issues:
       attribute: "Attribute"

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -44,36 +44,55 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
       allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
     end
 
-    context "when the file is a pdf" do
+    context "with annotation disabled" do
       before do
-        allow(file_set).to receive(:pdf?).and_return(true)
-        render 'hyrax/file_sets/actions', file_set: file_set
+        allow(Flipflop).to receive(:enabled?).with(:annotation).and_return(false)
       end
 
       it "includes google analytics data in the download link" do
-        expect(rendered).to have_css("a#file_download")
-        expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
-      end
-
-      it "allows the user to read and annotate the file" do
-        expect(rendered).to have_css("a#file_read")
-        expect(rendered).to have_selector("a[href=\"https://via.hypothes.is/viewer/web/viewer.html?http://test.host/downloads/file_set_id\"]")
-      end
-    end
-
-    context "when the file is a not  pdf" do
-      before do
-        allow(file_set).to receive(:pdf?).and_return(false)
         render 'hyrax/file_sets/actions', file_set: file_set
-      end
 
-      it "includes google analytics data in the download link" do
         expect(rendered).to have_css("a#file_download")
         expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
       end
 
       it "does not allow the user to read and annotate the file" do
         expect(rendered).not_to have_css("a#file_read")
+      end
+    end
+
+    context "with annotation enabled" do
+      before do
+        allow(Flipflop).to receive(:enabled?).with(:annotation).and_return(true)
+      end
+
+      context "when the file is a pdf" do
+        before do
+          allow(file_set).to receive(:pdf?).and_return(true)
+        end
+
+        it "allows the user to read and annotate the file" do
+          render 'hyrax/file_sets/actions', file_set: file_set
+
+          expect(rendered).to have_css("a#file_read")
+          expect(rendered).to have_selector("a[href=\"https://via.hypothes.is/viewer/web/viewer.html?http://test.host/downloads/file_set_id\"]")
+        end
+      end
+
+      context "when the file is a not  pdf" do
+        before do
+          allow(file_set).to receive(:pdf?).and_return(false)
+          render 'hyrax/file_sets/actions', file_set: file_set
+        end
+
+        it "includes google analytics data in the download link" do
+          expect(rendered).to have_css("a#file_download")
+          expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+        end
+
+        it "does not allow the user to read and annotate the file" do
+          expect(rendered).not_to have_css("a#file_read")
+        end
       end
     end
   end

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
+  let(:solr_document) { instance_double(SolrDocument, id: 'file_set_id', hydra_model: ::FileSet) }
+  let(:user) { build(:user) }
+  let(:ability) { Ability.new(user) }
+  let(:file_set) { Hyrax::FileSetPresenter.new(solr_document, ability) }
+
+  before do
+    allow(controller).to receive(:current_ability).and_return(ability)
+    allow(file_set).to receive(:parent).and_return(:parent)
+    allow(view).to receive(:can?).with(:edit, file_set.id).and_return(false)
+    allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(false)
+    allow(view).to receive(:can?).with(:download, file_set.id).and_return(false)
+  end
+
+  context 'with edit permission' do
+    before do
+      allow(view).to receive(:can?).with(:edit, file_set.id).and_return(true)
+    end
+
+    context 'when the file is a pdf' do
+      before do
+        allow(file_set).to receive(:pdf?).and_return(true)
+        render 'hyrax/file_sets/actions', file_set: file_set
+      end
+
+      it 'allows the user to edit the file' do
+        expect(rendered).to have_css('a#file_edit')
+      end
+
+      it 'allows the user to view the file versions' do
+        expect(rendered).to have_css('a#file_versions')
+      end
+
+      it 'allows the user to read and annotate the file' do
+        expect(rendered).to have_css('a#file_read')
+        expect(rendered).to have_selector("a[href=\"https://via.hypothes.is/viewer/web/viewer.html?http://test.host/downloads/file_set_id\"]")
+      end
+    end
+
+    context 'when the file is a not  pdf' do
+      before do
+        allow(file_set).to receive(:pdf?).and_return(false)
+        render 'hyrax/file_sets/actions', file_set: file_set
+      end
+
+      it 'allows the user to edit the file' do
+        expect(rendered).to have_css('a#file_edit')
+      end
+
+      it 'allows the user to view the file versions' do
+        expect(rendered).to have_css('a#file_versions')
+      end
+
+      it 'does not allow the user to read and annotate the file' do
+        expect(rendered).not_to have_css('a#file_read')
+      end
+    end
+  end
+
+  context 'with destroy permission' do
+    before do
+      allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(true)
+      render 'hyrax/file_sets/actions', file_set: file_set
+    end
+
+    it 'allows the user to edit the file' do
+      expect(rendered).to have_css('a#file_destroy')
+    end
+  end
+
+  context 'with download permission' do
+    before do
+      allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
+      render 'hyrax/file_sets/actions', file_set: file_set
+    end
+
+    it "includes google analytics data in the download link" do
+      expect(rendered).to have_css('a#file_download')
+      expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+    end
+  end
+
+  context 'with no permission' do
+    before do
+      render 'hyrax/file_sets/actions', file_set: file_set
+    end
+
+    it "renders nothing" do
+      expect(rendered).to eq('')
+    end
+  end
+end

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -13,81 +13,78 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
     allow(view).to receive(:can?).with(:download, file_set.id).and_return(false)
   end
 
-  context 'with edit permission' do
+  context "with edit permission" do
     before do
       allow(view).to receive(:can?).with(:edit, file_set.id).and_return(true)
+      render 'hyrax/file_sets/actions', file_set: file_set
     end
 
-    context 'when the file is a pdf' do
-      before do
-        allow(file_set).to receive(:pdf?).and_return(true)
-        render 'hyrax/file_sets/actions', file_set: file_set
-      end
-
-      it 'allows the user to edit the file' do
-        expect(rendered).to have_css('a#file_edit')
-      end
-
-      it 'allows the user to view the file versions' do
-        expect(rendered).to have_css('a#file_versions')
-      end
-
-      it 'allows the user to read and annotate the file' do
-        expect(rendered).to have_css('a#file_read')
-        expect(rendered).to have_selector("a[href=\"https://via.hypothes.is/viewer/web/viewer.html?http://test.host/downloads/file_set_id\"]")
-      end
+    it "allows the user to edit the file" do
+      expect(rendered).to have_css("a#file_edit")
     end
 
-    context 'when the file is a not  pdf' do
-      before do
-        allow(file_set).to receive(:pdf?).and_return(false)
-        render 'hyrax/file_sets/actions', file_set: file_set
-      end
-
-      it 'allows the user to edit the file' do
-        expect(rendered).to have_css('a#file_edit')
-      end
-
-      it 'allows the user to view the file versions' do
-        expect(rendered).to have_css('a#file_versions')
-      end
-
-      it 'does not allow the user to read and annotate the file' do
-        expect(rendered).not_to have_css('a#file_read')
-      end
+    it "allows the user to view the file versions" do
+      expect(rendered).to have_css("a#file_versions")
     end
   end
 
-  context 'with destroy permission' do
+  context "with destroy permission" do
     before do
       allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(true)
       render 'hyrax/file_sets/actions', file_set: file_set
     end
 
-    it 'allows the user to edit the file' do
-      expect(rendered).to have_css('a#file_destroy')
+    it "allows the user to edit the file" do
+      expect(rendered).to have_css("a#file_destroy")
     end
   end
 
-  context 'with download permission' do
+  context "with download permission" do
     before do
       allow(view).to receive(:can?).with(:download, file_set.id).and_return(true)
-      render 'hyrax/file_sets/actions', file_set: file_set
     end
 
-    it "includes google analytics data in the download link" do
-      expect(rendered).to have_css('a#file_download')
-      expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+    context "when the file is a pdf" do
+      before do
+        allow(file_set).to receive(:pdf?).and_return(true)
+        render 'hyrax/file_sets/actions', file_set: file_set
+      end
+
+      it "includes google analytics data in the download link" do
+        expect(rendered).to have_css("a#file_download")
+        expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+      end
+
+      it "allows the user to read and annotate the file" do
+        expect(rendered).to have_css("a#file_read")
+        expect(rendered).to have_selector("a[href=\"https://via.hypothes.is/viewer/web/viewer.html?http://test.host/downloads/file_set_id\"]")
+      end
+    end
+
+    context "when the file is a not  pdf" do
+      before do
+        allow(file_set).to receive(:pdf?).and_return(false)
+        render 'hyrax/file_sets/actions', file_set: file_set
+      end
+
+      it "includes google analytics data in the download link" do
+        expect(rendered).to have_css("a#file_download")
+        expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
+      end
+
+      it "does not allow the user to read and annotate the file" do
+        expect(rendered).not_to have_css("a#file_read")
+      end
     end
   end
 
-  context 'with no permission' do
+  context "with no permission" do
     before do
       render 'hyrax/file_sets/actions', file_set: file_set
     end
 
     it "renders nothing" do
-      expect(rendered).to eq('')
+      expect(rendered).to eq("")
     end
   end
 end

--- a/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
+++ b/spec/views/hyrax/file_sets/_actions.html.erb_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
-  let(:solr_document) { instance_double(SolrDocument, id: 'file_set_id', hydra_model: ::FileSet) }
+RSpec.describe "hyrax/file_sets/_actions.html.erb", type: :view do
+  let(:solr_document) { instance_double(SolrDocument, id: "file_set_id", hydra_model: ::FileSet) }
   let(:user) { build(:user) }
   let(:ability) { Ability.new(user) }
   let(:file_set) { Hyrax::FileSetPresenter.new(solr_document, ability) }
@@ -16,7 +16,7 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
   context "with edit permission" do
     before do
       allow(view).to receive(:can?).with(:edit, file_set.id).and_return(true)
-      render 'hyrax/file_sets/actions', file_set: file_set
+      render "hyrax/file_sets/actions", file_set: file_set
     end
 
     it "allows the user to edit the file" do
@@ -31,7 +31,7 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
   context "with destroy permission" do
     before do
       allow(view).to receive(:can?).with(:destroy, file_set.id).and_return(true)
-      render 'hyrax/file_sets/actions', file_set: file_set
+      render "hyrax/file_sets/actions", file_set: file_set
     end
 
     it "allows the user to edit the file" do
@@ -50,7 +50,7 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
       end
 
       it "includes google analytics data in the download link" do
-        render 'hyrax/file_sets/actions', file_set: file_set
+        render "hyrax/file_sets/actions", file_set: file_set
 
         expect(rendered).to have_css("a#file_download")
         expect(rendered).to have_selector("a[data-label=\"#{file_set.id}\"]")
@@ -72,7 +72,7 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
         end
 
         it "allows the user to read and annotate the file" do
-          render 'hyrax/file_sets/actions', file_set: file_set
+          render "hyrax/file_sets/actions", file_set: file_set
 
           expect(rendered).to have_css("a#file_read")
           expect(rendered).to have_selector("a[href=\"https://via.hypothes.is/viewer/web/viewer.html?http://test.host/downloads/file_set_id\"]")
@@ -82,7 +82,7 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
       context "when the file is a not  pdf" do
         before do
           allow(file_set).to receive(:pdf?).and_return(false)
-          render 'hyrax/file_sets/actions', file_set: file_set
+          render "hyrax/file_sets/actions", file_set: file_set
         end
 
         it "includes google analytics data in the download link" do
@@ -99,7 +99,7 @@ RSpec.describe 'hyrax/file_sets/_actions.html.erb', type: :view do
 
   context "with no permission" do
     before do
-      render 'hyrax/file_sets/actions', file_set: file_set
+      render "hyrax/file_sets/actions", file_set: file_set
     end
 
     it "renders nothing" do


### PR DESCRIPTION
On a work’s page, for each fileset the user can download, add a link to the Actions dropdown, which opens the file using hypothesis external service.

### Work completed
- [ ] Add Flipflop config control for `:annotation`
- [ ] Override [views/hyrax/file_sets/actions](https://github.com/samvera/hyrax/blob/main/app/views/hyrax/file_sets/_actions.html.erb) partial
- [ ] Refactor logic to test for config control.  When this is switched on, users with only the download permission will now be able to see two links and so the view must also display ul for them.
NB I have removed the configuration to run this locally as I can see little need to do this as we are essentially linking out to a third party service which we will not interact with afaik.

### Layout
![image](https://user-images.githubusercontent.com/7236943/141992651-bbc6bcc1-2841-4f26-9137-aded34bdb9d7.png)

### Ticket
https://ubiquitypress.atlassian.net/browse/REPO-1495