### PR TITLE
Update Rubocop config to enforce double quotes in test suite

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -176,3 +176,24 @@ Naming/FileName:
 Lint/HandleExceptions:
   Exclude:
     - 'app/models/hyku_addons/csv_entry.rb'
+
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+  SupportedStyles:
+    - single_quotes
+    - double_quotes
+  Exclude:
+    - 'app/**/*'
+    - 'config/**/*'
+    - 'lib/**/*'
+    - 'db/**/*'
+    - 'bin/**/*'
+    - '**/*.gemfile'
+    - '**/*.gemspec'
+    - '**/*.rake'
+    - '**/*.ru'
+    - '**/Gemfile'
+    - '**/Rakefile'
+    - 'spec/internal_test_hyku/**/*'
+    - 'spec/rails_helper.rb'
+    - 'spec/spec_helper.rb'

--- a/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/note_field_actor_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe HykuAddons::Actors::NoteFieldActor do
 
   describe "#create" do
     context "when the note attribute is present" do
-      let(:attributes) { { note: 'this is a note' } }
+      let(:attributes) { { note: "this is a note" } }
 
       before do
         allow(terminator).to receive(:create).with(env)
@@ -49,7 +49,7 @@ RSpec.describe HykuAddons::Actors::NoteFieldActor do
         note: ["{\"email\":\"email-1@test.com\",\"timestamp\":\"2021-05-27 23:15:23 UTC\",\"note\":\"first note\"}"]
       )
     end
-    let(:attributes) { { note: 'this is a new note' } }
+    let(:attributes) { { note: "this is a new note" } }
 
     context "when the note attribute is present" do
       before do
@@ -86,7 +86,7 @@ RSpec.describe HykuAddons::Actors::NoteFieldActor do
         note_content_ary = work.note.map do |note|
           JSON.parse(note)["note"]
         end
-        expect(note_content_ary).to include('first note')
+        expect(note_content_ary).to include("first note")
       end
     end
   end

--- a/spec/actors/hyku_addons/actors/task_master/work_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/task_master/work_actor_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe HykuAddons::Actors::TaskMaster::WorkActor do
   subject(:work) { create(:task_master_work, :with_one_file) }

--- a/spec/actors/hyrax/actors/article_actor_spec.rb
+++ b/spec/actors/hyrax/actors/article_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work Article`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::ArticleActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/book_actor_spec.rb
+++ b/spec/actors/hyrax/actors/book_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::BookActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/book_contribution_actor_spec.rb
+++ b/spec/actors/hyrax/actors/book_contribution_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::BookContributionActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/conference_item_actor_spec.rb
+++ b/spec/actors/hyrax/actors/conference_item_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work ConferenceItem`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::ConferenceItemActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/dataset_actor_spec.rb
+++ b/spec/actors/hyrax/actors/dataset_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work Dataset`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::DatasetActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/exhibition_item_actor_spec.rb
+++ b/spec/actors/hyrax/actors/exhibition_item_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work ExhibitionItem`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::ExhibitionItemActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/pacific_article_actor_spec.rb
+++ b/spec/actors/hyrax/actors/pacific_article_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work PacificArticle`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::PacificArticleActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/report_actor_spec.rb
+++ b/spec/actors/hyrax/actors/report_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work Report`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::ReportActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/thesis_or_dissertation_actor_spec.rb
+++ b/spec/actors/hyrax/actors/thesis_or_dissertation_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work ThesisOrDissertation`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::ThesisOrDissertationActor do
   it "behaves like a BaseActor" do

--- a/spec/actors/hyrax/actors/time_based_media_actor_spec.rb
+++ b/spec/actors/hyrax/actors/time_based_media_actor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work TimeBasedMedia`
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::Actors::TimeBasedMediaActor do
   it "behaves like a BaseActor" do

--- a/spec/controllers/catalog_controller_spec.rb
+++ b/spec/controllers/catalog_controller_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe CatalogController, clean: true do
-  let!(:work) { PacificArticle.create(title: ['Test'], official_link: official_link, doi_status_when_public: doi_status) }
+  let!(:work) { PacificArticle.create(title: ["Test"], official_link: official_link, doi_status_when_public: doi_status) }
   let!(:file_set) { create(:file_set, visibility: file_visibility) }
   let(:official_link) { nil }
   let(:doi_status) { nil }
-  let(:file_visibility) { 'restricted' }
+  let(:file_visibility) { "restricted" }
 
   before do
     work.ordered_members << file_set
@@ -15,48 +15,48 @@ RSpec.describe CatalogController, clean: true do
     sign_in create(:admin)
   end
 
-  describe 'file availability facet' do
-    context 'when work has public files' do
-      let(:file_visibility) { 'open' }
+  describe "file availability facet" do
+    context "when work has public files" do
+      let(:file_visibility) { "open" }
 
-      context 'and work has findable or registered DOI' do
-        let(:doi_status) { 'findable' }
+      context "and work has findable or registered DOI" do
+        let(:doi_status) { "findable" }
 
-        context 'and work has official link' do
-          let(:official_link) { 'https://example.com/link/to/work' }
+        context "and work has official link" do
+          let(:official_link) { "https://example.com/link/to/work" }
 
-          it 'is available' do
-            get 'index', params: { q: '' }
+          it "is available" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 1
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 0
           end
         end
 
-        context 'and work does not have official link' do
-          it 'is available' do
-            get 'index', params: { q: '' }
+        context "and work does not have official link" do
+          it "is available" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 1
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 0
           end
         end
       end
-      context 'and work does not have findable or registered DOI' do
-        context 'and work has official link' do
-          let(:official_link) { 'https://example.com/link/to/work' }
+      context "and work does not have findable or registered DOI" do
+        context "and work has official link" do
+          let(:official_link) { "https://example.com/link/to/work" }
 
-          it 'is available and external link' do
-            get 'index', params: { q: '' }
+          it "is available and external link" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 1
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 1
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 0
           end
         end
 
-        context 'and work does not have official link' do
-          it 'is available' do
-            get 'index', params: { q: '' }
+        context "and work does not have official link" do
+          it "is available" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 1
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 0
@@ -64,45 +64,45 @@ RSpec.describe CatalogController, clean: true do
         end
       end
     end
-    context 'when work does not have public files' do
-      context 'and work has findable or registered DOI' do
-        let(:doi_status) { 'findable' }
+    context "when work does not have public files" do
+      context "and work has findable or registered DOI" do
+        let(:doi_status) { "findable" }
 
-        context 'and work has official link' do
-          let(:official_link) { 'https://example.com/link/to/work' }
+        context "and work has official link" do
+          let(:official_link) { "https://example.com/link/to/work" }
 
-          it 'is not available' do
-            get 'index', params: { q: '' }
+          it "is not available" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 1
           end
         end
 
-        context 'and work does not have official link' do
-          it 'is not available' do
-            get 'index', params: { q: '' }
+        context "and work does not have official link" do
+          it "is not available" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 1
           end
         end
       end
-      context 'and work does not have findable or registered DOI' do
-        context 'and work has official link' do
-          let(:official_link) { 'https://example.com/link/to/work' }
+      context "and work does not have findable or registered DOI" do
+        context "and work has official link" do
+          let(:official_link) { "https://example.com/link/to/work" }
 
-          it 'is external link' do
-            get 'index', params: { q: '' }
+          it "is external link" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 1
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 0
           end
         end
 
-        context 'and work does not have official link' do
-          it 'is not available' do
-            get 'index', params: { q: '' }
+        context "and work does not have official link" do
+          it "is not available" do
+            get "index", params: { q: "" }
             expect(assigns[:response][:facet_counts][:facet_queries].values.first).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.second).to eq 0
             expect(assigns[:response][:facet_counts][:facet_queries].values.third).to eq 1

--- a/spec/controllers/hyrax/anschutz_works_controller_spec.rb
+++ b/spec/controllers/hyrax/anschutz_works_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::AnschutzWorksController, type: :controller do
-  let!(:work) { AnschutzWork.create(title: ['Test'], visibility: "open") }
+  let!(:work) { AnschutzWork.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/articles_controller_spec.rb
+++ b/spec/controllers/hyrax/articles_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::ArticlesController, type: :controller do
-  let!(:work) { Article.create(title: ['Test'], visibility: "open") }
+  let!(:work) { Article.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/book_contributions_controller_spec.rb
+++ b/spec/controllers/hyrax/book_contributions_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::BookContributionsController, type: :controller do
-  let!(:work) { BookContribution.create(title: ['Test'], visibility: "open") }
+  let!(:work) { BookContribution.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/conference_items_controller_spec.rb
+++ b/spec/controllers/hyrax/conference_items_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::ConferenceItemsController, type: :controller do
-  let!(:work) { ConferenceItem.create(title: ['Test'], visibility: "open") }
+  let!(:work) { ConferenceItem.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/datasets_controller_spec.rb
+++ b/spec/controllers/hyrax/datasets_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DatasetsController, type: :controller do
-  let!(:work) { Dataset.create(title: ['Test'], visibility: "open") }
+  let!(:work) { Dataset.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_articles_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_articles_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverArticlesController, type: :controller do
-  let!(:work) { DenverArticle.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverArticle.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_books_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_books_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverBooksController, type: :controller do
-  let!(:work) { DenverBook.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverBook.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_images_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_images_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverImagesController, type: :controller do
-  let!(:work) { DenverImage.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverImage.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_multimedias_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_multimedias_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverMultimediasController, type: :controller do
-  let!(:work) { DenverMultimedia.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverMultimedia.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_presentation_materials_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_presentation_materials_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverPresentationMaterialsController, type: :controller do
-  let!(:work) { DenverPresentationMaterial.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverPresentationMaterial.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_serial_publications_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_serial_publications_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverSerialPublicationsController, type: :controller do
-  let!(:work) { DenverSerialPublication.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverSerialPublication.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/denver_thesis_dissertation_capstones_controller_spec.rb
+++ b/spec/controllers/hyrax/denver_thesis_dissertation_capstones_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::DenverThesisDissertationCapstonesController, type: :controller do
-  let!(:work) { DenverThesisDissertationCapstone.create(title: ['Test'], visibility: "open") }
+  let!(:work) { DenverThesisDissertationCapstone.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/exhibition_items_controller_spec.rb
+++ b/spec/controllers/hyrax/exhibition_items_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::ExhibitionItemsController, type: :controller do
-  let!(:work) { ExhibitionItem.create(title: ['Test'], visibility: "open") }
+  let!(:work) { ExhibitionItem.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_articles_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_articles_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificArticlesController, type: :controller do
-  let!(:work) { PacificArticle.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificArticle.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_book_chapters_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_book_chapters_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificBookChaptersController, type: :controller do
-  let!(:work) { PacificBookChapter.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificBookChapter.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_books_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_books_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificBooksController, type: :controller do
-  let!(:work) { PacificBook.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificBook.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_images_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_images_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificImagesController, type: :controller do
-  let!(:work) { PacificImage.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificImage.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_medias_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_medias_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificMediasController, type: :controller do
-  let!(:work) { PacificMedia.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificMedia.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_news_clippings_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_news_clippings_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificNewsClippingsController, type: :controller do
-  let!(:work) { PacificNewsClipping.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificNewsClipping.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_presentations_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_presentations_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificPresentationsController, type: :controller do
-  let!(:work) { PacificPresentation.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificPresentation.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_text_works_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_text_works_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificTextWorksController, type: :controller do
-  let!(:work) { PacificTextWork.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificTextWork.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_thesis_or_dissertations_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_thesis_or_dissertations_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificThesisOrDissertationsController, type: :controller do
-  let!(:work) { PacificThesisOrDissertation.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificThesisOrDissertation.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/pacific_uncategorizeds_controller_spec.rb
+++ b/spec/controllers/hyrax/pacific_uncategorizeds_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::PacificUncategorizedsController, type: :controller do
-  let!(:work) { PacificUncategorized.create(title: ['Test'], visibility: "open") }
+  let!(:work) { PacificUncategorized.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/redlands_articles_controller_spec.rb
+++ b/spec/controllers/hyrax/redlands_articles_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::RedlandsArticlesController, type: :controller do
-  let!(:work) { RedlandsArticle.create(title: ['Test'], visibility: "open") }
+  let!(:work) { RedlandsArticle.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/redlands_chapters_and_book_sections_controller_spec.rb
+++ b/spec/controllers/hyrax/redlands_chapters_and_book_sections_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::RedlandsChaptersAndBookSectionsController, type: :controller do
-  let!(:work) { RedlandsChaptersAndBookSection.create(title: ['Test'], visibility: "open") }
+  let!(:work) { RedlandsChaptersAndBookSection.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/redlands_conferences_reports_and_papers_controller_spec.rb
+++ b/spec/controllers/hyrax/redlands_conferences_reports_and_papers_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::RedlandsConferencesReportsAndPapersController, type: :controller do
-  let!(:work) { RedlandsConferencesReportsAndPaper.create(title: ['Test'], visibility: "open") }
+  let!(:work) { RedlandsConferencesReportsAndPaper.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/redlands_medias_controller_spec.rb
+++ b/spec/controllers/hyrax/redlands_medias_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::RedlandsMediasController, type: :controller do
-  let!(:work) { RedlandsMedia.create(title: ['Test'], visibility: "open") }
+  let!(:work) { RedlandsMedia.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/redlands_open_educational_resources_controller_spec.rb
+++ b/spec/controllers/hyrax/redlands_open_educational_resources_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::RedlandsOpenEducationalResourcesController, type: :controller do
-  let!(:work) { RedlandsOpenEducationalResource.create(title: ['Test'], visibility: "open") }
+  let!(:work) { RedlandsOpenEducationalResource.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/redlands_student_works_controller_spec.rb
+++ b/spec/controllers/hyrax/redlands_student_works_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::RedlandsStudentWorksController, type: :controller do
-  let!(:work) { RedlandsStudentWork.create(title: ['Test'], visibility: "open") }
+  let!(:work) { RedlandsStudentWork.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/reports_controller_spec.rb
+++ b/spec/controllers/hyrax/reports_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::ReportsController, type: :controller do
-  let!(:work) { Report.create(title: ['Test'], visibility: "open") }
+  let!(:work) { Report.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/thesis_dissertations_controller_spec.rb
+++ b/spec/controllers/hyrax/thesis_dissertations_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::ThesisOrDissertationsController, type: :controller do
-  let!(:work) { ThesisOrDissertation.create(title: ['Test'], visibility: "open") }
+  let!(:work) { ThesisOrDissertation.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/time_based_medias_controller_spec.rb
+++ b/spec/controllers/hyrax/time_based_medias_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::TimeBasedMediasController, type: :controller do
-  let!(:work) { TimeBasedMedia.create(title: ['Test'], visibility: "open") }
+  let!(:work) { TimeBasedMedia.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/ubiquity_template_works_controller_spec.rb
+++ b/spec/controllers/hyrax/ubiquity_template_works_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::UbiquityTemplateWorksController, type: :controller do
-  let!(:work) { UbiquityTemplateWork.create(title: ['Test'], visibility: "open") }
+  let!(:work) { UbiquityTemplateWork.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/hyrax/uva_works_controller_spec.rb
+++ b/spec/controllers/hyrax/uva_works_controller_spec.rb
@@ -3,7 +3,7 @@
 require "rails_helper"
 
 RSpec.describe Hyrax::UvaWorksController, type: :controller do
-  let!(:work) { UvaWork.create(title: ['Test'], visibility: "open") }
+  let!(:work) { UvaWork.create(title: ["Test"], visibility: "open") }
 
   describe "responds to" do
     it "responds to html by default" do

--- a/spec/controllers/proprietor/accounts_controller_overrides_spec.rb
+++ b/spec/controllers/proprietor/accounts_controller_overrides_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
     sign_in user if user
   end
 
-  context 'as an admin of a site' do
+  context "as an admin of a site" do
     let(:user) { FactoryBot.create(:user).tap { |u| u.add_role(:admin, Site.instance) } }
     let(:account) { FactoryBot.create(:account) }
 
@@ -18,7 +18,7 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
     describe "PUT #update" do
       context "with valid params" do
         let(:new_attributes) do
-          { datacite_endpoint_attributes: { mode: 'production', prefix: '10.1234', username: 'user123', password: 'pass123' } }
+          { datacite_endpoint_attributes: { mode: "production", prefix: "10.1234", username: "user123", password: "pass123" } }
         end
 
         it "updates the requested account" do
@@ -27,10 +27,10 @@ RSpec.describe Proprietor::AccountsController, type: :controller, multitenant: t
           end
           put :update, params: { id: account.to_param, account: new_attributes }
           account.reload
-          expect(account.datacite_endpoint.mode).to eq 'production'
-          expect(account.datacite_endpoint.prefix).to eq '10.1234'
-          expect(account.datacite_endpoint.username).to eq 'user123'
-          expect(account.datacite_endpoint.password).to eq 'pass123'
+          expect(account.datacite_endpoint.mode).to eq "production"
+          expect(account.datacite_endpoint.prefix).to eq "10.1234"
+          expect(account.datacite_endpoint.username).to eq "user123"
+          expect(account.datacite_endpoint.password).to eq "pass123"
           expect(response).to redirect_to([:proprietor, account])
         end
       end

--- a/spec/controllers/proprietor/catalog_controller_overrides_spec.rb
+++ b/spec/controllers/proprietor/catalog_controller_overrides_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe CatalogController do
       it "is successful" do
         get :oai
         expect(response).to be_successful
-        expect(response.content_type).to eq 'text/xml'
+        expect(response.content_type).to eq "text/xml"
       end
     end
 
@@ -21,7 +21,7 @@ RSpec.describe CatalogController do
       let(:oai_enabled) { false }
 
       it "is raises a routing error" do
-        expect { get :oai }.to raise_error(ActionController::RoutingError, 'Enable the OAI Endpoint feature first')
+        expect { get :oai }.to raise_error(ActionController::RoutingError, "Enable the OAI Endpoint feature first")
       end
     end
   end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :datacite_endpoint do
-    options { Hash.new(mode: 'test', prefix: '10.1234', username: 'user123', password: 'pass123') }
+    options { Hash.new(mode: "test", prefix: "10.1234", username: "user123", password: "pass123") }
   end
 end
 
@@ -14,13 +14,13 @@ FactoryBot.modify do
     datacite_endpoint
     settings do
       {
-        contact_email: 'abc@abc.com', weekly_email_list: ["aaa@aaa.com", "bbb@bl.uk"], monthly_email_list: ["aaa@aaa.com", "bbb@bl.uk"],
+        contact_email: "abc@abc.com", weekly_email_list: ["aaa@aaa.com", "bbb@bl.uk"], monthly_email_list: ["aaa@aaa.com", "bbb@bl.uk"],
         yearly_email_list: ["aaa@aaa.com", "bbb@bl.uk"],
-        google_scholarly_work_types: ['Article', 'Book', 'ThesisOrDissertation', 'BookChapter'],
+        google_scholarly_work_types: ["Article", "Book", "ThesisOrDissertation", "BookChapter"],
         gtm_id: "GTM-123456", shared_login: "true",
         email_format: ["@pacificu.edu", "@ubiquitypress.com", "@test.com"],
         allow_signup: "true",
-        google_analytics_id: 'UA-123456-12'
+        google_analytics_id: "UA-123456-12"
       }
     end
     data do

--- a/spec/factories/bulkrax_exporters.rb
+++ b/spec/factories/bulkrax_exporters.rb
@@ -3,7 +3,7 @@
 # Later we could make a PR to expose them in Bulkrax so we don't have to copy them anymore
 
 FactoryBot.define do
-  factory :bulkrax_exporter, class: 'Bulkrax::Exporter' do
+  factory :bulkrax_exporter, class: "Bulkrax::Exporter" do
     name { "Export from Importer" }
     user { FactoryBot.build(:base_user) }
     export_type { "metadata" }

--- a/spec/factories/bulkrax_importers.rb
+++ b/spec/factories/bulkrax_importers.rb
@@ -4,7 +4,7 @@
 # Changed admin_set_id to be default admin set
 
 FactoryBot.define do
-  factory :bulkrax_importer, class: 'Bulkrax::Importer' do
+  factory :bulkrax_importer, class: "Bulkrax::Importer" do
     name { "A.N. Import" }
     admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
@@ -15,97 +15,97 @@ FactoryBot.define do
     field_mapping { [{}] }
   end
 
-  factory :bulkrax_importer_oai, class: 'Bulkrax::Importer' do
-    name { 'Oai Collection' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_oai, class: "Bulkrax::Importer" do
+    name { "Oai Collection" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::OaiDcParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::OaiDcParser" }
     limit { 10 }
     parser_fields do
       {
-        'base_url' => 'http://commons.ptsem.edu/api/oai-pmh',
-        'metadata_prefix' => 'oai_dc'
+        "base_url" => "http://commons.ptsem.edu/api/oai-pmh",
+        "metadata_prefix" => "oai_dc"
       }
     end
     field_mapping { {} }
   end
 
-  factory :bulkrax_importer_csv, class: 'Bulkrax::Importer' do
-    name { 'CSV Import' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_csv, class: "Bulkrax::Importer" do
+    name { "CSV Import" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::CsvParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::CsvParser" }
     limit { 10 }
-    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/good.csv' } }
+    parser_fields { { "import_file_path" => "spec/fixtures/csv/good.csv" } }
     field_mapping { {} }
     after :create, &:current_run
   end
 
-  factory :bulkrax_importer_csv_complex, class: 'Bulkrax::Importer' do
-    name { 'CSV Import' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_csv_complex, class: "Bulkrax::Importer" do
+    name { "CSV Import" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::CsvParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::CsvParser" }
     limit { 10 }
-    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/complex.csv' } }
+    parser_fields { { "import_file_path" => "spec/fixtures/csv/complex.csv" } }
     field_mapping { {} }
   end
 
-  factory :bulkrax_importer_bagit, class: 'Bulkrax::Importer' do
-    name { 'Bagit Import' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_bagit, class: "Bulkrax::Importer" do
+    name { "Bagit Import" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::BagitParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::BagitParser" }
     limit { 10 }
     parser_fields do
       {
-        'import_file_path' => 'spec/fixtures/bags/bag',
-        'metadata_file_name' => 'descMetadata.nt',
-        'metadata_format' => 'Bulkrax::RdfEntry'
+        "import_file_path" => "spec/fixtures/bags/bag",
+        "metadata_file_name" => "descMetadata.nt",
+        "metadata_format" => "Bulkrax::RdfEntry"
       }
     end
     field_mapping { {} }
     after :create, &:current_run
   end
 
-  factory :bulkrax_importer_csv_bad, class: 'Bulkrax::Importer' do
-    name { 'CSV Import' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_csv_bad, class: "Bulkrax::Importer" do
+    name { "CSV Import" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::CsvParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::CsvParser" }
     limit { 10 }
-    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/bad.csv' } }
+    parser_fields { { "import_file_path" => "spec/fixtures/csv/bad.csv" } }
     field_mapping { {} }
   end
 
-  factory :bulkrax_importer_csv_failed, class: 'Bulkrax::Importer' do
-    name { 'CSV Import' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_csv_failed, class: "Bulkrax::Importer" do
+    name { "CSV Import" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::CsvParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::CsvParser" }
     limit { 10 }
-    parser_fields { { 'import_file_path' => 'spec/fixtures/csv/failed.csv' } }
+    parser_fields { { "import_file_path" => "spec/fixtures/csv/failed.csv" } }
     field_mapping { {} }
   end
 
-  factory :bulkrax_importer_xml, class: 'Bulkrax::Importer' do
-    name { 'XML Import' }
-    admin_set_id { 'admin_set/default' }
+  factory :bulkrax_importer_xml, class: "Bulkrax::Importer" do
+    name { "XML Import" }
+    admin_set_id { "admin_set/default" }
     user { FactoryBot.build(:base_user) }
-    frequency { 'PT0S' }
-    parser_klass { 'Bulkrax::XmlParser' }
+    frequency { "PT0S" }
+    parser_klass { "Bulkrax::XmlParser" }
     limit { 10 }
-    parser_fields { { 'import_file_path' => 'spec/fixtures/xml/good.xml' } }
+    parser_fields { { "import_file_path" => "spec/fixtures/xml/good.xml" } }
     field_mapping do
       {
-        'title': { from: ['TitleLargerEntity'] },
-        'abstract': { from: ['Abstract'] }
+        'title': { from: ["TitleLargerEntity"] },
+        'abstract': { from: ["Abstract"] }
       }
     end
   end

--- a/spec/factories/works.rb
+++ b/spec/factories/works.rb
@@ -1,55 +1,55 @@
 # frozen_string_literal: true
 FactoryBot.define do
   factory :fully_described_work, parent: :work do
-    volume { ['1'] }
-    pagination { '1' }
-    issn { '' }
-    eissn { '' }
-    official_link { '' }
-    series_name { [''] }
-    edition { '' }
-    event_title { [''] }
-    event_date { ['2009'] }
-    event_location { [''] }
-    book_title { '' }
-    journal_title { '' }
-    issue { '' }
-    article_num { '' }
-    isbn { '' }
-    media { [''] }
-    related_exhibition { [''] }
-    related_exhibition_date { ['2009'] }
-    version { [''] }
-    version_number { [''] }
-    alternative_journal_title { [''] }
-    related_exhibition_venue { [''] }
-    current_he_institution { [''] }
-    qualification_name { '' }
-    qualification_level { '' }
-    duration { [''] }
-    editor { [''] }
+    volume { ["1"] }
+    pagination { "1" }
+    issn { "" }
+    eissn { "" }
+    official_link { "" }
+    series_name { [""] }
+    edition { "" }
+    event_title { [""] }
+    event_date { ["2009"] }
+    event_location { [""] }
+    book_title { "" }
+    journal_title { "" }
+    issue { "" }
+    article_num { "" }
+    isbn { "" }
+    media { [""] }
+    related_exhibition { [""] }
+    related_exhibition_date { ["2009"] }
+    version { [""] }
+    version_number { [""] }
+    alternative_journal_title { [""] }
+    related_exhibition_venue { [""] }
+    current_he_institution { [""] }
+    qualification_name { "" }
+    qualification_level { "" }
+    duration { [""] }
+    editor { [""] }
 
-    institution { [''] }
-    org_unit { [''] }
-    refereed { '' }
-    funder { [''] }
-    fndr_project_ref { [''] }
-    add_info { '' }
-    date_published { '' }
-    date_accepted { '' }
-    date_submitted { '' }
-    project_name { [''] }
-    rights_holder { [''] }
-    place_of_publication { [''] }
-    abstract { '' }
-    alternate_identifier { [''] }
-    related_identifier { [''] }
-    library_of_congress_classification { [''] }
-    alt_title { [''] }
-    dewey { '' }
+    institution { [""] }
+    org_unit { [""] }
+    refereed { "" }
+    funder { [""] }
+    fndr_project_ref { [""] }
+    add_info { "" }
+    date_published { "" }
+    date_accepted { "" }
+    date_submitted { "" }
+    project_name { [""] }
+    rights_holder { [""] }
+    place_of_publication { [""] }
+    abstract { "" }
+    alternate_identifier { [""] }
+    related_identifier { [""] }
+    library_of_congress_classification { [""] }
+    alt_title { [""] }
+    dewey { "" }
 
-    creator { [''] }
-    contributor { [''] }
+    creator { [""] }
+    contributor { [""] }
   end
 
   factory :task_master_work, parent: :work do
@@ -66,7 +66,7 @@ FactoryBot.define do
 
     trait :with_one_file do
       before(:create) do |work, evaluator|
-        work.ordered_members << create(:file_set, user: evaluator.user, title: ['A Contained PDF FileSet'], label: 'filename.pdf')
+        work.ordered_members << create(:file_set, user: evaluator.user, title: ["A Contained PDF FileSet"], label: "filename.pdf")
       end
     end
   end

--- a/spec/features/bulkrax_export_spec.rb
+++ b/spec/features/bulkrax_export_spec.rb
@@ -140,23 +140,23 @@ RSpec.describe "Bulkrax export", clean: true, perform_enqueued: true do
       end
     end
 
-    context 'file visibility' do
-      let(:import_batch_file) { 'spec/fixtures/csv/generic_work.file_set.csv' }
+    context "file visibility" do
+      let(:import_batch_file) { "spec/fixtures/csv/generic_work.file_set.csv" }
       let(:export_source) { "GenericWork" }
 
-      it 'imports files' do
+      it "imports files" do
         entry = exporter.entries.first
         expect(entry).to be_present
-        expect(entry.parsed_metadata['visibility']).to eq 'open'
-        expect(entry.parsed_metadata['file_1']).to end_with 'nypl-hydra-of-lerna.jpg'
-        expect(entry.parsed_metadata['file_visibility_1']).to eq 'restricted'
-        expect(entry.parsed_metadata['file_2']).to end_with 'nypl-hydra-of-lerna.jpg'
-        expect(entry.parsed_metadata['file_visibility_2']).to eq 'open'
-        expect(entry.parsed_metadata['file_3']).to end_with 'nypl-hydra-of-lerna.jpg'
-        expect(entry.parsed_metadata['file_visibility_3']).to eq 'embargo'
-        expect(entry.parsed_metadata['file_embargo_release_date_3']).to eq '2029-07-01'
-        expect(entry.parsed_metadata['file_visibility_during_embargo_3']).to eq 'authenticated'
-        expect(entry.parsed_metadata['file_visibility_after_embargo_3']).to eq 'open'
+        expect(entry.parsed_metadata["visibility"]).to eq "open"
+        expect(entry.parsed_metadata["file_1"]).to end_with "nypl-hydra-of-lerna.jpg"
+        expect(entry.parsed_metadata["file_visibility_1"]).to eq "restricted"
+        expect(entry.parsed_metadata["file_2"]).to end_with "nypl-hydra-of-lerna.jpg"
+        expect(entry.parsed_metadata["file_visibility_2"]).to eq "open"
+        expect(entry.parsed_metadata["file_3"]).to end_with "nypl-hydra-of-lerna.jpg"
+        expect(entry.parsed_metadata["file_visibility_3"]).to eq "embargo"
+        expect(entry.parsed_metadata["file_embargo_release_date_3"]).to eq "2029-07-01"
+        expect(entry.parsed_metadata["file_visibility_during_embargo_3"]).to eq "authenticated"
+        expect(entry.parsed_metadata["file_visibility_after_embargo_3"]).to eq "open"
       end
     end
   end

--- a/spec/features/bulkrax_import_spec.rb
+++ b/spec/features/bulkrax_import_spec.rb
@@ -1,20 +1,20 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Bulkrax import', clean: true, perform_enqueued: true do
-  let(:user) { create(:user, email: 'test@example.com') }
+RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
+  let(:user) { create(:user, email: "test@example.com") }
   # let! is needed below to ensure that this user is created for file attachment because this is the depositor in the CSV fixtures
-  let!(:depositor) { create(:user, email: 'batchuser@example.com') }
+  let!(:depositor) { create(:user, email: "batchuser@example.com") }
   let(:importer) do
     create(:bulkrax_importer_csv,
            user: user,
            field_mapping: Bulkrax.field_mappings["HykuAddons::CsvParser"],
            parser_klass: "HykuAddons::CsvParser",
-           parser_fields: { 'import_file_path' => import_batch_file },
+           parser_fields: { "import_file_path" => import_batch_file },
            limit: 0)
   end
-  let(:import_batch_file) { 'spec/fixtures/csv/pacific_articles.metadata.csv' }
+  let(:import_batch_file) { "spec/fixtures/csv/pacific_articles.metadata.csv" }
   # let(:field_mapping) do
   #   {
   #     "date_published" => { "from" => ["date_published"], "split" => true, "parsed" => true, "if" => nil, "excluded" => false },
@@ -30,25 +30,25 @@ RSpec.describe 'Bulkrax import', clean: true, perform_enqueued: true do
     allow(Hyrax::Hirmeos::HirmeosFileUpdaterJob).to receive(:perform_later)
   end
 
-  describe 'import works' do
+  describe "import works" do
     before do
       importer.import_collections
     end
 
-    it 'imports works' do
+    it "imports works" do
       expect { importer.import_works }.to change { PacificArticle.count }.by(2)
     end
 
-    it 'populates all fields' do
+    it "populates all fields" do
       importer.import_works
-      work = PacificArticle.find('c109b1ff-6d9a-4498-b86c-190e7dcbe2e0')
+      work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
       expect(work.title).to eq ["Bourdieu's Art"]
       expect(work.date_published).to eq "2010-1-1"
       expect(work.resource_type).to eq ["Research Article"]
       expect(work.subject).to eq ["Social Sciences", "Performing arts", "Music"]
       expect(work.license).to eq ["https://commons.pacificu.edu/rights"]
-      expect(work.publisher).to eq ['Pacific University Press', 'Ubiquity Press']
-      expect(work.depositor).to eq 'batchuser@example.com'
+      expect(work.publisher).to eq ["Pacific University Press", "Ubiquity Press"]
+      expect(work.depositor).to eq "batchuser@example.com"
 
       creators = JSON.parse(work.creator.first)
       creator = creators.first
@@ -62,14 +62,14 @@ RSpec.describe 'Bulkrax import', clean: true, perform_enqueued: true do
     end
 
     context "for an articles" do
-      let(:account) { FactoryBot.create(:account, locale_name: 'anschutz') }
-      let(:import_batch_file) { 'spec/fixtures/csv/anschutz.csv' }
+      let(:account) { FactoryBot.create(:account, locale_name: "anschutz") }
+      let(:import_batch_file) { "spec/fixtures/csv/anschutz.csv" }
 
       before do
         Site.update(account: account)
       end
 
-      it 'populates the fields' do
+      it "populates the fields" do
         importer.import_works
         work = AnschutzWork.last
         %w[advisor mesh subject_text citation references medium comittee_member time qualification_subject_text add_info].each do |field|
@@ -79,136 +79,136 @@ RSpec.describe 'Bulkrax import', clean: true, perform_enqueued: true do
       end
     end
 
-    context 'resource_type' do
-      let(:import_batch_file) { 'spec/fixtures/csv/generic_work.csv' }
+    context "resource_type" do
+      let(:import_batch_file) { "spec/fixtures/csv/generic_work.csv" }
 
-      it 'populates resource_type' do
+      it "populates resource_type" do
         importer.import_works
         work = GenericWork.last
         expect(work.resource_type).to eq ["Interactive resource"]
       end
     end
 
-    context 'language' do
-      let(:account) { FactoryBot.create(:account, locale_name: 'redlands') }
-      let(:import_batch_file) { 'spec/fixtures/csv/redlands_article.csv' }
+    context "language" do
+      let(:account) { FactoryBot.create(:account, locale_name: "redlands") }
+      let(:import_batch_file) { "spec/fixtures/csv/redlands_article.csv" }
 
       before do
         Site.update(account: account)
       end
 
-      it 'populates language' do
+      it "populates language" do
         importer.import_works
         work = RedlandsArticle.last
         expect(work.language).to eq ["eng", "ara", "zho", "fra", "rus", "spa", "Other"]
       end
     end
 
-    context 'with files' do
-      let(:import_batch_file) { 'spec/fixtures/csv/pacific_articles.csv' }
+    context "with files" do
+      let(:import_batch_file) { "spec/fixtures/csv/pacific_articles.csv" }
 
-      it 'is valid' do
+      it "is valid" do
         expect(importer.valid_import?).to eq true
-        expect(importer.parser.file_paths).to include 'spec/fixtures/csv/files/nypl-hydra-of-lerna.jpg'
+        expect(importer.parser.file_paths).to include "spec/fixtures/csv/files/nypl-hydra-of-lerna.jpg"
       end
 
-      it 'imports files' do
+      it "imports files" do
         # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
         ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
         importer.import_works
-        work = PacificArticle.find('c109b1ff-6d9a-4498-b86c-190e7dcbe2e0')
+        work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
         expect(work.file_sets.size).to eq 1
         expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
-        expect(work.file_sets.first.visibility).to eq 'open'
+        expect(work.file_sets.first.visibility).to eq "open"
       end
 
-      context 'with an alternate file path location' do
-        let(:path_to_files) { Rails.root.join('tmp', 'importer') }
+      context "with an alternate file path location" do
+        let(:path_to_files) { Rails.root.join("tmp", "importer") }
 
         before do
           allow(ENV).to receive(:[]).and_call_original
           allow(ENV).to receive(:[]).with("BULKRAX_FILE_PATH").and_return(path_to_files)
           FileUtils.mkdir_p path_to_files
-          FileUtils.cp_r 'spec/fixtures/csv/files/.', path_to_files
+          FileUtils.cp_r "spec/fixtures/csv/files/.", path_to_files
         end
 
         after do
           FileUtils.rm_rf path_to_files
         end
 
-        it 'is valid' do
+        it "is valid" do
           expect(importer.valid_import?).to eq true
           expect(importer.parser.file_paths).to include File.join(path_to_files, "nypl-hydra-of-lerna.jpg")
         end
 
-        it 'imports files' do
+        it "imports files" do
           # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
           ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
           importer.import_works
-          work = PacificArticle.find('c109b1ff-6d9a-4498-b86c-190e7dcbe2e0')
+          work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
           expect(work.file_sets.size).to eq 1
           expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
         end
       end
 
-      context 'file visibility' do
-        let(:import_batch_file) { 'spec/fixtures/csv/generic_work.file_set.csv' }
+      context "file visibility" do
+        let(:import_batch_file) { "spec/fixtures/csv/generic_work.file_set.csv" }
 
-        it 'imports files' do
+        it "imports files" do
           # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
           ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
           importer.import_works
           work = GenericWork.first
-          expect(work.visibility).to eq 'open'
+          expect(work.visibility).to eq "open"
           expect(work.file_sets.size).to eq 3
           expect(work.ordered_members.to_a.first.title).to eq ["Lerna"]
-          expect(work.ordered_members.to_a.first.visibility).to eq 'restricted'
-          expect(work.ordered_members.to_a.second.visibility).to eq 'open'
+          expect(work.ordered_members.to_a.first.visibility).to eq "restricted"
+          expect(work.ordered_members.to_a.second.visibility).to eq "open"
           expect(work.ordered_members.to_a.second.title).to eq ["nypl-hydra-of-lerna.jpg"]
-          expect(work.ordered_members.to_a.third.visibility).to eq 'authenticated'
-          expect(work.ordered_members.to_a.third.embargo_release_date).to eq '2029-07-01'
-          expect(work.ordered_members.to_a.third.visibility_after_embargo).to eq 'open'
+          expect(work.ordered_members.to_a.third.visibility).to eq "authenticated"
+          expect(work.ordered_members.to_a.third.embargo_release_date).to eq "2029-07-01"
+          expect(work.ordered_members.to_a.third.visibility_after_embargo).to eq "open"
         end
       end
     end
   end
 
-  describe 'import collections' do
-    it 'creates collections' do
+  describe "import collections" do
+    it "creates collections" do
       importer.import_collections
-      expect(Collection.exists?('e51dbdd3-11bd-47f6-b00a-8aace969f2ab')).to eq true
+      expect(Collection.exists?("e51dbdd3-11bd-47f6-b00a-8aace969f2ab")).to eq true
     end
   end
 
-  describe 'full import' do
-    it 'creates collections and works' do
+  describe "full import" do
+    it "creates collections and works" do
       expect { Bulkrax::ImporterJob.perform_now(importer.id) }.to change { Collection.count }.by(2).and change { PacificArticle.count }.by(2)
       # Check that created works are in created collection
-      collection = Collection.find('e51dbdd3-11bd-47f6-b00a-8aace969f2ab')
-      work = PacificArticle.find('c109b1ff-6d9a-4498-b86c-190e7dcbe2e0')
+      collection = Collection.find("e51dbdd3-11bd-47f6-b00a-8aace969f2ab")
+      work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
       expect(work.member_of_collections).to include collection
 
       # Check that other work is created
-      work_with_multiple_collections = PacificArticle.find('54237483-f9d9-4b03-8867-812eb58bd4ac')
-      other_collection = Collection.find('bedd7330-5040-4687-8226-0851f7256dff')
+      work_with_multiple_collections = PacificArticle.find("54237483-f9d9-4b03-8867-812eb58bd4ac")
+      other_collection = Collection.find("bedd7330-5040-4687-8226-0851f7256dff")
       expect(work_with_multiple_collections.member_of_collections).to include other_collection
       expect(work_with_multiple_collections.member_of_collections).to include collection
     end
 
-    context 'with admin sets' do
-      let(:import_batch_file) { 'spec/fixtures/csv/pacific_articles.admin_set.csv' }
+    context "with admin sets" do
+      let(:import_batch_file) { "spec/fixtures/csv/pacific_articles.admin_set.csv" }
 
-      it 'imports admin sets, collections, and works' do
+      it "imports admin sets, collections, and works" do
         expect { Bulkrax::ImporterJob.perform_now(importer.id) }.to change { Collection.count }.by(2).and change { AdminSet.count }.by(1).and change { PacificArticle.count }.by(2)
-        expect(AdminSet.where(title: 'Default Admin Set').count).to eq 1
-        expect(AdminSet.where(title: 'History').count).to eq 1
+        expect(AdminSet.where(title: "Default Admin Set").count).to eq 1
+        expect(AdminSet.where(title: "History").count).to eq 1
         # Check that created works are in created collection
-        default_admin_set = AdminSet.where(title: 'Default Admin Set').first
-        history_admin_set = AdminSet.where(title: 'History').first
-        default_collection = Collection.find('e51dbdd3-11bd-47f6-b00a-8aace969f2ab')
-        history_collection = Collection.find('bedd7330-5040-4687-8226-0851f7256dff')
-        work1 = PacificArticle.find('c109b1ff-6d9a-4498-b86c-190e7dcbe2e0')
-        work2 = PacificArticle.find('54237483-f9d9-4b03-8867-812eb58bd4ac')
+        default_admin_set = AdminSet.where(title: "Default Admin Set").first
+        history_admin_set = AdminSet.where(title: "History").first
+        default_collection = Collection.find("e51dbdd3-11bd-47f6-b00a-8aace969f2ab")
+        history_collection = Collection.find("bedd7330-5040-4687-8226-0851f7256dff")
+        work1 = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
+        work2 = PacificArticle.find("54237483-f9d9-4b03-8867-812eb58bd4ac")
         expect(work1.member_of_collections).to include default_collection
         expect(work1.admin_set).to eq default_admin_set
         expect(work2.member_of_collections).to include history_collection
@@ -217,12 +217,12 @@ RSpec.describe 'Bulkrax import', clean: true, perform_enqueued: true do
     end
   end
 
-  describe 'identifiers' do
-    context 'when only source_identifier is present' do
-      let(:import_batch_file) { 'spec/fixtures/csv/generic_work.csv' }
-      let(:source_identifier) { 'external-id-1' }
+  describe "identifiers" do
+    context "when only source_identifier is present" do
+      let(:import_batch_file) { "spec/fixtures/csv/generic_work.csv" }
+      let(:source_identifier) { "external-id-1" }
 
-      it 'mints a new id' do
+      it "mints a new id" do
         expect { Bulkrax::ImporterJob.perform_now(importer.id) }.to change { GenericWork.count }.by(1)
         work = GenericWork.where(source_identifier: source_identifier).first
         expect(work.id).not_to eq source_identifier
@@ -243,8 +243,8 @@ RSpec.describe 'Bulkrax import', clean: true, perform_enqueued: true do
     end
 
     context "when only source_identifier is present" do
-      let(:import_batch_file) { 'spec/fixtures/csv/generic_work.csv' }
-      let(:source_identifier) { 'external-id-1' }
+      let(:import_batch_file) { "spec/fixtures/csv/generic_work.csv" }
+      let(:source_identifier) { "external-id-1" }
 
       it "return the work imported" do
         Bulkrax::ImporterJob.perform_now(importer.id)

--- a/spec/features/create_admin_set_spec.rb
+++ b/spec/features/create_admin_set_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create an Admin Set', js: false, clean: true do
+RSpec.feature "Create an Admin Set", js: false, clean: true do
   let(:user_attributes) do
-    { email: 'test@example.com' }
+    { email: "test@example.com" }
   end
   let(:user) do
     User.new(user_attributes) { |u| u.save(validate: false) }
@@ -17,17 +17,17 @@ RSpec.feature 'Create an Admin Set', js: false, clean: true do
     login_as user
   end
 
-  it 'creates an admin set' do
+  it "creates an admin set" do
     # Go directly to the admin sets new form
-    visit '/admin/admin_sets/new'
+    visit "/admin/admin_sets/new"
 
     # Title
-    fill_in('Title', with: 'My Test Admin Set')
+    fill_in("Title", with: "My Test Admin Set")
 
-    click_button 'Save'
+    click_button "Save"
 
-    visit page.current_path.sub('/edit', '')
+    visit page.current_path.sub("/edit", "")
 
-    expect(page).to have_content('My Test Admin Set')
+    expect(page).to have_content("My Test Admin Set")
   end
 end

--- a/spec/features/create_anschutz_work_spec.rb
+++ b/spec/features/create_anschutz_work_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a AnschutzWork' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a AnschutzWork" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "anschutz_work" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Anschutz Work page' do
+  it "renders the new Anschutz Work page" do
     expect(page).to have_content "Add New Anschutz Work"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files" # switch tab
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions" # switch tab
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public') # This test is failing and works are not being saved as public, need to look into why
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public") # This test is failing and works are not being saved as public, need to look into why
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_article_spec.rb
+++ b/spec/features/create_article_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work Article`
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create an Article', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create an Article", js: false do
+  include_context "create work user context" do
     let(:work_type) { "article" }
 
     scenario do

--- a/spec/features/create_book_contribution_spec.rb
+++ b/spec/features/create_book_contribution_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a BookContribution', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a BookContribution", js: false do
+  include_context "create work user context" do
     let(:work_type) { "book_contribution" }
 
     scenario do

--- a/spec/features/create_book_spec.rb
+++ b/spec/features/create_book_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Book', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a Book", js: false do
+  include_context "create work user context" do
     let(:work_type) { "book" }
 
     scenario do

--- a/spec/features/create_collection_spec.rb
+++ b/spec/features/create_collection_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Collection', js: false, clean: true do
+RSpec.feature "Create a Collection", js: false, clean: true do
   let(:user) { FactoryBot.create(:admin) }
-  let(:collection_type) { Hyrax::CollectionType.create(title: 'test_collection_type') }
+  let(:collection_type) { Hyrax::CollectionType.create(title: "test_collection_type") }
 
   before do
     allow(Flipflop).to receive(:enabled?).and_return(false)
@@ -14,52 +14,52 @@ RSpec.feature 'Create a Collection', js: false, clean: true do
     login_as user
   end
 
-  it 'creates a collection without creator or contributor' do
-    visit '/dashboard'
+  it "creates a collection without creator or contributor" do
+    visit "/dashboard"
     click_link "Collections"
     click_link "New Collection"
 
     # Title
-    fill_in('Title', with: 'My Test Collection')
+    fill_in("Title", with: "My Test Collection")
 
-    click_button 'Save'
+    click_button "Save"
 
-    visit page.current_path.sub('/edit', '')
+    visit page.current_path.sub("/edit", "")
 
-    expect(page).to have_content('My Test Collection')
-    expect(page).not_to have_content('Creator')
-    expect(page).not_to have_content('Contributor')
+    expect(page).to have_content("My Test Collection")
+    expect(page).not_to have_content("Creator")
+    expect(page).not_to have_content("Contributor")
   end
 
-  it 'creates a collection with creator' do
-    visit '/dashboard'
+  it "creates a collection with creator" do
+    visit "/dashboard"
     click_link "Collections"
     click_link "New Collection"
 
     # Title
-    fill_in('Title', with: 'My Test Collection')
+    fill_in("Title", with: "My Test Collection")
 
     # Creator
-    select('Personal', from: 'collection_creator__creator_name_type')
-    fill_in('collection_creator__creator_family_name', with: 'Hawking')
-    fill_in('collection_creator__creator_given_name', with: 'Stephen')
-    fill_in('collection_creator__creator_orcid', with: '0000-0002-9079-593X')
-    select('Staff member', from: 'collection_creator__creator_institutional_relationship')
-    fill_in('collection_creator__creator_isni', with: '0000 0001 2103 4996')
+    select("Personal", from: "collection_creator__creator_name_type")
+    fill_in("collection_creator__creator_family_name", with: "Hawking")
+    fill_in("collection_creator__creator_given_name", with: "Stephen")
+    fill_in("collection_creator__creator_orcid", with: "0000-0002-9079-593X")
+    select("Staff member", from: "collection_creator__creator_institutional_relationship")
+    fill_in("collection_creator__creator_isni", with: "0000 0001 2103 4996")
 
-    click_button 'Save'
+    click_button "Save"
 
-    visit page.current_path.sub('/edit', '')
+    visit page.current_path.sub("/edit", "")
 
     # Title
-    expect(page).to have_content('My Test Collection')
+    expect(page).to have_content("My Test Collection")
 
     # Creator
-    expect(page).to have_content('Hawking, Stephen')
-    expect(page).to have_link('', href: 'https://orcid.org/0000-0002-9079-593X')
-    expect(page).to have_link('', href: 'https://isni.org/isni/0000000121034996')
+    expect(page).to have_content("Hawking, Stephen")
+    expect(page).to have_link("", href: "https://orcid.org/0000-0002-9079-593X")
+    expect(page).to have_link("", href: "https://isni.org/isni/0000000121034996")
 
-    expect(page).not_to have_content('Contributor')
+    expect(page).not_to have_content("Contributor")
   end
 
   context "when user is not an admin" do
@@ -67,26 +67,26 @@ RSpec.feature 'Create a Collection', js: false, clean: true do
     it "Does not display the collections link when the setting is off" do
       allow(Flipflop).to receive(:enabled?).with(:show_repository_objects_links).and_return(false)
 
-      visit '/dashboard'
+      visit "/dashboard"
       expect(page).not_to have_link("Collections")
     end
 
     it "Does display the collections link when the setting is on" do
       allow(Flipflop).to receive(:enabled?).with(:show_repository_objects_links).and_return(true)
-      visit '/dashboard'
+      visit "/dashboard"
       expect(page).to have_link("Collections")
     end
   end
   context "when user is an admin" do
     it "Displays the collections link when the setting is off" do
       allow(Flipflop).to receive(:enabled?).with(:show_repository_objects_links).and_return(false)
-      visit '/dashboard'
+      visit "/dashboard"
       expect(page).to have_link("Collections")
     end
 
     it "Does display the collections link when the setting is on" do
       allow(Flipflop).to receive(:enabled?).with(:show_repository_objects_links).and_return(true)
-      visit '/dashboard'
+      visit "/dashboard"
       expect(page).to have_link("Collections")
     end
   end

--- a/spec/features/create_conference_item_spec.rb
+++ b/spec/features/create_conference_item_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a ConferenceItem', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a ConferenceItem", js: false do
+  include_context "create work user context" do
     let(:work_type) { "conference_item" }
 
     scenario do

--- a/spec/features/create_dataset_spec.rb
+++ b/spec/features/create_dataset_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Dataset work', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a Dataset work", js: false do
+  include_context "create work user context" do
     let(:work_type) { "dataset" }
 
     scenario do

--- a/spec/features/create_denver_article_spec.rb
+++ b/spec/features/create_denver_article_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverArticle' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverArticle" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_article" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Article"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_book_chapter_spec.rb
+++ b/spec/features/create_denver_book_chapter_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverBookChapter' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverBookChapter" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_book_chapter" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Book Chapter"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_book_spec.rb
+++ b/spec/features/create_denver_book_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverBook' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverBook" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_book" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Book"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_dataset_spec.rb
+++ b/spec/features/create_denver_dataset_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverDataset' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverDataset" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_dataset" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Dataset"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_image_spec.rb
+++ b/spec/features/create_denver_image_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverImage' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverImage" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_image" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Image"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_map_spec.rb
+++ b/spec/features/create_denver_map_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverMap' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverMap" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_map" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Map"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_multimedia_spec.rb
+++ b/spec/features/create_denver_multimedia_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverMultimedia' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverMultimedia" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_multimedia" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Multimedia"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_presentation_material_spec.rb
+++ b/spec/features/create_denver_presentation_material_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverPresentationMaterial' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverPresentationMaterial" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_presentation_material" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Presentation Material"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_serial_publication_spec.rb
+++ b/spec/features/create_denver_serial_publication_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverSerialPublication' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverSerialPublication" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_serial_publication" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Serial Publication"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_denver_thesis_dissertation_capstone_spec.rb
+++ b/spec/features/create_denver_thesis_dissertation_capstone_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a DenverThesisDissertationCapstone' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a DenverThesisDissertationCapstone" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "denver_thesis_dissertation_capstone" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Denver Work page' do
+  it "renders the new Denver Work page" do
     expect(page).to have_content "Add New Denver Thesis Dissertation Capstone"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_exhibition_item_spec.rb
+++ b/spec/features/create_exhibition_item_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Exhibition Item work', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a Exhibition Item work", js: false do
+  include_context "create work user context" do
     let(:work_type) { "exhibition_item" }
 
     scenario do

--- a/spec/features/create_generic_work_spec.rb
+++ b/spec/features/create_generic_work_spec.rb
@@ -2,14 +2,14 @@
 
 # Generated via
 #  `rails generate hyrax:work GenericWork`
-require 'rails_helper'
+require "rails_helper"
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.describe 'Create a GenericWork', js: true, clean: true do
+RSpec.describe "Create a GenericWork", js: true, clean: true do
   include Warden::Test::Helpers
-  context 'a logged in user' do
+  context "a logged in user" do
     let(:user_attributes) do
-      { email: 'test@example.com' }
+      { email: "test@example.com" }
     end
     let(:user) do
       User.new(user_attributes) { |u| u.save(validate: false) }
@@ -19,7 +19,7 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
     let!(:workflow) do
       Sipity::Workflow.create!(
         active: true,
-        name: 'test-workflow',
+        name: "test-workflow",
         permission_template:
         permission_template
       )
@@ -54,14 +54,14 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
 
     before do
       # Create a single action that can be taken
-      Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+      Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
       # Grant the user access to deposit into the admin set.
       Hyrax::PermissionTemplateAccess.create!(
         permission_template_id: permission_template.id,
-        agent_type: 'user',
+        agent_type: "user",
         agent_id: user.user_key,
-        access: 'deposit'
+        access: "deposit"
       )
 
       # Stub Crossref funder request
@@ -70,8 +70,8 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       login_as user
     end
 
-    it 'persists a new work with only required fields' do
-      visit '/dashboard'
+    it "persists a new work with only required fields" do
+      visit "/dashboard"
       click_link "Works"
       click_link "Add new work"
 
@@ -84,70 +84,70 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       page.find('a[href="#files"]').click
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
-      within('span#addfiles') do
-        attach_file("files[]", File.join(fixture_path, 'hyrax', 'image.jp2'), visible: false)
+      within("span#addfiles") do
+        attach_file("files[]", File.join(fixture_path, "hyrax", "image.jp2"), visible: false)
       end
       click_link "Descriptions" # switch tab
 
       # Title
-      fill_in('Title', with: 'My Test Work')
+      fill_in("Title", with: "My Test Work")
 
       # Creator
-      select('Personal', from: 'generic_work_creator__creator_name_type')
-      fill_in('generic_work_creator__creator_family_name', with: 'Hawking')
-      fill_in('generic_work_creator__creator_given_name', with: 'Stephen')
-      fill_in('generic_work_creator__creator_orcid', with: '000000029079593X')
-      select('Staff member', from: 'generic_work_creator__creator_institutional_relationship')
-      fill_in('generic_work_creator__creator_isni', with: '0000 0001 2103 4996')
+      select("Personal", from: "generic_work_creator__creator_name_type")
+      fill_in("generic_work_creator__creator_family_name", with: "Hawking")
+      fill_in("generic_work_creator__creator_given_name", with: "Stephen")
+      fill_in("generic_work_creator__creator_orcid", with: "000000029079593X")
+      select("Staff member", from: "generic_work_creator__creator_institutional_relationship")
+      fill_in("generic_work_creator__creator_isni", with: "0000 0001 2103 4996")
 
       # Resource type
-      select('Blog post', from: 'Resource type')
+      select("Blog post", from: "Resource type")
 
       # Institution
-      select('University of Virginia', from: 'Institution')
+      select("University of Virginia", from: "Institution")
 
       # With selenium and the chrome driver, focus remains on the
       # select box. Click outside the box so the next line can't find
       # its element
-      find('body').click
-      choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      check('agreement')
+      find("body").click
+      choose("generic_work_visibility_open")
+      expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
+      check("agreement")
 
       # Save
-      page.find('input[name=save_with_files]').click
+      page.find("input[name=save_with_files]").click
 
       ################
       # Check metadata fields render properly after save
       # Title
-      expect(page).to have_content('My Test Work')
+      expect(page).to have_content("My Test Work")
 
       # Visibility
-      expect(page).to have_content('Public')
+      expect(page).to have_content("Public")
 
       # Creator
-      expect(page).to have_content('Hawking, Stephen')
-      expect(page).to have_link('', href: 'https://orcid.org/0000-0002-9079-593X')
-      expect(page).to have_link('', href: 'https://isni.org/isni/0000000121034996')
+      expect(page).to have_content("Hawking, Stephen")
+      expect(page).to have_link("", href: "https://orcid.org/0000-0002-9079-593X")
+      expect(page).to have_link("", href: "https://isni.org/isni/0000000121034996")
 
       # Resource type
-      expect(page).to have_link('Blog post', href: /catalog\?f.*Bresource_type_sim.*Blog\+post/)
+      expect(page).to have_link("Blog post", href: /catalog\?f.*Bresource_type_sim.*Blog\+post/)
 
       # Institution
-      expect(page).to have_content('University of Virginia')
+      expect(page).to have_content("University of Virginia")
 
-      expect(page).not_to have_content('Contributor') # FIXME
-      expect(page).not_to have_content('Editor') # FIXME
-      expect(page).not_to have_content('Funder')
-      expect(page).not_to have_content('Current HE Institution')
-      expect(page).not_to have_content('Alternate identifier')
-      expect(page).not_to have_content('Related identifier')
+      expect(page).not_to have_content("Contributor") # FIXME
+      expect(page).not_to have_content("Editor") # FIXME
+      expect(page).not_to have_content("Funder")
+      expect(page).not_to have_content("Current HE Institution")
+      expect(page).not_to have_content("Alternate identifier")
+      expect(page).not_to have_content("Related identifier")
 
       expect(page).to have_content "Your files are being processed by Hyku in the background."
     end
 
-    it 'persists a new work with multi-part fields' do
-      visit '/dashboard'
+    it "persists a new work with multi-part fields" do
+      visit "/dashboard"
       click_link "Works"
       click_link "Add new work"
 
@@ -160,86 +160,86 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       page.find('a[href="#files"]').click
       expect(page).to have_content "Add files"
       expect(page).to have_content "Add folder"
-      within('span#addfiles') do
-        attach_file("files[]", File.join(fixture_path, 'hyrax', 'image.jp2'), visible: false)
-        attach_file("files[]", File.join(fixture_path, 'hyrax', 'jp2_fits.xml'), visible: false)
+      within("span#addfiles") do
+        attach_file("files[]", File.join(fixture_path, "hyrax", "image.jp2"), visible: false)
+        attach_file("files[]", File.join(fixture_path, "hyrax", "jp2_fits.xml"), visible: false)
       end
       click_link "Descriptions" # switch tab
       click_link "Additional fields" # expand form for additional fields
-      fill_in('Title', with: 'My Test Work')
+      fill_in("Title", with: "My Test Work")
 
       # Creator
-      select('Personal', from: 'generic_work_creator__creator_name_type')
-      fill_in('generic_work_creator__creator_family_name', with: 'Hawking')
-      fill_in('generic_work_creator__creator_given_name', with: 'Stephen')
-      fill_in('generic_work_creator__creator_orcid', with: '000000029079593X')
-      select('Staff member', from: 'generic_work_creator__creator_institutional_relationship')
-      fill_in('generic_work_creator__creator_isni', with: '0000 0001 2103 4996')
+      select("Personal", from: "generic_work_creator__creator_name_type")
+      fill_in("generic_work_creator__creator_family_name", with: "Hawking")
+      fill_in("generic_work_creator__creator_given_name", with: "Stephen")
+      fill_in("generic_work_creator__creator_orcid", with: "000000029079593X")
+      select("Staff member", from: "generic_work_creator__creator_institutional_relationship")
+      fill_in("generic_work_creator__creator_isni", with: "0000 0001 2103 4996")
 
       # Resource type
-      select('Blog post', from: 'Resource type')
+      select("Blog post", from: "Resource type")
 
       # Alternative title
-      fill_in('Alt title', with: 'All fields test')
+      fill_in("Alt title", with: "All fields test")
 
       # Contributor
-      select('Personal', from: 'generic_work_contributor__contributor_name_type')
-      fill_in('generic_work_contributor__contributor_family_name', with: 'Jones')
-      fill_in('generic_work_contributor__contributor_given_name', with: 'James Earl')
-      fill_in('generic_work_contributor__contributor_isni', with: '0000 0001 2030 4456')
-      select('Narrator', from: 'generic_work_contributor__contributor_type')
+      select("Personal", from: "generic_work_contributor__contributor_name_type")
+      fill_in("generic_work_contributor__contributor_family_name", with: "Jones")
+      fill_in("generic_work_contributor__contributor_given_name", with: "James Earl")
+      fill_in("generic_work_contributor__contributor_isni", with: "0000 0001 2030 4456")
+      select("Narrator", from: "generic_work_contributor__contributor_type")
 
       # Abstract
-      fill_in('Abstract', with: 'Testing all fields persist and render')
+      fill_in("Abstract", with: "Testing all fields persist and render")
 
       # Date published
-      select('2021', from: 'generic_work_date_published__date_published_year')
-      select('01', from: 'generic_work_date_published__date_published_month')
-      select('01', from: 'generic_work_date_published__date_published_day')
+      select("2021", from: "generic_work_date_published__date_published_year")
+      select("01", from: "generic_work_date_published__date_published_month")
+      select("01", from: "generic_work_date_published__date_published_day")
 
       # Media
-      fill_in('Media', with: "video")
+      fill_in("Media", with: "video")
 
       # Duration
-      fill_in('Duration', with: '6 minutes')
+      fill_in("Duration", with: "6 minutes")
 
       # Institution
-      select('University of Virginia', from: 'Institution')
+      select("University of Virginia", from: "Institution")
 
       # Organizational unit
-      fill_in('Organisational Unit', with: 'Repositories team')
+      fill_in("Organisational Unit", with: "Repositories team")
 
       # Project name
-      fill_in('Project name', with: 'Project Hydra')
+      fill_in("Project name", with: "Project Hydra")
 
       # Funder
       # TODO: Test autocomplete
-      fill_in('generic_work_funder__funder_name', with: 'Japan Foundation, London')
-      fill_in('generic_work_funder__funder_doi', with: 'http://dx.doi.org/10.13039/100008699')
-      fill_in('generic_work_funder__funder_isni', with: '0000 0004 0516 7766')
-      fill_in('generic_work_funder__funder_ror', with: 'https://ror.org/024jbvq59')
-      fill_in('generic_work_funder__funder_award_', with: 'ABC-12345')
+      fill_in("generic_work_funder__funder_name", with: "Japan Foundation, London")
+      fill_in("generic_work_funder__funder_doi", with: "http://dx.doi.org/10.13039/100008699")
+      fill_in("generic_work_funder__funder_isni", with: "0000 0004 0516 7766")
+      fill_in("generic_work_funder__funder_ror", with: "https://ror.org/024jbvq59")
+      fill_in("generic_work_funder__funder_award_", with: "ABC-12345")
 
       # Event title
 
       # Event location
 
       # Event date
-      select('2020', from: 'generic_work_event_date__event_date_year')
-      select('12', from: 'generic_work_event_date__event_date_month')
-      select('25', from: 'generic_work_event_date__event_date_day')
+      select("2020", from: "generic_work_event_date__event_date_year")
+      select("12", from: "generic_work_event_date__event_date_month")
+      select("25", from: "generic_work_event_date__event_date_day")
 
       # Series name
 
       # Book title
 
       # Editor
-      select('Personal', from: 'generic_work_editor__editor_name_type')
-      fill_in('generic_work_editor__editor_isni', with: '0000 0001 2103 5000')
-      fill_in('generic_work_editor__editor_orcid', with: '0000-0002-9079-600X')
-      fill_in('generic_work_editor__editor_family_name', with: 'Curry')
-      fill_in('generic_work_editor__editor_given_name', with: 'Timothy')
-      select('Staff member', from: 'generic_work_editor__editor_institutional_relationship')
+      select("Personal", from: "generic_work_editor__editor_name_type")
+      fill_in("generic_work_editor__editor_isni", with: "0000 0001 2103 5000")
+      fill_in("generic_work_editor__editor_orcid", with: "0000-0002-9079-600X")
+      fill_in("generic_work_editor__editor_family_name", with: "Curry")
+      fill_in("generic_work_editor__editor_given_name", with: "Timothy")
+      select("Staff member", from: "generic_work_editor__editor_institutional_relationship")
 
       # Journal title
       # Alternative journal title
@@ -257,17 +257,17 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
 
       # Current HE institution
       # TODO test autocomplete
-      select('Abertay University', from: 'generic_work_current_he_institution__current_he_institution_name')
+      select("Abertay University", from: "generic_work_current_he_institution__current_he_institution_name")
 
       # Date accepted
-      select('2020', from: 'generic_work_date_accepted__date_accepted_year')
-      select('12', from: 'generic_work_date_accepted__date_accepted_month')
-      select('31', from: 'generic_work_date_accepted__date_accepted_day')
+      select("2020", from: "generic_work_date_accepted__date_accepted_year")
+      select("12", from: "generic_work_date_accepted__date_accepted_month")
+      select("31", from: "generic_work_date_accepted__date_accepted_day")
 
       # Date submitted
-      select('2020', from: 'generic_work_date_submitted__date_submitted_year')
-      select('12', from: 'generic_work_date_submitted__date_submitted_month')
-      select('30', from: 'generic_work_date_submitted__date_submitted_day')
+      select("2020", from: "generic_work_date_submitted__date_submitted_year")
+      select("12", from: "generic_work_date_submitted__date_submitted_month")
+      select("30", from: "generic_work_date_submitted__date_submitted_day")
 
       # Official URL
       # Related URL
@@ -275,13 +275,13 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # Related exhibition venue
 
       # Related exhibition date
-      select('2021', from: 'generic_work_related_exhibition_date__related_exhibition_date_year')
-      select('01', from: 'generic_work_related_exhibition_date__related_exhibition_date_month')
-      select('04', from: 'generic_work_related_exhibition_date__related_exhibition_date_day')
+      select("2021", from: "generic_work_related_exhibition_date__related_exhibition_date_year")
+      select("01", from: "generic_work_related_exhibition_date__related_exhibition_date_month")
+      select("04", from: "generic_work_related_exhibition_date__related_exhibition_date_day")
 
       # Language
       # License
-      select('CC BY 4.0 Attribution', from: 'generic_work_license')
+      select("CC BY 4.0 Attribution", from: "generic_work_license")
       # TODO?
 
       # Rights statement
@@ -291,25 +291,25 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # DOI
 
       # Qualification name
-      select('Doctor of Philosophy', from: 'generic_work_qualification_name')
+      select("Doctor of Philosophy", from: "generic_work_qualification_name")
 
       # Qualification level
-      select('Doctoral', from: 'generic_work_qualification_level')
+      select("Doctoral", from: "generic_work_qualification_level")
 
       # Alternate identifier
-      fill_in('generic_work_alternate_identifier__alternate_identifier', with: 'CD12345')
-      fill_in('generic_work_alternate_identifier__alternate_identifier_type', with: 'Local CD IDs')
+      fill_in("generic_work_alternate_identifier__alternate_identifier", with: "CD12345")
+      fill_in("generic_work_alternate_identifier__alternate_identifier_type", with: "Local CD IDs")
 
       # Related identifier
-      fill_in('generic_work_related_identifier__related_identifier', with: '978-3-16-148410-0')
-      select('ISBN', from: 'generic_work_related_identifier__related_identifier_type')
-      select('Cites', from: 'generic_work_related_identifier__relation_type')
+      fill_in("generic_work_related_identifier__related_identifier", with: "978-3-16-148410-0")
+      select("ISBN", from: "generic_work_related_identifier__related_identifier_type")
+      select("Cites", from: "generic_work_related_identifier__relation_type")
 
       # Peer-reviewed (Refereed)
-      select('Peer-reviewed', from: 'generic_work_refereed')
+      select("Peer-reviewed", from: "generic_work_refereed")
 
       # Keywords
-      fill_in('Keyword', with: 'keyword_testing')
+      fill_in("Keyword", with: "keyword_testing")
 
       # Dewey
       # Library of Congress Classification
@@ -317,86 +317,86 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # Rendering ids
 
       # Visibility
-      select('In Copyright', from: 'Rights statement')
+      select("In Copyright", from: "Rights statement")
 
       # With selenium and the chrome driver, focus remains on the
       # select box. Click outside the box so the next line can't find
       # its element
-      find('body').click
-      choose('generic_work_visibility_open')
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
-      check('agreement')
+      find("body").click
+      choose("generic_work_visibility_open")
+      expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
+      check("agreement")
 
       # Save
-      page.find('input[name=save_with_files]').click
+      page.find("input[name=save_with_files]").click
 
       ################
       # Check metadata fields render properly after save
       # Title
-      expect(page).to have_content('My Test Work')
+      expect(page).to have_content("My Test Work")
 
       # Visibility
-      expect(page).to have_content('Public')
+      expect(page).to have_content("Public")
 
       # Creator
-      expect(page).to have_content('Hawking, Stephen')
-      expect(page).to have_link('', href: 'https://orcid.org/0000-0002-9079-593X')
-      expect(page).to have_link('', href: 'https://isni.org/isni/0000000121034996')
+      expect(page).to have_content("Hawking, Stephen")
+      expect(page).to have_link("", href: "https://orcid.org/0000-0002-9079-593X")
+      expect(page).to have_link("", href: "https://isni.org/isni/0000000121034996")
 
       # Resource type
-      expect(page).to have_link('Blog post', href: /catalog\?f.*Bresource_type_sim.*Blog\+post/)
+      expect(page).to have_link("Blog post", href: /catalog\?f.*Bresource_type_sim.*Blog\+post/)
 
       # Alternative title
-      expect(page).to have_content('All fields test')
+      expect(page).to have_content("All fields test")
 
       # Contributor
-      expect(page).to have_content('Jones, James Earl')
-      expect(page).to have_link('', href: 'https://isni.org/isni/0000000120304456')
+      expect(page).to have_content("Jones, James Earl")
+      expect(page).to have_link("", href: "https://isni.org/isni/0000000120304456")
 
       # Abstract
-      expect(page).to have_content('Testing all fields persist and render')
+      expect(page).to have_content("Testing all fields persist and render")
 
       # Date published
-      expect(page).to have_content('2021-1-1')
+      expect(page).to have_content("2021-1-1")
 
       # Media
-      expect(page).to have_content('video')
+      expect(page).to have_content("video")
 
       # Duration
-      expect(page).to have_content('6 minutes')
+      expect(page).to have_content("6 minutes")
 
       # Institution
-      expect(page).to have_content('University of Virginia')
+      expect(page).to have_content("University of Virginia")
 
       # Organizational unit
-      expect(page).to have_content('Repositories team')
+      expect(page).to have_content("Repositories team")
 
       # Project name
-      expect(page).to have_content('Project Hydra')
+      expect(page).to have_content("Project Hydra")
 
       # Funder
       # TODO: Test autocomplete
-      expect(page).to have_content('Japan Foundation, London')
-      expect(page).to have_content('http://dx.doi.org/10.13039/100008699')
-      expect(page).to have_content('0000 0004 0516 7766')
-      expect(page).to have_content('https://ror.org/024jbvq59')
-      expect(page).to have_content('ABC-12345')
+      expect(page).to have_content("Japan Foundation, London")
+      expect(page).to have_content("http://dx.doi.org/10.13039/100008699")
+      expect(page).to have_content("0000 0004 0516 7766")
+      expect(page).to have_content("https://ror.org/024jbvq59")
+      expect(page).to have_content("ABC-12345")
 
       # Event title
 
       # Event location
 
       # Event date
-      expect(page).to have_content('2020-12-25')
+      expect(page).to have_content("2020-12-25")
 
       # Series name
 
       # Book title
 
       # Editor
-      expect(page).to have_link('', href: 'https://isni.org/isni/0000000121035000')
-      expect(page).to have_link('', href: 'https://orcid.org/0000-0002-9079-600X')
-      expect(page).to have_content('Curry, Timothy')
+      expect(page).to have_link("", href: "https://isni.org/isni/0000000121035000")
+      expect(page).to have_link("", href: "https://orcid.org/0000-0002-9079-600X")
+      expect(page).to have_content("Curry, Timothy")
 
       # Journal title
       # Alternative journal title
@@ -413,15 +413,15 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # eISSN
 
       # Current HE institution
-      expect(page).to have_content('Abertay University')
+      expect(page).to have_content("Abertay University")
       # expect(page).to have_content('0000 0001 0339 8665')
       # expect(page).to have_content('https://ror.org/04mwwnx67')
 
       # Date accepted
-      expect(page).to have_content('2020-12-30')
+      expect(page).to have_content("2020-12-30")
 
       # Date submitted
-      expect(page).to have_content('2020-12-31')
+      expect(page).to have_content("2020-12-31")
 
       # Official URL
       # Related URL
@@ -429,11 +429,11 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # Related exhibition venue
 
       # Related exhibition date
-      expect(page).to have_content('2021-1-4')
+      expect(page).to have_content("2021-1-4")
 
       # Language
       # License
-      expect(page).to have_link('CC BY 4.0 Attribution', href: 'https://creativecommons.org/licenses/by/4.0/')
+      expect(page).to have_link("CC BY 4.0 Attribution", href: "https://creativecommons.org/licenses/by/4.0/")
       # TODO?
 
       # Rights statement
@@ -443,20 +443,20 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # DOI
 
       # Qualification name
-      expect(page).to have_content('PhD')
+      expect(page).to have_content("PhD")
 
       # Qualification level
-      expect(page).to have_content('Doctoral')
+      expect(page).to have_content("Doctoral")
 
       # Alternate identifier
-      expect(page).to have_content('CD12345')
-      expect(page).to have_content('Local CD IDs')
+      expect(page).to have_content("CD12345")
+      expect(page).to have_content("Local CD IDs")
 
       # Peer-reviewed
       # This isn't rendered on the show page currently
 
       # Keywords
-      expect(page).to have_content('keyword_testing')
+      expect(page).to have_content("keyword_testing")
 
       # Dewey
       # Library of Congress Classification
@@ -464,9 +464,9 @@ RSpec.describe 'Create a GenericWork', js: true, clean: true do
       # Rendering ids
 
       # Related identifier
-      expect(page).to have_content('978-3-16-148410-0')
-      expect(page).to have_content('ISBN')
-      expect(page).to have_content('Cites')
+      expect(page).to have_content("978-3-16-148410-0")
+      expect(page).to have_content("ISBN")
+      expect(page).to have_content("Cites")
 
       expect(page).to have_content "Your files are being processed by Hyku in the background."
     end

--- a/spec/features/create_image_spec.rb
+++ b/spec/features/create_image_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work Image`
-require 'rails_helper'
+require "rails_helper"
 
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Image', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a Image", js: false do
+  include_context "create work user context" do
     let(:work_type) { "image" }
 
     scenario do

--- a/spec/features/create_nsu_article_spec.rb
+++ b/spec/features/create_nsu_article_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a NsuArticle' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a NsuArticle" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "nsu_article" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new NSU Work page' do
+  it "renders the new NSU Work page" do
     expect(page).to have_content "Add New Nsu Article"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_nsu_generic_work_spec.rb
+++ b/spec/features/create_nsu_generic_work_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a NsuGenericWork' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a NsuGenericWork" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "nsu_generic_work" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new NSU Work page' do
+  it "renders the new NSU Work page" do
     expect(page).to have_content "Add New Nsu Generic Work"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_article_spec.rb
+++ b/spec/features/create_pacific_article_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificArticle' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificArticle" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_article" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Article"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_book_chapter_spec.rb
+++ b/spec/features/create_pacific_book_chapter_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificBookChapter' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificBookChapter" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_book_chapter" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Book Chapter"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_book_spec.rb
+++ b/spec/features/create_pacific_book_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificBook' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificBook" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_book" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Book"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_image_spec.rb
+++ b/spec/features/create_pacific_image_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificImage' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificImage" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_image" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Image"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_media_spec.rb
+++ b/spec/features/create_pacific_media_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificMedia' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificMedia" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_media" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Media"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_news_clipping_spec.rb
+++ b/spec/features/create_pacific_news_clipping_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificNewsClipping' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificNewsClipping" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_news_clipping" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific News Clipping"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_presentation_spec.rb
+++ b/spec/features/create_pacific_presentation_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificPresentation' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificPresentation" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_presentation" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Presentation"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_text_work_spec.rb
+++ b/spec/features/create_pacific_text_work_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificTextWork' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificTextWork" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_text_work" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Text Work"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_thesis_or_dissertation_spec.rb
+++ b/spec/features/create_pacific_thesis_or_dissertation_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificThesisOrDissertation' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificThesisOrDissertation" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_thesis_or_dissertation" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Thesis Or Dissertation"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_pacific_uncategorized_spec.rb
+++ b/spec/features/create_pacific_uncategorized_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a PacificUncategorized' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a PacificUncategorized" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "pacific_uncategorized" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Pacific Work page' do
+  it "renders the new Pacific Work page" do
     expect(page).to have_content "Add New Pacific Uncategorized"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_article_spec.rb
+++ b/spec/features/create_redlands_article_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsArticle' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsArticle" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_article" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Article"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_book_spec.rb
+++ b/spec/features/create_redlands_book_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsBook' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsBook" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_book" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Book"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_chapters_and_book_section_spec.rb
+++ b/spec/features/create_redlands_chapters_and_book_section_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsChaptersAndBookSection' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsChaptersAndBookSection" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_chapters_and_book_section" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Chapters And Book Section"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_conferences_reports_and_paper_spec.rb
+++ b/spec/features/create_redlands_conferences_reports_and_paper_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsConferencesReportsAndPaper' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsConferencesReportsAndPaper" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_conferences_reports_and_paper" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Conferences Reports And Paper"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_media_spec.rb
+++ b/spec/features/create_redlands_media_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsMedia' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsMedia" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_media" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Media"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_open_educational_resource_spec.rb
+++ b/spec/features/create_redlands_open_educational_resource_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsOpenEducationalResource' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsOpenEducationalResource" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_open_educational_resource" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Open Educational Resource"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_redlands_student_work_spec.rb
+++ b/spec/features/create_redlands_student_work_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a RedlandsStudentWork' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a RedlandsStudentWork" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "redlands_student_work" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Redlands Work page' do
+  it "renders the new Redlands Work page" do
     expect(page).to have_content "Add New Redlands Student Work"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_report_spec.rb
+++ b/spec/features/create_report_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Report work', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a Report work", js: false do
+  include_context "create work user context" do
     let(:work_type) { "report" }
 
     scenario do

--- a/spec/features/create_thesis_or_dissertation_spec.rb
+++ b/spec/features/create_thesis_or_dissertation_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work ThesisOrDissertation`
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a ThesisOrDissertation', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a ThesisOrDissertation", js: false do
+  include_context "create work user context" do
     let(:work_type) { "book" }
 
     scenario do

--- a/spec/features/create_time_based_media_spec.rb
+++ b/spec/features/create_time_based_media_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_work_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_work_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a Time Based Media Article', js: false do
-  include_context 'create work user context' do
+RSpec.feature "Create a Time Based Media Article", js: false do
+  include_context "create work user context" do
     let(:work_type) { "time_based_media" }
 
     scenario do

--- a/spec/features/create_ubiquity_template_work_spec.rb
+++ b/spec/features/create_ubiquity_template_work_spec.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../helpers/create_ubiquity_template_user_context', __dir__)
+require "rails_helper"
+require File.expand_path("../helpers/create_ubiquity_template_user_context", __dir__)
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UbiquityTemplateWork' do
-  include_context 'ubiquity template user context' do
+RSpec.feature "Create a UbiquityTemplateWork" do
+  include_context "ubiquity template user context" do
     let(:work_type) { "ubiquity_template_work" }
 
     scenario do

--- a/spec/features/create_una_archival_item_spec.rb
+++ b/spec/features/create_una_archival_item_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaArchivalItem' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaArchivalItem" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_archival_item" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new UNA Work page' do
+  it "renders the new UNA Work page" do
     expect(page).to have_content "Add New Una Archival Item"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_article_spec.rb
+++ b/spec/features/create_una_article_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaArticle' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaArticle" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_article" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new UNA Work page' do
+  it "renders the new UNA Work page" do
     expect(page).to have_content "Add New Una Article"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_book_spec.rb
+++ b/spec/features/create_una_book_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaBook' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaBook" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_book" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
@@ -26,36 +26,36 @@ RSpec.feature 'Create a UnaBook' do
     visit new_work_path
   end
 
-  it 'renders the new UNA Work page' do
+  it "renders the new UNA Work page" do
     expect(page).to have_content "Add New Una Book"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_chapters_and_book_section_spec.rb
+++ b/spec/features/create_una_chapters_and_book_section_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaChaptersAndBookSection' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaChaptersAndBookSection" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_chapters_and_book_section" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
@@ -26,36 +26,36 @@ RSpec.feature 'Create a UnaChaptersAndBookSection' do
     visit new_work_path
   end
 
-  it 'renders the new Una Work page' do
+  it "renders the new Una Work page" do
     expect(page).to have_content "Add New Una Chapters And Book Section"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_exhibition_spec.rb
+++ b/spec/features/create_una_exhibition_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaExhibition' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaExhibition" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_exhibition" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
@@ -26,36 +26,36 @@ RSpec.feature 'Create a UnaExhibition' do
     visit new_work_path
   end
 
-  it 'renders the new UNA Work page' do
+  it "renders the new UNA Work page" do
     expect(page).to have_content "Add New Una Exhibition"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_image_spec.rb
+++ b/spec/features/create_una_image_spec.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaImage' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaImage" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_image" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
@@ -26,36 +26,36 @@ RSpec.feature 'Create a UnaImage' do
     visit new_work_path
   end
 
-  it 'renders the new UNA Work page' do
+  it "renders the new UNA Work page" do
     expect(page).to have_content "Add New Una Image"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_presentation_spec.rb
+++ b/spec/features/create_una_presentation_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaPresentation' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaPresentation" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_presentation" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Una Work page' do
+  it "renders the new Una Work page" do
     expect(page).to have_content "Add New Una Presentation"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_thesis_or_dissertation_spec.rb
+++ b/spec/features/create_una_thesis_or_dissertation_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaThesisOrDissertation' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaThesisOrDissertation" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_thesis_or_dissertation" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Una Work page' do
+  it "renders the new Una Work page" do
     expect(page).to have_content "Add New Una Thesis Or Dissertation"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_una_time_based_media_spec.rb
+++ b/spec/features/create_una_time_based_media_spec.rb
@@ -1,61 +1,61 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UnaTimeBasedMedia' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UnaTimeBasedMedia" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "una_time_based_media" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new Una Work page' do
+  it "renders the new Una Work page" do
     expect(page).to have_content "Add New Una Time Based Media"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
-    find('body').click
+  it "applys work visibility" do
+    find("body").click
     choose("#{work_type}_visibility_open")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/create_uva_work_spec.rb
+++ b/spec/features/create_uva_work_spec.rb
@@ -1,62 +1,62 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Create a UvaWork' do
-  let(:user) { User.new(email: 'test@example.com') { |u| u.save(validate: false) } }
+RSpec.feature "Create a UvaWork" do
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
-  let(:workflow) { Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
   let(:work_type) { "uva_work" }
   let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
     visit new_work_path
   end
 
-  it 'renders the new UVA Work page' do
+  it "renders the new UVA Work page" do
     expect(page).to have_content "Add New Uva Work"
   end
 
-  it 'adds files to work' do
+  it "adds files to work" do
     click_link "Files"
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
-  it 'applys work visibility' do
+  it "applys work visibility" do
     visibility = :open
-    find('body').click
+    find("body").click
     choose("#{work_type}_visibility_#{visibility}")
 
-    expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+    expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
   end
 
-  it 'saves the work' do
+  it "saves the work" do
     click_link "Descriptions"
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/features/oai_pmh_spec.rb
+++ b/spec/features/oai_pmh_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "OAI PMH Support", type: :feature do
     work
   end
 
-  context 'oai interface with works present' do
+  context "oai interface with works present" do
     it "shows extended metadata"
   end
 end

--- a/spec/features/select_work_type_deposit_form.rb
+++ b/spec/features/select_work_type_deposit_form.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 include Warden::Test::Helpers
 
 # NOTE: If you generated more than one work, you have to set "js: true"
-RSpec.feature 'Select work type deposit form', js: true do
+RSpec.feature "Select work type deposit form", js: true do
   let(:user_attributes) do
-    { email: 'test@example.com' }
+    { email: "test@example.com" }
   end
   let(:user) do
     User.new(user_attributes) { |u| u.save(validate: false) }
@@ -14,27 +14,27 @@ RSpec.feature 'Select work type deposit form', js: true do
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
   let(:workflow) do
-    Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template)
+    Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template)
   end
   let(:work_type) { "book" }
   let(:human_work_type_name) { I18n.t("hyrax.select_type.#{work_type}.name") }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
   end
 
   scenario "Create popup", js: true do
-    visit '/dashboard'
+    visit "/dashboard"
     click_link "Works"
     click_link "Add new work"
     choose "payload_concern", option: work_type.to_s.camelize

--- a/spec/features/sign_up_settings_spec.rb
+++ b/spec/features/sign_up_settings_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Sign Up", type: :feature do
   let(:account) { FactoryBot.create(:account) }
@@ -9,38 +9,38 @@ RSpec.describe "Sign Up", type: :feature do
     Site.update(account: account)
   end
 
-  context 'with account signup enabled' do
+  context "with account signup enabled" do
     it "allows the user to create an account with a valid email format" do
-      visit '/users/sign_up'
-      fill_in 'user_display_name', with: "Test User"
-      fill_in 'user_email', with: "test@test.com"
-      fill_in 'user_password', with: "Potato123!"
-      fill_in 'user_password_confirmation', with: "Potato123!"
-      expect { click_on 'Create account' }.to change { User.count }.by(1)
+      visit "/users/sign_up"
+      fill_in "user_display_name", with: "Test User"
+      fill_in "user_email", with: "test@test.com"
+      fill_in "user_password", with: "Potato123!"
+      fill_in "user_password_confirmation", with: "Potato123!"
+      expect { click_on "Create account" }.to change { User.count }.by(1)
     end
 
     it "prevents users from creating an account without the correct email formats" do
-      visit '/users/sign_up'
-      fill_in 'user_display_name', with: "Test User"
-      fill_in 'user_email', with: "test@badformat.com"
-      fill_in 'user_password', with: "Potato123!"
-      fill_in 'user_password_confirmation', with: "Potato123!"
-      expect { click_on 'Create account' }.to change { User.count }.by(0)
-      expect(page).to have_content('Email must contain @pacificu.edu, @ubiquitypress.com, @test.com')
+      visit "/users/sign_up"
+      fill_in "user_display_name", with: "Test User"
+      fill_in "user_email", with: "test@badformat.com"
+      fill_in "user_password", with: "Potato123!"
+      fill_in "user_password_confirmation", with: "Potato123!"
+      expect { click_on "Create account" }.to change { User.count }.by(0)
+      expect(page).to have_content("Email must contain @pacificu.edu, @ubiquitypress.com, @test.com")
     end
   end
 
-  context 'with account signup diabled' do
-    it 'does not allow a user to create an account' do
+  context "with account signup diabled" do
+    it "does not allow a user to create an account" do
       account.allow_signup = "false"
       account.save!
-      visit '/users/sign_up'
+      visit "/users/sign_up"
       expect(page).to have_content("Account registration is disabled")
     end
   end
 
-  context 'default value' do
-    it 'defaults to true' do
+  context "default value" do
+    it "defaults to true" do
       expect(Account.new.allow_signup).to eq "true"
     end
   end

--- a/spec/forms/generic_work_form_spec.rb
+++ b/spec/forms/generic_work_form_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'hyrax/doi/spec/shared_specs'
+require "spec_helper"
+require "hyrax/doi/spec/shared_specs"
 
 RSpec.describe Hyrax::GenericWorkForm do
   let(:work) { GenericWork.new }
   let(:form) { described_class.new(work, nil, nil) }
 
-  it_behaves_like 'a DOI-enabled form'
-  it_behaves_like 'a DataCite DOI-enabled form'
+  it_behaves_like "a DOI-enabled form"
+  it_behaves_like "a DataCite DOI-enabled form"
 
   describe ".required_fields" do
     subject { form.required_fields }
@@ -50,35 +50,35 @@ RSpec.describe Hyrax::GenericWorkForm do
     let(:params) { ActionController::Parameters.new(attributes) }
     let(:attributes) do
       {
-        title: ['foo'],
-        rendering_ids: ['file-set-id'],
-        abstract: 'abstract'
+        title: ["foo"],
+        rendering_ids: ["file-set-id"],
+        abstract: "abstract"
       }
     end
 
-    it 'permits parameters' do
-      expect(model_attributes['title']).to eq ['foo']
-      expect(model_attributes['rendering_ids']).to eq ['file-set-id']
-      expect(model_attributes['abstract']).to eq 'abstract'
+    it "permits parameters" do
+      expect(model_attributes["title"]).to eq ["foo"]
+      expect(model_attributes["rendering_ids"]).to eq ["file-set-id"]
+      expect(model_attributes["abstract"]).to eq "abstract"
     end
 
-    context '.model_attributes' do
+    context ".model_attributes" do
       let(:params) do
         ActionController::Parameters.new(
-          title: [''],
-          abstract: '',
-          keyword: [''],
-          license: [''],
-          on_behalf_of: 'Melissa'
+          title: [""],
+          abstract: "",
+          keyword: [""],
+          license: [""],
+          on_behalf_of: "Melissa"
         )
       end
 
-      it 'removes blank parameters' do
-        expect(model_attributes['title']).to be_empty
-        expect(model_attributes['abstract']).to be_nil
-        expect(model_attributes['license']).to be_empty
-        expect(model_attributes['keyword']).to be_empty
-        expect(model_attributes['on_behalf_of']).to eq 'Melissa'
+      it "removes blank parameters" do
+        expect(model_attributes["title"]).to be_empty
+        expect(model_attributes["abstract"]).to be_nil
+        expect(model_attributes["license"]).to be_empty
+        expect(model_attributes["keyword"]).to be_empty
+        expect(model_attributes["on_behalf_of"]).to eq "Melissa"
       end
     end
   end

--- a/spec/forms/hyku_addons/work_form_spec.rb
+++ b/spec/forms/hyku_addons/work_form_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe HykuAddons::WorkForm do
   let(:form) { form_class.new(work, nil, nil) }
@@ -11,7 +11,7 @@ RSpec.describe HykuAddons::WorkForm do
 
     it { is_expected.not_to include :admin_set_id }
 
-    context 'with simplified_admin_set_selection enabled' do
+    context "with simplified_admin_set_selection enabled" do
       before do
         allow(Flipflop).to receive(:enabled?).and_call_original
         allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(true)
@@ -20,13 +20,13 @@ RSpec.describe HykuAddons::WorkForm do
       it { is_expected.to include :admin_set_id }
     end
 
-    context 'with RedlandsArticle' do
+    context "with RedlandsArticle" do
       let(:form_class) { Hyrax::RedlandsArticleForm }
       let(:work) { RedlandsArticle.new }
 
       it { is_expected.not_to include :admin_set_id }
 
-      context 'with simplified_admin_set_selection enabled' do
+      context "with simplified_admin_set_selection enabled" do
         before do
           allow(Flipflop).to receive(:enabled?).and_call_original
           allow(Flipflop).to receive(:enabled?).with(:simplified_admin_set_selection).and_return(true)

--- a/spec/forms/hyrax/article_form_spec.rb
+++ b/spec/forms/hyrax/article_form_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work Article`
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::ArticleForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -33,7 +33,7 @@ RSpec.describe Hyrax::ArticleForm do
         common_params
       end
 
-      it 'permits parameters' do
+      it "permits parameters" do
         check_common_fields_presence
       end
     end

--- a/spec/forms/hyrax/book_contribution_form_spec.rb
+++ b/spec/forms/hyrax/book_contribution_form_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::BookContributionForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -33,7 +33,7 @@ RSpec.describe Hyrax::BookContributionForm do
         common_params.merge(editor_params)
       end
 
-      it 'permits parameters' do
+      it "permits parameters" do
         check_common_fields_presence
         check_attribute_group_presence(:editor, [:editor_isni, :editor_orcid, :editor_family_name, :editor_given_name])
       end

--- a/spec/forms/hyrax/book_form_spec.rb
+++ b/spec/forms/hyrax/book_form_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::BookForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::BookForm do
         common_params.merge(editor_params)
       end
 
-      it 'permits parameters' do
+      it "permits parameters" do
         check_common_fields_presence
         check_attribute_group_presence(:editor, [:editor_isni, :editor_orcid, :editor_family_name, :editor_given_name])
       end

--- a/spec/forms/hyrax/conference_item_form_spec.rb
+++ b/spec/forms/hyrax/conference_item_form_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::ConferenceItemForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::ConferenceItemForm do
         common_params.merge(editor_params, event_params, event_date_params)
       end
 
-      it 'permits parameters' do
+      it "permits parameters" do
         check_common_fields_presence
         check_attribute_group_presence(:editor, [:editor_isni, :editor_orcid, :editor_family_name, :editor_given_name])
         check_attribute_group_presence(:event_date, [:event_date_year, :event_date_month, :event_date_day])

--- a/spec/forms/hyrax/dataset_form_spec.rb
+++ b/spec/forms/hyrax/dataset_form_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::DatasetForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -31,12 +31,12 @@ RSpec.describe Hyrax::DatasetForm do
       let(:params) { ActionController::Parameters.new(attributes) }
       let(:attributes) do
         {
-          version_number: 'version_number',
-          place_of_publication: 'place_of_publication'
+          version_number: "version_number",
+          place_of_publication: "place_of_publication"
         }.merge(common_params)
       end
 
-      it 'permits parameters' do
+      it "permits parameters" do
         check_common_fields_presence
         %w[version_number place_of_publication].each do |attr|
           expect(model_attributes[attr]).to eq attr

--- a/spec/forms/hyrax/denver_book_chapter_form_spec.rb
+++ b/spec/forms/hyrax/denver_book_chapter_form_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::DenverBookChapterForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 

--- a/spec/forms/hyrax/denver_dataset_form_spec.rb
+++ b/spec/forms/hyrax/denver_dataset_form_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::DenverDatasetForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 

--- a/spec/forms/hyrax/denver_map_form_spec.rb
+++ b/spec/forms/hyrax/denver_map_form_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::DenverMapForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 

--- a/spec/forms/hyrax/exhibition_item_form_spec.rb
+++ b/spec/forms/hyrax/exhibition_item_form_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 # Generated via
 #  `rails generate hyrax:work BookContribution`
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::ExhibitionItemForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -34,7 +34,7 @@ RSpec.describe Hyrax::ExhibitionItemForm do
         common_params.merge(editor_params, event_params, event_date_params)
       end
 
-      it 'permits parameters' do
+      it "permits parameters" do
         check_common_fields_presence
         check_attribute_group_presence(:editor, [:editor_isni, :editor_orcid, :editor_family_name, :editor_given_name])
         check_attribute_group_presence(:event_date, [:event_date_year, :event_date_month, :event_date_day])

--- a/spec/forms/hyrax/report_form_spec.rb
+++ b/spec/forms/hyrax/report_form_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::ReportForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -37,7 +37,7 @@ RSpec.describe Hyrax::ReportForm do
         common_params
       end
 
-      it 'permits the default parameters' do
+      it "permits the default parameters" do
         check_common_fields_presence
       end
     end

--- a/spec/forms/hyrax/thesis_or_dissertation_form_spec.rb
+++ b/spec/forms/hyrax/thesis_or_dissertation_form_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::ThesisOrDissertationForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -36,7 +36,7 @@ RSpec.describe Hyrax::ThesisOrDissertationForm do
         common_params
       end
 
-      it 'permits the default parameters' do
+      it "permits the default parameters" do
         check_common_fields_presence
       end
     end

--- a/spec/forms/hyrax/time_based_media_form_spec.rb
+++ b/spec/forms/hyrax/time_based_media_form_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
-require 'rails_helper'
-require File.expand_path('../../helpers/work_forms_context', __dir__)
+require "rails_helper"
+require File.expand_path("../../helpers/work_forms_context", __dir__)
 
 RSpec.describe Hyrax::TimeBasedMediaForm do
-  include_context 'work forms context' do
+  include_context "work forms context" do
     describe "#required_fields" do
       subject { form.required_fields }
 
@@ -30,17 +30,17 @@ RSpec.describe Hyrax::TimeBasedMediaForm do
     let(:params) { ActionController::Parameters.new(attributes) }
     let(:attributes) do
       {
-        media: 'media',
-        duration: 'duration',
-        version: 'version',
-        publisher: 'publisher',
-        place_of_publication: 'place_of_publication',
-        official_url: 'official_url',
-        related_url: 'related_url'
+        media: "media",
+        duration: "duration",
+        version: "version",
+        publisher: "publisher",
+        place_of_publication: "place_of_publication",
+        official_url: "official_url",
+        related_url: "related_url"
       }.merge(common_params, editor_params, event_params, event_date_params)
     end
 
-    it 'permits parameters' do
+    it "permits parameters" do
       check_common_fields_presence
       check_attribute_group_presence(:event_date, [:event_date_year, :event_date_month, :event_date_day])
       %w[event_title event_location].each do |attr|

--- a/spec/forms/image_form_spec.rb
+++ b/spec/forms/image_form_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'hyrax/doi/spec/shared_specs'
+require "spec_helper"
+require "hyrax/doi/spec/shared_specs"
 
 RSpec.describe Hyrax::ImageForm do
   let(:work) { GenericWork.new }
   let(:form) { described_class.new(work, nil, nil) }
 
-  it_behaves_like 'a DOI-enabled form'
-  it_behaves_like 'a DataCite DOI-enabled form'
+  it_behaves_like "a DOI-enabled form"
+  it_behaves_like "a DataCite DOI-enabled form"
 
   describe ".required_fields" do
     subject { form.required_fields }
@@ -51,35 +51,35 @@ RSpec.describe Hyrax::ImageForm do
     let(:params) { ActionController::Parameters.new(attributes) }
     let(:attributes) do
       {
-        title: ['foo'],
-        rendering_ids: ['file-set-id'],
-        abstract: 'abstract'
+        title: ["foo"],
+        rendering_ids: ["file-set-id"],
+        abstract: "abstract"
       }
     end
 
-    it 'permits parameters' do
-      expect(model_attributes['title']).to eq ['foo']
-      expect(model_attributes['rendering_ids']).to eq ['file-set-id']
-      expect(model_attributes['abstract']).to eq 'abstract'
+    it "permits parameters" do
+      expect(model_attributes["title"]).to eq ["foo"]
+      expect(model_attributes["rendering_ids"]).to eq ["file-set-id"]
+      expect(model_attributes["abstract"]).to eq "abstract"
     end
 
-    context '.model_attributes' do
+    context ".model_attributes" do
       let(:params) do
         ActionController::Parameters.new(
-          title: [''],
-          abstract: '',
-          keyword: [''],
-          license: [''],
-          on_behalf_of: 'Melissa'
+          title: [""],
+          abstract: "",
+          keyword: [""],
+          license: [""],
+          on_behalf_of: "Melissa"
         )
       end
 
-      it 'removes blank parameters' do
-        expect(model_attributes['title']).to be_empty
-        expect(model_attributes['abstract']).to be_nil
-        expect(model_attributes['license']).to be_empty
-        expect(model_attributes['keyword']).to be_empty
-        expect(model_attributes['on_behalf_of']).to eq 'Melissa'
+      it "removes blank parameters" do
+        expect(model_attributes["title"]).to be_empty
+        expect(model_attributes["abstract"]).to be_nil
+        expect(model_attributes["license"]).to be_empty
+        expect(model_attributes["keyword"]).to be_empty
+        expect(model_attributes["on_behalf_of"]).to eq "Melissa"
       end
     end
   end

--- a/spec/generators/install_generator_spec.rb
+++ b/spec/generators/install_generator_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 # Generators are not automatically loaded by Rails
-require 'generators/hyku_addons/install_generator'
+require "generators/hyku_addons/install_generator"
 
 RSpec.describe HykuAddons::InstallGenerator, type: :generator do
   # Tell the generator where to put its output (what it thinks of as Rails.root)
@@ -12,7 +12,7 @@ RSpec.describe HykuAddons::InstallGenerator, type: :generator do
     prepare_destination
   end
 
-  it 'runs' do
+  it "runs" do
     run_generator
   end
 end

--- a/spec/helpers/create_ubiquity_template_user_context.rb
+++ b/spec/helpers/create_ubiquity_template_user_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-RSpec.shared_context 'ubiquity template user context' do
+RSpec.shared_context "ubiquity template user context" do
   let(:user_attributes) do
-    { email: 'test@example.com' }
+    { email: "test@example.com" }
   end
   let(:user) do
     User.new(user_attributes) { |u| u.save(validate: false) }
@@ -9,20 +9,20 @@ RSpec.shared_context 'ubiquity template user context' do
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
   let(:workflow) do
-    Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template)
+    Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template)
   end
   let(:work_type) { "generic_work" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
   end
@@ -36,37 +36,37 @@ RSpec.shared_context 'ubiquity template user context' do
     click_link "Files" # switch tab
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
   def add_metadata_to_work
     click_link "Descriptions" # switch tab
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    fill_in('Keyword', with: 'testing')
-    select('In Copyright', from: 'Rights statement')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    fill_in("Keyword", with: "testing")
+    select("In Copyright", from: "Rights statement")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
     select("British Library", from: "#{work_type}_institution")
     yield if block_given?
   end
 
   def apply_work_visibility(visibility = :open)
-    find('body').click
+    find("body").click
     choose("#{work_type}_visibility_#{visibility}")
     case visibility
     when :open
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
     end
   end
 
   def check_agreement_and_submit
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/helpers/create_work_user_context.rb
+++ b/spec/helpers/create_work_user_context.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
-RSpec.shared_context 'create work user context' do
+RSpec.shared_context "create work user context" do
   let(:user_attributes) do
-    { email: 'test@example.com' }
+    { email: "test@example.com" }
   end
   let(:user) do
     User.new(user_attributes) { |u| u.save(validate: false) }
@@ -9,20 +9,20 @@ RSpec.shared_context 'create work user context' do
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
   let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
   let(:workflow) do
-    Sipity::Workflow.create!(active: true, name: 'test-workflow', permission_template: permission_template)
+    Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template)
   end
   let(:work_type) { "generic_work" }
 
   before do
     # Create a single action that can be taken
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
 
     # Grant the user access to deposit into the admin set.
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
     login_as user
   end
@@ -36,37 +36,37 @@ RSpec.shared_context 'create work user context' do
     click_link "Files" # switch tab
     expect(page).to have_content "Add files"
     expect(page).to have_content "Add folder"
-    within('span#addfiles') do
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'image.jp2'), visible: false)
-      attach_file("files[]", Rails.root.join('spec', 'fixtures', 'hyrax', 'jp2_fits.xml'), visible: false)
+    within("span#addfiles") do
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "image.jp2"), visible: false)
+      attach_file("files[]", Rails.root.join("spec", "fixtures", "hyrax", "jp2_fits.xml"), visible: false)
     end
   end
 
   def add_metadata_to_work
     click_link "Descriptions" # switch tab
-    fill_in("#{work_type}_title", with: 'My Test Work')
-    fill_in('Keyword', with: 'testing')
-    select('In Copyright', from: 'Rights statement')
-    select('Organisational', from: "#{work_type}_creator__creator_name_type")
-    fill_in("#{work_type}_creator__creator_organization_name", with: 'Ubiquity Press')
+    fill_in("#{work_type}_title", with: "My Test Work")
+    fill_in("Keyword", with: "testing")
+    select("In Copyright", from: "Rights statement")
+    select("Organisational", from: "#{work_type}_creator__creator_name_type")
+    fill_in("#{work_type}_creator__creator_organization_name", with: "Ubiquity Press")
     select("British Library", from: "#{work_type}_institution")
     yield if block_given?
   end
 
   def apply_work_visibility(visibility = :open)
-    find('body').click
+    find("body").click
     choose("#{work_type}_visibility_#{visibility}")
     case visibility
     when :open
-      expect(page).to have_content('Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to')
+      expect(page).to have_content("Please note, making something visible to the world (i.e. marking this as Public) may be viewed as publishing which could impact your ability to")
     end
   end
 
   def check_agreement_and_submit
-    check('agreement')
-    click_on('Save')
-    expect(page).to have_content('My Test Work')
-    expect(page).to have_content('Public')
+    check("agreement")
+    click_on("Save")
+    expect(page).to have_content("My Test Work")
+    expect(page).to have_content("Public")
     expect(page).to have_content("Your files are being processed by Hyku in the background.")
   end
 

--- a/spec/helpers/cross_tenant_shared_search_helper_spec.rb
+++ b/spec/helpers/cross_tenant_shared_search_helper_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe HykuAddons::CrossTenantSharedSearchHelper do
   end
 
   describe "cross_tenant_shared_search_helper" do
-    context '#feature_for_display_in_proprietor_account_ui' do
+    context "#feature_for_display_in_proprietor_account_ui" do
       let(:proprietor_account_flipflop_features_list) { helper.feature_for_display_in_proprietor_account_ui }
 
       it "returns truthy" do
@@ -47,7 +47,7 @@ RSpec.describe HykuAddons::CrossTenantSharedSearchHelper do
 
       let(:uuid) { SecureRandom.uuid }
       let(:request) { instance_double(ActionDispatch::Request, port: 3000, protocol: "https://", host: account.cname) }
-      let(:attributes_hash) { { "id" => uuid, "has_model_ssim" => ['GenericWork'], "account_cname_tesim" => account.cname } }
+      let(:attributes_hash) { { "id" => uuid, "has_model_ssim" => ["GenericWork"], "account_cname_tesim" => account.cname } }
 
       it "returns #generate_work_url for production" do
         allow(Rails.env).to receive(:development?).and_return(false)

--- a/spec/helpers/user_with_work_context.rb
+++ b/spec/helpers/user_with_work_context.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 include Warden::Test::Helpers
 
-RSpec.shared_context 'user with work context' do
+RSpec.shared_context "user with work context" do
   let(:xml) { Nokogiri::XML(response.body) }
 
   let(:user)       { create(:user) }
   let(:account)    do
     create(:account,
-           name:   'example',
-           oai_admin_email: 'some@example.com',
-           oai_prefix:      'hyku.example.com',
+           name:   "example",
+           oai_admin_email: "some@example.com",
+           oai_prefix:      "hyku.example.com",
            oai_sample_identifier: work.id)
   end
-  let!(:work)      { create(:work, user: user, visibility: 'open') }
+  let!(:work)      { create(:work, user: user, visibility: "open") }
   let(:identifier) { work.id }
 
   before do

--- a/spec/helpers/work_forms_context.rb
+++ b/spec/helpers/work_forms_context.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-RSpec.shared_context 'work forms context' do
+RSpec.shared_context "work forms context" do
   let(:work) { described_class.model_class.new }
   let(:form) { described_class.new(work, nil, nil) }
 
@@ -37,22 +37,22 @@ RSpec.shared_context 'work forms context' do
 
   def common_params
     {
-      title: 'title',
+      title: "title",
       resource_type: described_class.model_class.to_s,
-      alternative_name: 'alternative_name',
-      institution: 'institution',
-      project_name: 'project_name',
-      abstract: 'abstract',
-      official_link: 'official_link',
-      language: 'language',
-      license: 'license',
-      rights_statement: 'rights_statement',
-      rights_holder: 'rights_holder',
-      doi: 'doi',
-      keywords: 'keywords',
-      dewey: 'dewey',
-      library_of_congress_classification: 'library_of_congress_classification',
-      add_info: 'add_info'
+      alternative_name: "alternative_name",
+      institution: "institution",
+      project_name: "project_name",
+      abstract: "abstract",
+      official_link: "official_link",
+      language: "language",
+      license: "license",
+      rights_statement: "rights_statement",
+      rights_holder: "rights_holder",
+      doi: "doi",
+      keywords: "keywords",
+      dewey: "dewey",
+      library_of_congress_classification: "library_of_congress_classification",
+      add_info: "add_info"
     }.merge(creator_params, contributor_params, date_published_params, funder_params, date_accepted_params,
             date_submitted_params, related_identifier_params, alternate_identifier_params)
   end
@@ -60,16 +60,16 @@ RSpec.shared_context 'work forms context' do
   def creator_params
     {
       creator: {
-        creator_organization_name: 'creator_organization_name',
-        creator_given_name: 'creator_given_name',
-        creator_name_type: 'creator_name_type',
-        creator_family_name: 'creator_family_name',
-        creator_orcid: 'creator_orcid',
-        creator_isni: 'creator_isni',
-        creator_ror: 'creator_ror',
-        creator_grid: 'creator_grid',
-        creator_wikidata: 'creator_wikidata',
-        creator_institutional_relationship: ['creator_institutional_relationship']
+        creator_organization_name: "creator_organization_name",
+        creator_given_name: "creator_given_name",
+        creator_name_type: "creator_name_type",
+        creator_family_name: "creator_family_name",
+        creator_orcid: "creator_orcid",
+        creator_isni: "creator_isni",
+        creator_ror: "creator_ror",
+        creator_grid: "creator_grid",
+        creator_wikidata: "creator_wikidata",
+        creator_institutional_relationship: ["creator_institutional_relationship"]
       }
     }
   end
@@ -77,17 +77,17 @@ RSpec.shared_context 'work forms context' do
   def contributor_params
     {
       contributor: {
-        contributor_organization_name: 'contributor_organization_name',
-        contributor_given_name: 'contributor_given_name',
-        contributor_name_type: 'contributor_name_type',
-        contributor_family_name: 'contributor_family_name',
-        contributor_orcid: 'contributor_orcid',
-        contributor_isni: 'contributor_isni',
-        contributor_ror: 'contributor_ror',
-        contributor_grid: 'contributor_grid',
-        contributor_wikidata: 'contributor_wikidata',
-        contributor_type: 'contributor_type',
-        contributor_institutional_relationship: ['contributor_institutional_relationship']
+        contributor_organization_name: "contributor_organization_name",
+        contributor_given_name: "contributor_given_name",
+        contributor_name_type: "contributor_name_type",
+        contributor_family_name: "contributor_family_name",
+        contributor_orcid: "contributor_orcid",
+        contributor_isni: "contributor_isni",
+        contributor_ror: "contributor_ror",
+        contributor_grid: "contributor_grid",
+        contributor_wikidata: "contributor_wikidata",
+        contributor_type: "contributor_type",
+        contributor_institutional_relationship: ["contributor_institutional_relationship"]
       }
     }
   end
@@ -95,9 +95,9 @@ RSpec.shared_context 'work forms context' do
   def date_accepted_params
     {
       date_accepted: {
-        date_accepted_year: 'date_accepted_year',
-        date_accepted_month: 'date_accepted_month',
-        date_accepted_day: 'date_accepted_day'
+        date_accepted_year: "date_accepted_year",
+        date_accepted_month: "date_accepted_month",
+        date_accepted_day: "date_accepted_day"
       }
     }
   end
@@ -105,9 +105,9 @@ RSpec.shared_context 'work forms context' do
   def date_published_params
     {
       date_published: {
-        date_published_year: 'date_published_year',
-        date_published_month: 'date_published_month',
-        date_published_day: 'date_published_day'
+        date_published_year: "date_published_year",
+        date_published_month: "date_published_month",
+        date_published_day: "date_published_day"
       }
     }
   end
@@ -115,9 +115,9 @@ RSpec.shared_context 'work forms context' do
   def date_submitted_params
     {
       date_submitted: {
-        date_submitted_year: 'date_submitted_year',
-        date_submitted_month: 'date_submitted_month',
-        date_submitted_day: 'date_submitted_day'
+        date_submitted_year: "date_submitted_year",
+        date_submitted_month: "date_submitted_month",
+        date_submitted_day: "date_submitted_day"
       }
     }
   end
@@ -125,12 +125,12 @@ RSpec.shared_context 'work forms context' do
   def editor_params
     {
       editor: {
-        editor_isni: 'editor_isni',
-        editor_orcid: 'editor_orcid',
-        editor_family_name: 'editor_family_name',
-        editor_given_name: 'editor_given_name',
-        editor_organisational_name: 'editor_organisational_name',
-        editor_institutional_relationship: 'editor_institutional_relationship'
+        editor_isni: "editor_isni",
+        editor_orcid: "editor_orcid",
+        editor_family_name: "editor_family_name",
+        editor_given_name: "editor_given_name",
+        editor_organisational_name: "editor_organisational_name",
+        editor_institutional_relationship: "editor_institutional_relationship"
       }
     }
   end
@@ -138,11 +138,11 @@ RSpec.shared_context 'work forms context' do
   def funder_params
     {
       funder: {
-        funder_isni: 'funder_isni',
-        funder_name: 'funder_name',
-        funder_doi: 'funder_doi',
-        funder_ror: 'funder_ror',
-        funder_award: ['funder_award']
+        funder_isni: "funder_isni",
+        funder_name: "funder_name",
+        funder_doi: "funder_doi",
+        funder_ror: "funder_ror",
+        funder_award: ["funder_award"]
       }
     }
   end
@@ -150,8 +150,8 @@ RSpec.shared_context 'work forms context' do
   def alternate_identifier_params
     {
       alternate_identifier: {
-        alternate_identifier: 'alternate_identifier',
-        alternate_identifier_type: 'alternate_identifier_type'
+        alternate_identifier: "alternate_identifier",
+        alternate_identifier_type: "alternate_identifier_type"
       }
     }
   end
@@ -159,32 +159,32 @@ RSpec.shared_context 'work forms context' do
   def related_identifier_params
     {
       related_identifier: {
-        related_identifier: 'related_identifier',
-        related_identifier_type: 'related_identifier_type',
-        relation_type: 'relation_type'
+        related_identifier: "related_identifier",
+        related_identifier_type: "related_identifier_type",
+        relation_type: "relation_type"
       }
     }
   end
 
   def event_params
     {
-      event_title: 'event_title',
-      event_location: 'event_location'
+      event_title: "event_title",
+      event_location: "event_location"
     }
   end
 
   def event_date_params
     {
       event_date: {
-        event_date_year: 'event_date_year',
-        event_date_month: 'event_date_month',
-        event_date_day: 'event_date_day'
+        event_date_year: "event_date_year",
+        event_date_month: "event_date_month",
+        event_date_day: "event_date_day"
       }
     }
   end
 
-  describe 'add_terms' do
-    context 'with no previous terms' do
+  describe "add_terms" do
+    context "with no previous terms" do
       around do |example|
         # Reset the class variable to avoid side effects in subsequent tests
         @terms = described_class.terms

--- a/spec/indexers/work_indexer_spec.rb
+++ b/spec/indexers/work_indexer_spec.rb
@@ -4,43 +4,43 @@ RSpec.describe WorkIndexer do
   let(:service) { described_class.new(work) }
   let(:creator) do
     [
-      { creator_family_name: 'Hawking', creator_given_name: 'Stephen', creator_organization_name: '' }
+      { creator_family_name: "Hawking", creator_given_name: "Stephen", creator_organization_name: "" }
     ].to_json
   end
   let(:contributor) do
     [
-      { contributor_family_name: 'Jones', contributor_given_name: 'James Earl', contributor_organization_name: '' }
+      { contributor_family_name: "Jones", contributor_given_name: "James Earl", contributor_organization_name: "" }
     ].to_json
   end
   let(:editor) do
     [
-      { editor_family_name: '', editor_given_name: '', editor_organization_name: 'University of Cambridge' }
+      { editor_family_name: "", editor_given_name: "", editor_organization_name: "University of Cambridge" }
     ].to_json
   end
   let(:work) { create(:work, creator: [creator], editor: [editor], contributor: [contributor]) }
 
   it "indexes the correct fields" do
-    expect(solr_document.fetch('creator_display_ssim')).to eq ["Hawking, Stephen"]
-    expect(solr_document.fetch('contributor_display_ssim')).to eq ["Jones, James Earl"]
-    expect(solr_document.fetch('editor_display_ssim')).to eq ["University of Cambridge"]
+    expect(solr_document.fetch("creator_display_ssim")).to eq ["Hawking, Stephen"]
+    expect(solr_document.fetch("contributor_display_ssim")).to eq ["Jones, James Earl"]
+    expect(solr_document.fetch("editor_display_ssim")).to eq ["University of Cambridge"]
   end
 
-  context 'with extra blankspace' do
+  context "with extra blankspace" do
     let(:contributor) do
       [
-        { contributor_family_name: 'Jones ', contributor_given_name: 'James Earl ', contributor_organization_name: '' }
+        { contributor_family_name: "Jones ", contributor_given_name: "James Earl ", contributor_organization_name: "" }
       ].to_json
     end
 
     it "indexes the correct fields" do
-      expect(solr_document.fetch('creator_display_ssim')).to eq ["Hawking, Stephen"]
-      expect(solr_document.fetch('contributor_display_ssim')).to eq ["Jones, James Earl"]
-      expect(solr_document.fetch('editor_display_ssim')).to eq ["University of Cambridge"]
+      expect(solr_document.fetch("creator_display_ssim")).to eq ["Hawking, Stephen"]
+      expect(solr_document.fetch("contributor_display_ssim")).to eq ["Jones, James Earl"]
+      expect(solr_document.fetch("editor_display_ssim")).to eq ["University of Cambridge"]
     end
   end
 
   context "account_cname_tesim" do
-    let(:account) { create(:account, cname: 'hyky-test.me') }
+    let(:account) { create(:account, cname: "hyky-test.me") }
 
     before do
       allow(Apartment::Tenant).to receive(:switch!).with(account.tenant) do |&block|

--- a/spec/jobs/import_mode_spec.rb
+++ b/spec/jobs/import_mode_spec.rb
@@ -2,9 +2,9 @@
 
 RSpec.describe HykuAddons::ImportMode, perform_enqueued_jobs: true do
   before do
-    allow(Apartment::Tenant).to receive(:current).and_return('x')
-    allow(Account).to receive(:find_by).with(tenant: 'x').and_return(account)
-    allow(Apartment::Tenant).to receive(:switch).with('x') do |&block|
+    allow(Apartment::Tenant).to receive(:current).and_return("x")
+    allow(Account).to receive(:find_by).with(tenant: "x").and_return(account)
+    allow(Apartment::Tenant).to receive(:switch).with("x") do |&block|
       block.call
     end
 
@@ -16,11 +16,11 @@ RSpec.describe HykuAddons::ImportMode, perform_enqueued_jobs: true do
       queue_as :test
     end
   end
-  let(:account) { FactoryBot.build(:account, name: 'moominU') }
+  let(:account) { FactoryBot.build(:account, name: "moominU") }
   let(:import_mode) { false }
 
-  describe 'queue_name' do
-    context 'with non_tenant_job' do
+  describe "queue_name" do
+    context "with non_tenant_job" do
       let(:job) do
         Class.new(ApplicationJob) do
           non_tenant_job
@@ -28,21 +28,21 @@ RSpec.describe HykuAddons::ImportMode, perform_enqueued_jobs: true do
         end
       end
 
-      it 'returns super if non_tenant_job' do
+      it "returns super if non_tenant_job" do
         expect(job.new.queue_name).to eq "test"
       end
     end
 
-    context 'when not in import mode' do
-      it 'returns super if not in import mode' do
+    context "when not in import mode" do
+      it "returns super if not in import mode" do
         expect(job.new.queue_name).to eq "test"
       end
     end
 
-    context 'when in import mode' do
+    context "when in import mode" do
       let(:import_mode) { true }
 
-      it 'returns special queue name if in import mode' do
+      it "returns special queue name if in import mode" do
         expect(job.new.queue_name).to eq "moominU_import_test"
       end
     end

--- a/spec/jobs/multitenant_exporter_job_spec.rb
+++ b/spec/jobs/multitenant_exporter_job_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 # Copied over from hyrax-doi as a sanity check that things are still working
 RSpec.describe HykuAddons::MultitenantExporterJob, type: :job do
@@ -12,7 +12,7 @@ RSpec.describe HykuAddons::MultitenantExporterJob, type: :job do
     allow(Bulkrax::ExporterJob).to receive(:perform_now)
   end
 
-  it 'switches into the account before delegating into Bulkrax::ExporterJob' do
+  it "switches into the account before delegating into Bulkrax::ExporterJob" do
     described_class.perform_now(account, 1)
     expect(AccountElevator).to have_received(:switch!)
     expect(Bulkrax::ExporterJob).to have_received(:perform_now)

--- a/spec/jobs/register_doi_job_spec.rb
+++ b/spec/jobs/register_doi_job_spec.rb
@@ -1,40 +1,40 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 # Copied over from hyrax-doi as a sanity check that things are still working
 RSpec.describe Hyrax::DOI::RegisterDOIJob, type: :job do
-  let(:work) { create(:work, visibility: 'open', doi_status_when_public: 'findable') }
+  let(:work) { create(:work, visibility: "open", doi_status_when_public: "findable") }
   let(:prefix) { "10.1234" }
   let(:suffix) { "abcdef" }
   let(:doi) { "#{prefix}/#{suffix}" }
   let(:response_body) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "doi", "mint_doi_return_body.json")) }
 
   before do
-    Rails.application.routes.default_url_options[:host] = 'example.com'
+    Rails.application.routes.default_url_options[:host] = "example.com"
     Hyrax.config.identifier_registrars = { datacite: Hyrax::DOI::DataCiteRegistrar }
     Hyrax::DOI::DataCiteRegistrar.mode = :test
     Hyrax::DOI::DataCiteRegistrar.prefix = prefix
-    Hyrax::DOI::DataCiteRegistrar.username = 'username'
-    Hyrax::DOI::DataCiteRegistrar.password = 'password'
+    Hyrax::DOI::DataCiteRegistrar.username = "username"
+    Hyrax::DOI::DataCiteRegistrar.password = "password"
 
     stub_request(:post, URI.join(Hyrax::DOI::DataCiteClient::TEST_BASE_URL, "dois"))
       .with(headers: { "Content-Type" => "application/vnd.api+json" },
-            basic_auth: ['username', 'password'],
+            basic_auth: ["username", "password"],
             body: "{\"data\":{\"type\":\"dois\",\"attributes\":{\"prefix\":\"#{prefix}\"}}}")
       .to_return(status: 201, body: response_body)
 
     stub_request(:put, URI.join(Hyrax::DOI::DataCiteClient::TEST_MDS_BASE_URL, "metadata/#{doi}"))
-      .with(headers: { 'Content-Type': 'application/xml;charset=UTF-8' },
-            basic_auth: ['username', 'password'])
+      .with(headers: { 'Content-Type': "application/xml;charset=UTF-8" },
+            basic_auth: ["username", "password"])
       .to_return(status: 201, body: "OK (#{doi})")
 
     stub_request(:put, URI.join(Hyrax::DOI::DataCiteClient::TEST_MDS_BASE_URL, "doi/#{doi}"))
-      .with(headers: { 'Content-Type': 'text/plain;charset=UTF-8' },
-            basic_auth: ['username', 'password'])
+      .with(headers: { 'Content-Type': "text/plain;charset=UTF-8" },
+            basic_auth: ["username", "password"])
       .to_return(status: 201, body: "")
   end
 
-  it 'mints a DOI' do
+  it "mints a DOI" do
     expect { described_class.perform_now(work, registrar: work.doi_registrar.presence, registrar_opts: work.doi_registrar_opts) }
       .to change { work.doi }
       .to eq [doi]

--- a/spec/lib/hyku_addons_spec.rb
+++ b/spec/lib/hyku_addons_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 RSpec.describe HykuAddons do
-  describe 'version' do
-    it 'is has a version' do
+  describe "version" do
+    it "is has a version" do
       expect(described_class::VERSION).to be_present
     end
   end

--- a/spec/lib/work_factory_spec.rb
+++ b/spec/lib/work_factory_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-require 'hyku_addons/work_factory'
-require 'rails_helper'
+require "hyku_addons/work_factory"
+require "rails_helper"
 
 RSpec.describe HykuAddons::WorkFactory do
   WebMock.allow_net_connect!
@@ -8,7 +8,7 @@ RSpec.describe HykuAddons::WorkFactory do
   let(:account) { build(:account) }
 
   before do
-    Rails.application.routes.default_url_options[:host] = 'localhost:3000'
+    Rails.application.routes.default_url_options[:host] = "localhost:3000"
     allow(Site).to receive(:account).and_return(account)
   end
 

--- a/spec/mailers/mailboxer/messages_mailer_spec.rb
+++ b/spec/mailers/mailboxer/messages_mailer_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Mailboxer::MessageMailer, clean: true, multitenant: true do
   let(:account) do
-    Account.create(name: 'test', cname: 'test.lvh.me', locale_name: 'test')
+    Account.create(name: "test", cname: "test.lvh.me", locale_name: "test")
   end
   let(:user) { create :user }
 

--- a/spec/mailers/per_tenant_smtp_mailers_spec.rb
+++ b/spec/mailers/per_tenant_smtp_mailers_spec.rb
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::ContactMailer, clean: true, multitenant: true do
   let(:contact_form) do
     Hyrax::ContactForm.new(
-      email: 'test@example.com',
-      category: 'Test',
-      subject: 'Test',
-      name: 'Test Tester',
-      message: 'This is a test'
+      email: "test@example.com",
+      category: "Test",
+      subject: "Test",
+      name: "Test Tester",
+      message: "This is a test"
     )
   end
   let(:mail_from) { "test@test.edu" }
@@ -17,23 +17,23 @@ RSpec.describe Hyrax::ContactMailer, clean: true, multitenant: true do
   describe "reset_password_instructions" do
     context "with per tenant SMTP" do
       let(:account) do
-        Account.create(name: 'test', cname: 'test.lvh.me', locale_name: 'test',
+        Account.create(name: "test", cname: "test.lvh.me", locale_name: "test",
                        settings: { smtp_settings: smtp_settings })
       end
       let(:mail) { described_class.contact(contact_form) }
       let(:smtp_settings) do
         {
-          from: 'test@test.edu',
-          address: 'test.edu',
-          user_name: 'username',
-          password: 'password',
-          authentication: 'login',
-          domain: 'test.custom_domain.com'
+          from: "test@test.edu",
+          address: "test.edu",
+          user_name: "username",
+          password: "password",
+          authentication: "login",
+          domain: "test.custom_domain.com"
         }
       end
 
       before do
-        allow(Site).to receive(:contact_email).and_return('me@example.com')
+        allow(Site).to receive(:contact_email).and_return("me@example.com")
 
         Settings.instance_eval do
           def smtp_settings; end
@@ -70,18 +70,18 @@ RSpec.describe Hyrax::ContactMailer, clean: true, multitenant: true do
       context "with a custom from alias" do
         let(:smtp_settings) do
           {
-            from: 'test@test.edu',
-            from_alias: 'Me',
-            address: 'test.edu',
-            user_name: 'username',
-            password: 'password',
-            authentication: 'login',
-            domain: 'test.custom_domain.com'
+            from: "test@test.edu",
+            from_alias: "Me",
+            address: "test.edu",
+            user_name: "username",
+            password: "password",
+            authentication: "login",
+            domain: "test.custom_domain.com"
           }
         end
 
         it "replaces the email headers" do
-          from_field = mail.header.fields.select { |f| f.name == 'From' }.first
+          from_field = mail.header.fields.select { |f| f.name == "From" }.first
           expect(from_field.value).to eq "Me <test@test.edu>"
         end
       end

--- a/spec/models/account_cross_search_spec.rb
+++ b/spec/models/account_cross_search_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe AccountCrossSearch, type: :model do
   it do
-    is_expected.to belong_to(:full_account).class_name('Account')
+    is_expected.to belong_to(:full_account).class_name("Account")
 
-    is_expected.to belong_to(:search_account).class_name('Account')
+    is_expected.to belong_to(:search_account).class_name("Account")
   end
 end

--- a/spec/models/account_spec.rb
+++ b/spec/models/account_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Account, type: :model do
   describe "The injected methods" do
-    subject(:account) { described_class.create(name: 'example', tenant: 'example', cname: 'example.com') }
+    subject(:account) { described_class.create(name: "example", tenant: "example", cname: "example.com") }
 
     it { described_class.respond_to?(:single_tenant_default) }
     it { account.respond_to?(:switch!) }
@@ -10,97 +10,97 @@ RSpec.describe Account, type: :model do
     it { account.respond_to?(:reset!) }
   end
 
-  describe 'Settings' do
-    let!(:account) { described_class.create(name: 'example', tenant: 'example', cname: 'example.com') }
+  describe "Settings" do
+    let!(:account) { described_class.create(name: "example", tenant: "example", cname: "example.com") }
 
     after do
       # FIXME: move this out to a global before/after?
       account.reset!
     end
 
-    it 'loads settings' do
+    it "loads settings" do
       account.switch!
       expect(Settings.google_analytics_id).to eq nil
     end
 
-    context 'with a settings.yml override' do
+    context "with a settings.yml override" do
       before do
-        account.update(locale_name: 'test')
-        allow(Settings).to receive(:tenant_settings_filename).with('test').and_return(HykuAddons::Engine.root.join('spec', 'fixtures', 'settings', 'test-TEST.yml'))
+        account.update(locale_name: "test")
+        allow(Settings).to receive(:tenant_settings_filename).with("test").and_return(HykuAddons::Engine.root.join("spec", "fixtures", "settings", "test-TEST.yml"))
       end
 
-      it 'loads settings' do
+      it "loads settings" do
         account.switch!
-        expect(Settings.google_analytics_id).to eq 'yml-id'
+        expect(Settings.google_analytics_id).to eq "yml-id"
       end
     end
 
-    context 'with environment variables' do
+    context "with environment variables" do
       before do
-        ENV['SETTINGS__GOOGLE_ANALYTICS_ID'] = 'env-id'
-        ENV['SETTINGS__OTHER_SETTING'] = 'moomin'
+        ENV["SETTINGS__GOOGLE_ANALYTICS_ID"] = "env-id"
+        ENV["SETTINGS__OTHER_SETTING"] = "moomin"
       end
 
       after do
-        ENV.delete('SETTINGS__GOOGLE_ANALYTICS_ID')
-        ENV.delete('SETTINGS__OTHER_SETTING')
+        ENV.delete("SETTINGS__GOOGLE_ANALYTICS_ID")
+        ENV.delete("SETTINGS__OTHER_SETTING")
       end
 
-      it 'loads settings' do
+      it "loads settings" do
         account.switch!
-        expect(Settings.google_analytics_id).to eq 'env-id'
-        expect(Settings.other_setting).to eq 'moomin'
+        expect(Settings.google_analytics_id).to eq "env-id"
+        expect(Settings.other_setting).to eq "moomin"
       end
 
-      context 'with locale_name' do
+      context "with locale_name" do
         before do
-          account.update(locale_name: 'test')
-          ENV['SETTINGS__TEST__GOOGLE_ANALYTICS_ID'] = 'env-test-id'
+          account.update(locale_name: "test")
+          ENV["SETTINGS__TEST__GOOGLE_ANALYTICS_ID"] = "env-test-id"
         end
 
         after do
-          ENV.delete('SETTINGS__TEST__GOOGLE_ANALYTICS_ID')
+          ENV.delete("SETTINGS__TEST__GOOGLE_ANALYTICS_ID")
         end
 
-        it 'loads settings' do
+        it "loads settings" do
           account.switch!
-          expect(Settings.google_analytics_id).to eq 'env-test-id'
+          expect(Settings.google_analytics_id).to eq "env-test-id"
         end
 
-        it 'still loads fallback settings' do
+        it "still loads fallback settings" do
           account.switch!
-          expect(Settings.other_setting).to eq 'moomin'
+          expect(Settings.other_setting).to eq "moomin"
         end
       end
     end
 
-    context 'with DB settings' do
+    context "with DB settings" do
       before do
-        account.settings['google_analytics_id'] = 'db-id'
+        account.settings["google_analytics_id"] = "db-id"
         account.save
       end
 
-      it 'loads settings' do
+      it "loads settings" do
         account.switch!
-        expect(Settings.google_analytics_id).to eq 'db-id'
+        expect(Settings.google_analytics_id).to eq "db-id"
       end
     end
 
-    describe 'tenant_settings_filename' do
-      it 'returns a standardized filename' do
+    describe "tenant_settings_filename" do
+      it "returns a standardized filename" do
         account.switch!
-        expect(Settings.tenant_settings_filename('test')).to eq Rails.root.join('config', 'settings', 'test-TEST.yml')
+        expect(Settings.tenant_settings_filename("test")).to eq Rails.root.join("config", "settings", "test-TEST.yml")
       end
     end
 
-    context 'Hyrax configuration' do
+    context "Hyrax configuration" do
       before do
-        account.settings['google_analytics_id'] = 'GA-TEST1234'
+        account.settings["google_analytics_id"] = "GA-TEST1234"
         account.save
       end
 
-      it 'dynamically loads google analytics id from Settings' do
-        expect { account.switch! }.to change { Hyrax.config.google_analytics_id }.to('GA-TEST1234')
+      it "dynamically loads google analytics id from Settings" do
+        expect { account.switch! }.to change { Hyrax.config.google_analytics_id }.to("GA-TEST1234")
       end
     end
   end

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe HykuAddons::AccountBehavior do
   subject(:account) { Account.new }
   let(:cache_enabled) { false }
-  describe '#switch!' do
+  describe "#switch!" do
     before do
-      account.build_solr_endpoint(url: 'http://example.com/solr/')
-      account.build_fcrepo_endpoint(url: 'http://example.com/fedora', base_path: '/dev')
-      account.build_redis_endpoint(namespace: 'foobaz')
-      account.build_datacite_endpoint(mode: 'test', prefix: '10.1234', username: 'user123', password: 'pass123')
+      account.build_solr_endpoint(url: "http://example.com/solr/")
+      account.build_fcrepo_endpoint(url: "http://example.com/fedora", base_path: "/dev")
+      account.build_redis_endpoint(namespace: "foobaz")
+      account.build_datacite_endpoint(mode: "test", prefix: "10.1234", username: "user123", password: "pass123")
       allow(Flipflop).to receive(:enabled?).with(:cache_api).and_return(cache_enabled)
       allow(Redis.current).to receive(:id).and_return "redis://localhost:6379/0"
       account.switch!
@@ -20,11 +20,11 @@ RSpec.describe HykuAddons::AccountBehavior do
       account.reset!
     end
 
-    it 'switches the DataCite connection' do
-      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq 'test'
-      expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq '10.1234'
-      expect(Hyrax::DOI::DataCiteRegistrar.username).to eq 'user123'
-      expect(Hyrax::DOI::DataCiteRegistrar.password).to eq 'pass123'
+    it "switches the DataCite connection" do
+      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq "test"
+      expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq "10.1234"
+      expect(Hyrax::DOI::DataCiteRegistrar.username).to eq "user123"
+      expect(Hyrax::DOI::DataCiteRegistrar.password).to eq "pass123"
       expect(Rails.application.routes.default_url_options[:host]).to eq account.cname
     end
 
@@ -55,7 +55,7 @@ RSpec.describe HykuAddons::AccountBehavior do
     end
   end
 
-  describe '#switch' do
+  describe "#switch" do
     let!(:previous_datacite_mode) { Hyrax::DOI::DataCiteRegistrar.mode }
     let!(:previous_datacite_prefix) { Hyrax::DOI::DataCiteRegistrar.prefix }
     let!(:previous_datacite_username) { Hyrax::DOI::DataCiteRegistrar.username }
@@ -63,27 +63,27 @@ RSpec.describe HykuAddons::AccountBehavior do
     let!(:previous_account_cname) { account.cname }
 
     before do
-      account.build_solr_endpoint(url: 'http://example.com/solr/')
-      account.build_fcrepo_endpoint(url: 'http://example.com/fedora', base_path: '/dev')
-      account.build_redis_endpoint(namespace: 'foobaz')
-      account.build_datacite_endpoint(mode: 'test', prefix: '10.1234', username: 'user123', password: 'pass123')
+      account.build_solr_endpoint(url: "http://example.com/solr/")
+      account.build_fcrepo_endpoint(url: "http://example.com/fedora", base_path: "/dev")
+      account.build_redis_endpoint(namespace: "foobaz")
+      account.build_datacite_endpoint(mode: "test", prefix: "10.1234", username: "user123", password: "pass123")
     end
 
     after do
       account.reset!
     end
 
-    it 'switches to the account-specific connection' do
+    it "switches to the account-specific connection" do
       account.switch do
-        expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq 'test'
-        expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq '10.1234'
-        expect(Hyrax::DOI::DataCiteRegistrar.username).to eq 'user123'
-        expect(Hyrax::DOI::DataCiteRegistrar.password).to eq 'pass123'
+        expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq "test"
+        expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq "10.1234"
+        expect(Hyrax::DOI::DataCiteRegistrar.username).to eq "user123"
+        expect(Hyrax::DOI::DataCiteRegistrar.password).to eq "pass123"
         expect(Rails.application.routes.default_url_options[:host]).to eq account.cname
       end
     end
 
-    it 'resets the active connections back to the defaults' do
+    it "resets the active connections back to the defaults" do
       account.switch do
         # no-op
       end
@@ -94,8 +94,8 @@ RSpec.describe HykuAddons::AccountBehavior do
       expect(Rails.application.routes.default_url_options[:host]).to eq previous_account_cname
     end
 
-    context 'with missing endpoint' do
-      it 'returns a NilDataCiteEndpoint' do
+    context "with missing endpoint" do
+      it "returns a NilDataCiteEndpoint" do
         account.datacite_endpoint = nil
         expect(account.datacite_endpoint).to be_kind_of NilDataCiteEndpoint
         expect(account.datacite_endpoint.persisted?).to eq false
@@ -110,58 +110,58 @@ RSpec.describe HykuAddons::AccountBehavior do
     end
   end
 
-  describe 'Settings Customisations' do
+  describe "Settings Customisations" do
     let(:account) { build(:account) }
-    context 'settings jsonb keys' do
-      it 'has contact_email key that is not empty' do
-        expect(account.settings['contact_email']).to eq 'abc@abc.com'
-        expect(account.settings['contact_email']).to be_an_instance_of(String)
+    context "settings jsonb keys" do
+      it "has contact_email key that is not empty" do
+        expect(account.settings["contact_email"]).to eq "abc@abc.com"
+        expect(account.settings["contact_email"]).to be_an_instance_of(String)
       end
 
       it "has key weekly_email_list" do
-        expect(account.settings['weekly_email_list']).to  eq ['aaa@aaa.com', 'bbb@bl.uk']
-        expect(account.settings['weekly_email_list']).to be_an_instance_of(Array)
+        expect(account.settings["weekly_email_list"]).to  eq ["aaa@aaa.com", "bbb@bl.uk"]
+        expect(account.settings["weekly_email_list"]).to be_an_instance_of(Array)
       end
 
       it "has non empty month_email_list" do
-        expect(account.settings['monthly_email_list']).to  eq ['aaa@aaa.com', 'bbb@bl.uk']
-        expect(account.settings['monthly_email_list']).to be_an_instance_of(Array)
+        expect(account.settings["monthly_email_list"]).to  eq ["aaa@aaa.com", "bbb@bl.uk"]
+        expect(account.settings["monthly_email_list"]).to be_an_instance_of(Array)
       end
 
       it "has non empty yearly_email_list" do
-        expect(account.settings['yearly_email_list']).to  eq ['aaa@aaa.com', 'bbb@bl.uk']
-        expect(account.settings['yearly_email_list']).to be_an_instance_of(Array)
+        expect(account.settings["yearly_email_list"]).to  eq ["aaa@aaa.com", "bbb@bl.uk"]
+        expect(account.settings["yearly_email_list"]).to be_an_instance_of(Array)
       end
 
       it "has google_scholarly_work_types" do
-        expect(account.google_scholarly_work_types).to  eq ['Article', 'Book', 'ThesisOrDissertation', 'BookChapter']
+        expect(account.google_scholarly_work_types).to  eq ["Article", "Book", "ThesisOrDissertation", "BookChapter"]
         expect(account.google_scholarly_work_types).to be_an_instance_of(Array)
-        expect(account.google_scholarly_work_types).to include('Book')
+        expect(account.google_scholarly_work_types).to include("Book")
       end
     end
 
     context "settings from environment variable" do
       it "check all boolean truthy values" do
-        ['allow_signup', "shared_login"].each do |key|
-          expect(account.settings[key]).to eq('true')
+        ["allow_signup", "shared_login"].each do |key|
+          expect(account.settings[key]).to eq("true")
         end
       end
 
       it "contains gtm_id" do
-        expect(account.settings['gtm_id']).to eq 'GTM-123456'
+        expect(account.settings["gtm_id"]).to eq "GTM-123456"
       end
 
       it "allows UA google_analytics_id" do
-        expect(account.settings['google_analytics_id']).to eq 'UA-123456-12'
+        expect(account.settings["google_analytics_id"]).to eq "UA-123456-12"
       end
 
       it "allows G4A google_analytics_id" do
-        account.settings['google_analytics_id'] = 'G-ABCDE12345'
-        expect(account.settings['google_analytics_id']).to eq 'G-ABCDE12345'
+        account.settings["google_analytics_id"] = "G-ABCDE12345"
+        expect(account.settings["google_analytics_id"]).to eq "G-ABCDE12345"
       end
 
       it "contains email_format" do
-        expect(account.settings['email_format']).to include('@pacificu.edu')
+        expect(account.settings["email_format"]).to include("@pacificu.edu")
       end
     end
   end
@@ -191,7 +191,7 @@ RSpec.describe HykuAddons::AccountBehavior do
     end
 
     context "with an invalid tenant UUID" do
-      let(:uuid) { 'foo-bar' }
+      let(:uuid) { "foo-bar" }
 
       it "respects the existing tenant UUID" do
         expect(account.tenant).to eq uuid
@@ -235,35 +235,35 @@ RSpec.describe HykuAddons::AccountBehavior do
     end
   end
 
-  describe 'cross tenant shared search' do
-    context 'settings keys' do
-      it 'has default value for #shared_search' do
+  describe "cross tenant shared search" do
+    context "settings keys" do
+      it "has default value for #shared_search" do
         expect(account.search_only).to eq false
       end
     end
 
-    context 'boolean method checks' do
-      it '#shared_search_enabled? defaults to true using Flipflop' do
+    context "boolean method checks" do
+      it "#shared_search_enabled? defaults to true using Flipflop" do
         expect(account.shared_search_enabled?).to be_truthy
       end
 
-      it '#shared_search_tenant? defaults to false' do
+      it "#shared_search_tenant? defaults to false" do
         expect(account.search_only?).to be_falsey
       end
     end
 
-    context 'can add and remove Full Account from shared search' do
+    context "can add and remove Full Account from shared search" do
       let(:normal_account) { create(:account) }
       let(:cross_search_solr) { create(:solr_endpoint, url: "http://solr:8983/solr/hydra-cross-search-tenant") }
 
       let(:shared_search_account) { create(:account, search_only: true, full_account_ids: [normal_account.id], solr_endpoint: cross_search_solr, fcrepo_endpoint: nil) }
 
-      it 'contains full_account' do
+      it "contains full_account" do
         expect(shared_search_account.full_accounts).to be_truthy
         expect(shared_search_account.full_accounts.size).to eq 1
       end
 
-      it 'removes full_account' do
+      it "removes full_account" do
         shared_search_account.full_account_ids = []
         expect(shared_search_account.full_accounts.size).to eq 0
       end

--- a/spec/models/concerns/hyku_addons/task_master/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/task_master/account_behavior_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe HykuAddons::TaskMaster::AccountBehavior do
   subject(:account) { model_class.new(name: "example", tenant: tenant, cname: cname) }

--- a/spec/models/concerns/hyku_addons/task_master/work_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/task_master/work_behavior_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe HykuAddons::TaskMaster::WorkBehavior do
   subject(:work) { create(:task_master_work, :with_one_file) }

--- a/spec/models/datacite_endpoint_spec.rb
+++ b/spec/models/datacite_endpoint_spec.rb
@@ -1,34 +1,34 @@
 # frozen_string_literal: true
 
 RSpec.describe DataCiteEndpoint do
-  subject(:endpoint) { described_class.new mode: 'test', prefix: '10.1234', username: 'user123', password: 'pass123' }
+  subject(:endpoint) { described_class.new mode: "test", prefix: "10.1234", username: "user123", password: "pass123" }
 
-  describe '.options' do
-    it 'uses the configured application settings' do
-      expect(endpoint.options[:mode]).to eq 'test'
-      expect(endpoint.options[:prefix]).to eq '10.1234'
-      expect(endpoint.options[:username]).to eq 'user123'
-      expect(endpoint.options[:password]).to eq 'pass123'
+  describe ".options" do
+    it "uses the configured application settings" do
+      expect(endpoint.options[:mode]).to eq "test"
+      expect(endpoint.options[:prefix]).to eq "10.1234"
+      expect(endpoint.options[:username]).to eq "user123"
+      expect(endpoint.options[:password]).to eq "pass123"
     end
   end
 
-  describe '#ping' do
+  describe "#ping" do
     # TODO: make this test better when #ping has a real implementation
-    it 'returns true' do
+    it "returns true" do
       expect(endpoint.ping).to eq true
     end
   end
 
-  describe '#remove!' do
-    it 'destroys the endpoint' do
+  describe "#remove!" do
+    it "destroys the endpoint" do
       expect { endpoint.remove! }.to change { endpoint.destroyed? }.from(false).to(true)
     end
 
-    context 'cascades from account' do
+    context "cascades from account" do
       let(:account) { Account.create(name: "test") }
       let!(:endpoint) { account.create_datacite_endpoint }
 
-      it 'destroys the endpoint' do
+      it "destroys the endpoint" do
         expect(account.datacite_endpoint).to be_persisted
         expect { account.destroy }.to change { endpoint.destroyed? }.from(false).to(true)
       end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'hyrax/doi/spec/shared_specs'
+require "spec_helper"
+require "hyrax/doi/spec/shared_specs"
 
 RSpec.describe GenericWork do
   let(:work) { described_class.new }
   let(:fully_described_work) { build(:fully_described_work) }
 
-  it_behaves_like 'a DOI-enabled model'
-  it_behaves_like 'a DataCite DOI-enabled model'
+  it_behaves_like "a DOI-enabled model"
+  it_behaves_like "a DataCite DOI-enabled model"
 
-  describe 'additional properties' do
+  describe "additional properties" do
     let(:additional_properties) do
       [
         :volume, :pagination, :issn, :eissn, :official_link, :series_name, :edition,
@@ -43,15 +43,15 @@ RSpec.describe GenericWork do
       ]
     end
 
-    it 'defines additional property accessors' do
+    it "defines additional property accessors" do
       additional_properties.each { |property| expect(work.respond_to?(property)).to eq true }
     end
 
-    it 'defines additional property writers' do
+    it "defines additional property writers" do
       additional_properties.each { |property| expect(work.respond_to?("#{property}=".to_sym)).to eq true }
     end
 
-    it 'indexes additional properties' do
+    it "indexes additional properties" do
       expect(fully_described_work.to_solr.symbolize_keys.keys).to include(*additional_property_index_keys)
     end
   end

--- a/spec/models/nil_datacite_endpoint_spec.rb
+++ b/spec/models/nil_datacite_endpoint_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
+require "spec_helper"
 
 RSpec.describe NilDataCiteEndpoint do
   let(:instance) { described_class.new }

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'hyrax/doi/spec/shared_specs'
+require "spec_helper"
+require "hyrax/doi/spec/shared_specs"
 
 RSpec.describe SolrDocument do
   let(:document) { described_class.new }
@@ -21,11 +21,11 @@ RSpec.describe SolrDocument do
   end
 
   let(:solr_document_class) { described_class }
-  it_behaves_like 'a DOI-enabled solr document'
-  it_behaves_like 'a DataCite DOI-enabled solr document'
+  it_behaves_like "a DOI-enabled solr document"
+  it_behaves_like "a DataCite DOI-enabled solr document"
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       additional_properties.each { |property| expect(document).to respond_to(property) }
     end
   end

--- a/spec/presenters/generic_work_presenter_spec.rb
+++ b/spec/presenters/generic_work_presenter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'spec_helper'
-require 'hyrax/doi/spec/shared_specs'
+require "spec_helper"
+require "hyrax/doi/spec/shared_specs"
 
 RSpec.describe Hyrax::GenericWorkPresenter do
   let(:presenter) { described_class.new(solr_document, nil, nil) }
@@ -58,15 +58,15 @@ RSpec.describe Hyrax::GenericWorkPresenter do
     }
   end
 
-  it_behaves_like 'a DOI-enabled presenter'
-  it_behaves_like 'a DataCite DOI-enabled presenter'
+  it_behaves_like "a DOI-enabled presenter"
+  it_behaves_like "a DataCite DOI-enabled presenter"
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
 
-    it 'defines isbns' do
+    it "defines isbns" do
       expect(presenter).to respond_to(:isbns)
     end
   end

--- a/spec/presenters/hyrax/article_presenter_spec.rb
+++ b/spec/presenters/hyrax/article_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::ArticlePresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { Article.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/book_contribution_presenter_spec.rb
+++ b/spec/presenters/hyrax/book_contribution_presenter_spec.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::BookContributionPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { BookContribution.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
 
-    it 'defines isbns' do
+    it "defines isbns" do
       expect(presenter).to respond_to(:isbns)
     end
   end

--- a/spec/presenters/hyrax/book_presenter_spec.rb
+++ b/spec/presenters/hyrax/book_presenter_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::BookPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }

--- a/spec/presenters/hyrax/conference_item_presenter_spec.rb
+++ b/spec/presenters/hyrax/conference_item_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::ConferenceItemPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { ConferenceItem.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/dataset_presenter_spec.rb
+++ b/spec/presenters/hyrax/dataset_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::DatasetPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { Dataset.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/exhibition_item_presenter_spec.rb
+++ b/spec/presenters/hyrax/exhibition_item_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::ExhibitionItemPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { ExhibitionItem.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/pacific_article_presenter_spec.rb
+++ b/spec/presenters/hyrax/pacific_article_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::PacificArticlePresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { PacificArticle.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/pacific_book_presenter_spec.rb
+++ b/spec/presenters/hyrax/pacific_book_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::PacificBookPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { PacificBook.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/pacific_image_presenter_spec.rb
+++ b/spec/presenters/hyrax/pacific_image_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::PacificImagePresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { PacificImage.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/report_presenter_spec.rb
+++ b/spec/presenters/hyrax/report_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::ReportPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { Report.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/thesis_or_dissertation_presenter_spec.rb
+++ b/spec/presenters/hyrax/thesis_or_dissertation_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::ThesisOrDissertationPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { ThesisOrDissertation.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/presenters/hyrax/time_based_media_presenter_spec.rb
+++ b/spec/presenters/hyrax/time_based_media_presenter_spec.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyrax::TimeBasedMediaPresenter do
   let(:presenter) { described_class.new(solrdoc, nil, nil) }
   let(:work) { TimeBasedMedia.new }
   let(:solrdoc) { SolrDocument.new(work.to_solr, nil) }
 
-  describe 'accessors' do
-    it 'defines accessors' do
+  describe "accessors" do
+    it "defines accessors" do
       described_class.delegated_methods.each { |property| expect(presenter).to respond_to(property) }
     end
   end

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multitenant: true do
   let(:account) { create(:account) }
@@ -138,10 +138,10 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
   describe "/work/:id" do
     let(:json_response) { JSON.parse(response.body) }
 
-    context 'when repository has content' do
-      let(:work) { create(:work, visibility: 'open') }
+    context "when repository has content" do
+      let(:work) { create(:work, visibility: "open") }
 
-      it 'returns work json' do
+      it "returns work json" do
         get "/api/v1/tenant/#{account.tenant}/work/#{work.id}"
 
         expect(response.status).to eq(200)
@@ -257,9 +257,9 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                          "workflow_status" => nil)
       end
 
-      context 'with data when it exists' do
+      context "with data when it exists" do
         let(:work) { GenericWork.new(attributes) }
-        it 'returns work json' do
+        it "returns work json" do
           work.save!
           get "/api/v1/tenant/#{account.tenant}/work/#{work.id}"
 

--- a/spec/requests/catalog_controller_spec.rb
+++ b/spec/requests/catalog_controller_spec.rb
@@ -3,24 +3,24 @@
 require "spec_helper"
 
 RSpec.describe CatalogController, type: :request, clean: true, multitenant: true do
-  let(:user) { create(:user, email: 'test_user@repo-sample.edu') }
-  let(:work) { build(:work, title: ['welcome test'], id: SecureRandom.uuid, user: user) }
+  let(:user) { create(:user, email: "test_user@repo-sample.edu") }
+  let(:work) { build(:work, title: ["welcome test"], id: SecureRandom.uuid, user: user) }
 
-  let(:hyku_sample_work) { build(:work, title: ['sample test'], id: SecureRandom.uuid, user: user) }
-  let(:sample_solr_connection) { RSolr.connect url: 'http://solr:8983/solr/hydra-sample' }
+  let(:hyku_sample_work) { build(:work, title: ["sample test"], id: SecureRandom.uuid, user: user) }
+  let(:sample_solr_connection) { RSolr.connect url: "http://solr:8983/solr/hydra-sample" }
 
   let(:cross_search_solr) { create(:solr_endpoint, url: "http://solr:8983/solr/hydra-cross-search-tenant") }
   let!(:cross_search_tenant_account) do
     create(:account,
-           name: 'cross_serch',
+           name: "cross_serch",
            solr_endpoint: cross_search_solr,
            fcrepo_endpoint: nil)
   end
 
   before do
     WebMock.disable!
-    allow(AccountElevator).to receive(:switch!).with(cross_search_tenant_account.cname).and_return('public')
-    allow(Apartment::Tenant.adapter).to receive(:connect_to_new).and_return('')
+    allow(AccountElevator).to receive(:switch!).with(cross_search_tenant_account.cname).and_return("public")
+    allow(Apartment::Tenant.adapter).to receive(:connect_to_new).and_return("")
     ActiveFedora::SolrService.instance.conn = sample_solr_connection
     ActiveFedora::SolrService.add(hyku_sample_work.to_solr)
     ActiveFedora::SolrService.commit
@@ -42,7 +42,7 @@ RSpec.describe CatalogController, type: :request, clean: true, multitenant: true
     ActiveFedora::SolrService.commit
   end
 
-  describe 'Cross Tenant Search' do
+  describe "Cross Tenant Search" do
     let(:cross_tenant_solr_options) do
       {
         "read_timeout" => 120,
@@ -60,13 +60,13 @@ RSpec.describe CatalogController, type: :request, clean: true, multitenant: true
       host! cross_search_tenant_account.cname
     end
 
-    context 'can fetch data from other tenants' do
-      xit 'cross-search-tenant can fetch all record in child tenants' do
-        connection = RSolr.connect(url: 'http://solr:8983/solr/hydra-cross-search-tenant')
+    context "can fetch data from other tenants" do
+      xit "cross-search-tenant can fetch all record in child tenants" do
+        connection = RSolr.connect(url: "http://solr:8983/solr/hydra-cross-search-tenant")
         allow(blacklight_solr_repository).to receive(:build_connection).and_return(connection)
         allow(CatalogController).to receive(:blacklight_config).and_return(black_light_config)
 
-        get search_catalog_url, params: { locale: 'en', q: 'test' }
+        get search_catalog_url, params: { locale: "en", q: "test" }
         expect(response.status).to eq(200)
       end
     end

--- a/spec/requests/hyku_addons/account_settings_request_spec.rb
+++ b/spec/requests/hyku_addons/account_settings_request_spec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "::HykuAddons::AccountSettingsController", type: :request do
   let(:user) { FactoryBot.create(:admin) }
@@ -16,7 +16,7 @@ RSpec.describe "::HykuAddons::AccountSettingsController", type: :request do
     account.reset!
   end
 
-  describe 'GET /admin/account_settings' do
+  describe "GET /admin/account_settings" do
     it "GETS index  /admin/account_settings" do
       get admin_account_settings_url
       expect(response).to have_http_status(:ok)
@@ -26,17 +26,17 @@ RSpec.describe "::HykuAddons::AccountSettingsController", type: :request do
   describe "Update single keys in settings hash" do
     context "can display edit page" do
       it "GET text_field edit page" do
-        get edit_admin_account_setting_url(id: account, partial_name: 'render_text_fields', field_name: 'contact_email')
+        get edit_admin_account_setting_url(id: account, partial_name: "render_text_fields", field_name: "contact_email")
         expect(response).to have_http_status(:ok)
       end
 
       it "GET array edit page" do
-        get edit_admin_account_setting_url(id: account, partial_name: 'render_array_list', field_name: 'weekly_email_list')
+        get edit_admin_account_setting_url(id: account, partial_name: "render_array_list", field_name: "weekly_email_list")
         expect(response).to have_http_status(:ok)
       end
 
       it "GET boolean_field edit page" do
-        get edit_admin_account_setting_url(id: account, partial_name: 'render_single_boolean', field_name: 'shared_login')
+        get edit_admin_account_setting_url(id: account, partial_name: "render_single_boolean", field_name: "shared_login")
         expect(response).to have_http_status(:ok)
       end
     end
@@ -45,7 +45,7 @@ RSpec.describe "::HykuAddons::AccountSettingsController", type: :request do
       it "can update a single settings key eg  contact_email" do
         patch update_single_admin_account_setting_url(id: account), params: { "account" => { "settings" => { "contact_email" => "bo@abc.com" } } }
         account.reload
-        expect(account.settings['contact_email']).to eq 'bo@abc.com'
+        expect(account.settings["contact_email"]).to eq "bo@abc.com"
         expect(response).to redirect_to admin_account_settings_url
       end
     end
@@ -54,10 +54,10 @@ RSpec.describe "::HykuAddons::AccountSettingsController", type: :request do
   describe "Update all or multiple settings keys" do
     context "update fields" do
       it "can update multiple fields eg contact_email and weekly_email_list" do
-        put admin_account_setting_url(account.id), params: { 'account' => { "settings" => { "contact_email" => "ta@abc.com", "weekly_email_list" => ['we@we.com'] } } }
+        put admin_account_setting_url(account.id), params: { "account" => { "settings" => { "contact_email" => "ta@abc.com", "weekly_email_list" => ["we@we.com"] } } }
         account.reload
-        expect(account.settings['contact_email']).to eq 'ta@abc.com'
-        expect(account.settings['weekly_email_list']).to include('we@we.com')
+        expect(account.settings["contact_email"]).to eq "ta@abc.com"
+        expect(account.settings["weekly_email_list"]).to include("we@we.com")
         expect(response).to redirect_to admin_account_settings_url
       end
     end
@@ -66,22 +66,22 @@ RSpec.describe "::HykuAddons::AccountSettingsController", type: :request do
   describe "updating settings moved from environment variables" do
     context "boolean keys" do
       it "can set booleans setting keys to false" do
-        boolean_keys = [['allow_signup', false], ["shared_login", false]]
+        boolean_keys = [["allow_signup", false], ["shared_login", false]]
         boolean_hash = Hash[*boolean_keys.flatten]
-        put admin_account_setting_url(account.id), params: { 'account' => { "settings" => boolean_hash } }
+        put admin_account_setting_url(account.id), params: { "account" => { "settings" => boolean_hash } }
         account.reload
-        ['allow_signup', "shared_login"].each do |key|
-          expect(account.settings[key]).to eq 'false'
+        ["allow_signup", "shared_login"].each do |key|
+          expect(account.settings[key]).to eq "false"
         end
         expect(response).to redirect_to admin_account_settings_url
       end
 
       it "can set booleans setting keys to true" do
-        boolean_keys = [['allow_signup', true]]
+        boolean_keys = [["allow_signup", true]]
         boolean_hash = Hash[*boolean_keys.flatten]
-        put admin_account_setting_url(account.id), params: { 'account' => { "settings" => boolean_hash } }
+        put admin_account_setting_url(account.id), params: { "account" => { "settings" => boolean_hash } }
         account.reload
-        ['allow_signup'].each do |key|
+        ["allow_signup"].each do |key|
           expect(account.settings[key]).to be_truthy
         end
         expect(response).to redirect_to admin_account_settings_url

--- a/spec/requests/hyku_addons/multitenant_cookie_controller_behavior_spec.rb
+++ b/spec/requests/hyku_addons/multitenant_cookie_controller_behavior_spec.rb
@@ -5,9 +5,9 @@ require "rails_helper"
 RSpec.describe HykuAddons::MultitenantCookieControllerBehavior, type: :request, multitenant: true do
   let(:main_app) { Rails.application.routes.url_helpers }
   let(:user) { create(:user) }
-  let(:account) { create(:account, cname: 'foo.bar', frontend_url: 'bar') }
+  let(:account) { create(:account, cname: "foo.bar", frontend_url: "bar") }
   let(:work) { create(:work, user: user) }
-  let(:cookie_details) { cookies.send(:hash_for, nil).fetch('_hyku_session', nil) }
+  let(:cookie_details) { cookies.send(:hash_for, nil).fetch("_hyku_session", nil) }
 
   before do
     login_as(user, scope: :user)

--- a/spec/requests/hyku_addons/oai_pmh/get_record_spec.rb
+++ b/spec/requests/hyku_addons/oai_pmh/get_record_spec.rb
@@ -1,26 +1,26 @@
 # frozen_string_literal: true
-require 'spec_helper'
-require File.expand_path('../../../helpers/user_with_work_context.rb', __dir__)
+require "spec_helper"
+require File.expand_path("../../../helpers/user_with_work_context.rb", __dir__)
 
 RSpec.describe CatalogController, multitenant: true do
-  include_context 'user with work context'
+  include_context "user with work context"
   describe "GetRecord" do
     let(:params) do
       {
-        verb: 'GetRecord',
+        verb: "GetRecord",
         identifier: "#{account.oai_prefix}:#{work.id}",
-        metadataPrefix: 'oai_dc'
+        metadataPrefix: "oai_dc"
       }
     end
 
-    it 'shows public records' do
+    it "shows public records" do
       get oai_catalog_path(params)
       expect(response.body).not_to include("idDoesNotExist")
     end
 
-    context 'with a restricted work' do
+    context "with a restricted work" do
       before do
-        work.update visibility: 'restricted'
+        work.update visibility: "restricted"
         get oai_catalog_path(params)
       end
 

--- a/spec/requests/hyku_addons/oai_pmh/identify_spec.rb
+++ b/spec/requests/hyku_addons/oai_pmh/identify_spec.rb
@@ -1,36 +1,36 @@
 # frozen_string_literal: true
-require 'spec_helper'
-require File.expand_path('../../../helpers/user_with_work_context.rb', __dir__)
+require "spec_helper"
+require File.expand_path("../../../helpers/user_with_work_context.rb", __dir__)
 
 RSpec.describe CatalogController, multitenant: true do
-  include_context 'user with work context' do
-    let(:params) { { verb: 'Identify' } }
+  include_context "user with work context" do
+    let(:params) { { verb: "Identify" } }
 
     before do
       get oai_catalog_path(params)
     end
 
     it "contains repository name" do
-      expect(xml.at_xpath('//xmlns:repositoryName').text).to eql 'example'
+      expect(xml.at_xpath("//xmlns:repositoryName").text).to eql "example"
     end
 
     it "contains base url" do
-      expect(xml.at_xpath('//xmlns:baseURL').text).to eql "http://#{account.cname}/catalog/oai?locale=en"
+      expect(xml.at_xpath("//xmlns:baseURL").text).to eql "http://#{account.cname}/catalog/oai?locale=en"
     end
 
     it "contains admin email" do
-      expect(xml.at_xpath('//xmlns:adminEmail').text).to eql 'some@example.com'
+      expect(xml.at_xpath("//xmlns:adminEmail").text).to eql "some@example.com"
     end
 
     it "contains repository prefix/identifier" do
       expect(
-        xml.at_xpath('//oai-identifier:repositoryIdentifier', 'oai-identifier' => "http://www.openarchives.org/OAI/2.0/oai-identifier").text
-      ).to eql 'hyku.example.com'
+        xml.at_xpath("//oai-identifier:repositoryIdentifier", "oai-identifier" => "http://www.openarchives.org/OAI/2.0/oai-identifier").text
+      ).to eql "hyku.example.com"
     end
 
     it "contains sample identifier" do
       expect(
-        xml.at_xpath('//oai-identifier:sampleIdentifier', 'oai-identifier' => "http://www.openarchives.org/OAI/2.0/oai-identifier").text
+        xml.at_xpath("//oai-identifier:sampleIdentifier", "oai-identifier" => "http://www.openarchives.org/OAI/2.0/oai-identifier").text
       ).to eql "hyku.example.com:#{work.id}"
     end
   end

--- a/spec/requests/hyrax/doi/hyrax_doi_controller_specs.rb
+++ b/spec/requests/hyrax/doi/hyrax_doi_controller_specs.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe Hyrax::DOI::HyraxDOIController, type: :request, multitenant: true, clean_repo: true do
-  let(:user) { create(:user, email: 'user@pacificu.edu') }
+  let(:user) { create(:user, email: "user@pacificu.edu") }
   let!(:account) { create(:account) }
 
   let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
@@ -11,7 +11,7 @@ RSpec.describe Hyrax::DOI::HyraxDOIController, type: :request, multitenant: true
   let(:workflow) do
     Sipity::Workflow.create!(
       active: true,
-      name: 'test-workflow',
+      name: "test-workflow",
       permission_template: permission_template
     )
   end
@@ -22,12 +22,12 @@ RSpec.describe Hyrax::DOI::HyraxDOIController, type: :request, multitenant: true
 
   before do
     # Required to set deposit permissions for the user or the request will see a Not Authorized exception
-    Sipity::WorkflowAction.create!(name: 'submit', workflow: workflow)
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
     Hyrax::PermissionTemplateAccess.create!(
       permission_template_id: permission_template.id,
-      agent_type: 'user',
+      agent_type: "user",
       agent_id: user.user_key,
-      access: 'deposit'
+      access: "deposit"
     )
 
     login_as user

--- a/spec/requests/hyrax/generic_works_controller_spec.rb
+++ b/spec/requests/hyrax/generic_works_controller_spec.rb
@@ -4,7 +4,7 @@ require "spec_helper"
 
 RSpec.describe Hyrax::GenericWorksController, type: :request, multitenant: true do
   let(:main_app) { Rails.application.routes.url_helpers }
-  let(:user) { create(:user, email: 'user@pacificu.edu') }
+  let(:user) { create(:user, email: "user@pacificu.edu") }
   let(:work) { create(:work, user: user) }
   let!(:account) { create(:account) }
 

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyku::API::V1::FilesController, type: :request, clean: true, multitenant: true do
   let(:account) { create(:account) }
-  let(:work) { create(:work_with_one_file, visibility: 'open') }
+  let(:work) { create(:work_with_one_file, visibility: "open") }
   let(:file_set) { work.file_sets.first }
 
   before do

--- a/spec/requests/v1/tenant_spec.rb
+++ b/spec/requests/v1/tenant_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe Hyku::API::V1::TenantController, type: :request, clean: true, multitenant: true do
-  let(:account) { create(:account, name: 'test') }
+  let(:account) { create(:account, name: "test") }
   let(:json_response) { JSON.parse(response.body) }
   let(:work_types) { ["Article", "Book", "ThesisOrDissertation", "BookChapter"] }
 
@@ -37,7 +37,7 @@ RSpec.describe Hyku::API::V1::TenantController, type: :request, clean: true, mul
     context "with private settings do" do
       before do
         Account.private_settings.each do |setting|
-          account.settings[setting] = { foo: 'bar' }
+          account.settings[setting] = { foo: "bar" }
         end
         account.save
       end

--- a/spec/services/bolognese/writers/hyku_addons_work_form_fields_writer_spec.rb
+++ b/spec/services/bolognese/writers/hyku_addons_work_form_fields_writer_spec.rb
@@ -26,23 +26,23 @@ RSpec.describe Bolognese::Writers::HykuAddonsWorkFormFieldsWriter do
 
     it { expect(meta.send(:validate_funder_doi, "10.13039/100000050")).to eq "https://doi.org/10.13039/100000050" }
     it { expect(meta.send(:validate_funder_doi, "10.13039/100006492")).to eq "https://doi.org/10.13039/100006492" }
-    it { expect(meta.send(:validate_funder_doi, 'http://handle.test.datacite.org/10.13039/100000080')).to eq "https://doi.org/10.13039/100000080" }
-    it { expect(meta.send(:validate_funder_doi, 'https://doi.org/10.13039/100000001')).to eq "https://doi.org/10.13039/100000001" }
-    it { expect(meta.send(:validate_funder_doi, 'http://doi.org/10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
-    it { expect(meta.send(:validate_funder_doi, 'https://dx.doi.org/10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
-    it { expect(meta.send(:validate_funder_doi, 'doi:10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
-    it { expect(meta.send(:validate_funder_doi, '10.13039/501100001711')).to eq "https://doi.org/10.13039/501100001711" }
-    it { expect(meta.send(:validate_funder_doi, '501100001711')).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(meta.send(:validate_funder_doi, "http://handle.test.datacite.org/10.13039/100000080")).to eq "https://doi.org/10.13039/100000080" }
+    it { expect(meta.send(:validate_funder_doi, "https://doi.org/10.13039/100000001")).to eq "https://doi.org/10.13039/100000001" }
+    it { expect(meta.send(:validate_funder_doi, "http://doi.org/10.13039/501100001711")).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(meta.send(:validate_funder_doi, "https://dx.doi.org/10.13039/501100001711")).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(meta.send(:validate_funder_doi, "doi:10.13039/501100001711")).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(meta.send(:validate_funder_doi, "10.13039/501100001711")).to eq "https://doi.org/10.13039/501100001711" }
+    it { expect(meta.send(:validate_funder_doi, "501100001711")).to eq "https://doi.org/10.13039/501100001711" }
     it { expect(meta.send(:validate_funder_doi, "https://doi.org/10.13039/5monkeymonkey")).to be_nil }
-    it { expect(meta.send(:validate_funder_doi, '10.13039/5monkeymonkey')).to be_nil }
+    it { expect(meta.send(:validate_funder_doi, "10.13039/5monkeymonkey")).to be_nil }
   end
 
   context "Hyku Addons Writer" do
     let(:faraday_headers) do
       {
-        'Accept' => '*/*',
-        'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'User-Agent' => 'Faraday v0.17.4'
+        "Accept" => "*/*",
+        "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+        "User-Agent" => "Faraday v0.17.4"
       }
     end
     let(:meta) { Bolognese::Metadata.new(input: fixture) }
@@ -71,7 +71,7 @@ RSpec.describe Bolognese::Writers::HykuAddonsWorkFormFieldsWriter do
     end
 
     describe "a journal doi with multiple complete creators" do
-      let(:fixture) { File.read Rails.root.join("..", "fixtures", "doi", '10.7554-elife.63646.xml') }
+      let(:fixture) { File.read Rails.root.join("..", "fixtures", "doi", "10.7554-elife.63646.xml") }
       let(:json_501100001349) { File.read Rails.root.join("..", "fixtures", "ror", "501100001349.json") }
       let(:json_501100001441) { File.read Rails.root.join("..", "fixtures", "ror", "501100001441.json") }
       let(:json_501100001352) { File.read Rails.root.join("..", "fixtures", "ror", "501100001352.json") }

--- a/spec/services/hyku_addons/cache_expiration_service_spec.rb
+++ b/spec/services/hyku_addons/cache_expiration_service_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 RSpec.describe HykuAddons::CacheExpirationService do
   let(:service) { described_class.new }
   let(:account) do
-    account = create(:account, name: 'tenant')
+    account = create(:account, name: "tenant")
     account.create_redis_endpoint!
     account
   end

--- a/spec/services/hyku_addons/file_signed_url_service_spec.rb
+++ b/spec/services/hyku_addons/file_signed_url_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 # NOTE:
 # I've disabled the following rule as Google Cloud is hard enough to test without Rubocop harrassing me.

--- a/spec/services/hyku_addons/qa_select_service_spec.rb
+++ b/spec/services/hyku_addons/qa_select_service_spec.rb
@@ -4,35 +4,35 @@ require "rails_helper"
 RSpec.describe HykuAddons::QaSelectService do
   let(:default_authority_map) do
     [
-      HashWithIndifferentAccess.new(term: 'Active Label', label: 'Active Label', id: 'active-id', active: true),
-      HashWithIndifferentAccess.new(term: 'Inactive Label', label: 'Inactive Label', id: 'inactive-id', active: false),
-      HashWithIndifferentAccess.new(label: 'Active No Term', id: 'active-no-term-id', active: true)
+      HashWithIndifferentAccess.new(term: "Active Label", label: "Active Label", id: "active-id", active: true),
+      HashWithIndifferentAccess.new(term: "Inactive Label", label: "Inactive Label", id: "inactive-id", active: false),
+      HashWithIndifferentAccess.new(label: "Active No Term", id: "active-no-term-id", active: true)
     ]
   end
   let(:model_authority_map) do
     [
-      HashWithIndifferentAccess.new(term: 'Model Active Label', label: 'Model Active Label', id: 'model-active-id', active: true)
+      HashWithIndifferentAccess.new(term: "Model Active Label", label: "Model Active Label", id: "model-active-id", active: true)
     ]
   end
   let(:tenant_authority_map) do
     [
-      HashWithIndifferentAccess.new(term: 'Tenant Active Label', label: 'Tenant Active Label', id: 'tenant-active-id', active: true)
+      HashWithIndifferentAccess.new(term: "Tenant Active Label", label: "Tenant Active Label", id: "tenant-active-id", active: true)
     ]
   end
   let(:model_tenant_authority_map) do
     [
-      HashWithIndifferentAccess.new(term: 'Model Tenant Active Label', label: 'Model Tenant Active Label', id: 'model-tenant-active-id', active: true)
+      HashWithIndifferentAccess.new(term: "Model Tenant Active Label", label: "Model Tenant Active Label", id: "model-tenant-active-id", active: true)
     ]
   end
 
   let(:authority) { FakeAuthority }
-  let(:authority_name) { 'respect_my' }
+  let(:authority_name) { "respect_my" }
   let(:tenant_authority_name) { "#{authority_name}-TENANT" }
   let(:model_authority_name) { "#{authority_name}-MODEL_CLASS" }
   let(:model_tenant_authority_name) { "#{authority_name}-MODEL_CLASS-TENANT" }
   let(:qa_select_service) { described_class.new(authority_name) }
   let(:model_class) { Class.new }
-  let(:account) { build(:account, name: 'tenant') }
+  let(:account) { build(:account, name: "tenant") }
   let(:site) { Site.new(account: account) }
   let(:subauthorities) { [authority_name] }
 
@@ -46,34 +46,34 @@ RSpec.describe HykuAddons::QaSelectService do
     stub_const("ModelClass", model_class)
   end
 
-  describe '#select_all_options' do
-    context 'with no overrides' do
-      it 'will be default terms' do
-        expect(described_class.new(authority_name).select_all_options).to eq([['Active Label', 'active-id'], ['Inactive Label', 'inactive-id'], ['Active No Term', 'active-no-term-id']])
+  describe "#select_all_options" do
+    context "with no overrides" do
+      it "will be default terms" do
+        expect(described_class.new(authority_name).select_all_options).to eq([["Active Label", "active-id"], ["Inactive Label", "inactive-id"], ["Active No Term", "active-no-term-id"]])
       end
     end
 
-    context 'with tenant override' do
+    context "with tenant override" do
       let(:subauthorities) { [authority_name, tenant_authority_name] }
 
-      it 'will be tenant terms' do
-        expect(described_class.new(authority_name).select_all_options).to eq([['Tenant Active Label', 'tenant-active-id']])
+      it "will be tenant terms" do
+        expect(described_class.new(authority_name).select_all_options).to eq([["Tenant Active Label", "tenant-active-id"]])
       end
     end
 
-    context 'with model override' do
+    context "with model override" do
       let(:subauthorities) { [authority_name, model_authority_name, tenant_authority_name] }
 
-      it 'will be model terms' do
-        expect(described_class.new(authority_name, model: ModelClass).select_all_options).to eq([['Model Active Label', 'model-active-id']])
+      it "will be model terms" do
+        expect(described_class.new(authority_name, model: ModelClass).select_all_options).to eq([["Model Active Label", "model-active-id"]])
       end
     end
 
-    context 'with model tenant override' do
+    context "with model tenant override" do
       let(:subauthorities) { [authority_name, model_tenant_authority_name, model_authority_name, tenant_authority_name] }
 
-      it 'will be model tenant terms' do
-        expect(described_class.new(authority_name, model: ModelClass).select_all_options).to eq([['Model Tenant Active Label', 'model-tenant-active-id']])
+      it "will be model tenant terms" do
+        expect(described_class.new(authority_name, model: ModelClass).select_all_options).to eq([["Model Tenant Active Label", "model-tenant-active-id"]])
       end
     end
   end

--- a/spec/services/hyku_addons/task_master/publish_service_spec.rb
+++ b/spec/services/hyku_addons/task_master/publish_service_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe HykuAddons::TaskMaster::PublishService do
   subject(:service) { described_class.new(type, action, json) }

--- a/spec/services/hyku_addons/update_account_cname_spec.rb
+++ b/spec/services/hyku_addons/update_account_cname_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe HykuAddons::UpdateAccountCname do
   let(:service) { described_class.new(account, cname) }
-  let(:account) { create(:account, name: 'tenant', cname: 'example.com') }
+  let(:account) { create(:account, name: "tenant", cname: "example.com") }
 
   describe "save" do
     let(:cname) { "foo.example.com" }

--- a/spec/services/hyku_addons/update_account_frontend_url_spec.rb
+++ b/spec/services/hyku_addons/update_account_frontend_url_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 
 RSpec.describe HykuAddons::UpdateAccountFrontendUrl do
   let(:service) { described_class.new(account, frontend_url) }
-  let(:account) { create(:account, name: 'tenant') }
+  let(:account) { create(:account, name: "tenant") }
 
   describe "save" do
     let(:frontend_url) { "example.com/frontend" }

--- a/spec/services/hyku_addons/validations/csv_entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/csv_entry_validation_service_spec.rb
@@ -2,8 +2,8 @@
 require "rails_helper"
 
 RSpec.describe HykuAddons::Validations::CsvEntryValidationService, type: :model do
-  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: 'Complete', id: 1, identifier: '123') }
-  let(:account) { create(:account, name: 'tenant', cname: 'example.com') }
+  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: "Complete", id: 1, identifier: "123") }
+  let(:account) { create(:account, name: "tenant", cname: "example.com") }
 
   let(:service) { described_class.new(account, entry) }
 
@@ -26,18 +26,18 @@ RSpec.describe HykuAddons::Validations::CsvEntryValidationService, type: :model 
   # rubocop:disable RSpec/EmptyExampleGroup
   describe "validate" do
     context "with a correctly imported CSV file" do
-      let(:user) { create(:user, email: 'test@example.com') }
+      let(:user) { create(:user, email: "test@example.com") }
       # let! is needed below to ensure that this user is created for file attachment because this is the depositor in the CSV fixtures
-      let(:depositor) { create(:user, email: 'batchuser@example.com') }
+      let(:depositor) { create(:user, email: "batchuser@example.com") }
       let(:importer) do
         create(:bulkrax_importer_csv,
                user: user,
                field_mapping: Bulkrax.field_mappings["HykuAddons::CsvParser"],
                parser_klass: "HykuAddons::CsvParser",
-               parser_fields: { 'import_file_path' => import_batch_file },
+               parser_fields: { "import_file_path" => import_batch_file },
                limit: 0)
       end
-      let(:import_batch_file) { 'spec/fixtures/csv/pacific_articles.metadata.csv' }
+      let(:import_batch_file) { "spec/fixtures/csv/pacific_articles.metadata.csv" }
     end
   end
   # rubocop:enable RSpec/EmptyExampleGroup

--- a/spec/services/hyku_addons/validations/entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/entry_validation_service_spec.rb
@@ -2,8 +2,8 @@
 require "rails_helper"
 
 RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
-  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: 'Complete', id: 1, identifier: '123') }
-  let(:account) { create(:account, name: 'tenant', cname: 'example.com') }
+  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: "Complete", id: 1, identifier: "123") }
+  let(:account) { create(:account, name: "tenant", cname: "example.com") }
 
   let(:source_metadata) do
     {
@@ -45,7 +45,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
     end
 
     context "with a non complete entry" do
-      let(:entry) { instance_double(HykuAddons::CsvEntry, status: 'Pending') }
+      let(:entry) { instance_double(HykuAddons::CsvEntry, status: "Pending") }
 
       it "raise an Argument Error" do
         expect { service }.to raise_error(ArgumentError, "You must pass a valid HykuAddons::CsvEntry with  successfully imported items")
@@ -54,7 +54,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
   end
 
   describe "validate" do
-    context 'with no validation errors' do
+    context "with no validation errors" do
       before do
         [:left_differences, :right_differences, :merged_fields_differences].each do |validation_method|
           allow(service).to receive(validation_method).and_return([])
@@ -71,9 +71,9 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       end
     end
 
-    context 'with validation errors' do
+    context "with validation errors" do
       let(:entry) do
-        instance_double(HykuAddons::CsvEntry, status: 'Complete', id: 1, current_status: instance_double(Bulkrax::Status, update: true))
+        instance_double(HykuAddons::CsvEntry, status: "Complete", id: 1, current_status: instance_double(Bulkrax::Status, update: true))
       end
 
       before do
@@ -92,14 +92,14 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
         expect(service.errors.first).to eq(foo: :bar)
       end
 
-      it 'updates the current status' do
+      it "updates the current status" do
         service.validate
         expect(entry.current_status).to have_received(:update).with(error_backtrace: service.errors)
       end
     end
   end
 
-  describe 'difference matchers' do
+  describe "difference matchers" do
     before do
       allow(service).to receive(:source_metadata).and_return(source_metadata)
       allow(service).to receive(:source_metadata_after_transforms).and_return(source_metadata)
@@ -107,7 +107,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       allow(service).to receive(:destination_metadata_after_transforms).and_return(destination_metadata)
     end
 
-    describe 'left' do
+    describe "left" do
       it "returns :remove diffs for items on the left only" do
         expect(service.left_differences).to eq(
           [{ dest_v: nil, op: :remove, path: :left_only, source_v: true, t_dest_v: nil, t_source_v: true }]
@@ -115,7 +115,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       end
     end
 
-    describe 'right' do
+    describe "right" do
       it "returns :add items for the items on the right only" do
         expect(service.right_differences).to eq(
           [{ dest_v: true, op: :add, path: :right_only, source_v: nil, t_dest_v: true, t_source_v: nil }]
@@ -123,27 +123,27 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       end
     end
 
-    describe 'merged_fields' do
+    describe "merged_fields" do
       it "returns :change items for the items appearing on both lists" do
         expect(service.merged_fields_differences).to eq(
           [{ dest_v: false, op: :change, path: :common, source_v: true, t_dest_v: false, t_source_v: true }]
         )
       end
 
-      context 'with non stripped metadata' do
+      context "with non stripped metadata" do
         before do
           source_metadata[:stripped] = " stripped"
           destination_metadata[:stripped] = "stripped "
         end
 
         it "returns :change items for the items appearing on both lists" do
-          expect(service.merged_fields_differences).not_to include(op: :change, path: :stripped, value: 'stripped')
+          expect(service.merged_fields_differences).not_to include(op: :change, path: :stripped, value: "stripped")
         end
       end
     end
   end
 
-  describe 'source_metadata_after_transforms' do
+  describe "source_metadata_after_transforms" do
     before do
       allow(service).to receive(:source_metadata).and_return(data: :something)
       allow(service).to receive(:processable_fields).and_call_original
@@ -159,7 +159,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
     end
   end
 
-  describe 'destination_metadata_after_transforms' do
+  describe "destination_metadata_after_transforms" do
     before do
       allow(service).to receive(:destination_metadata).and_return(data: :something)
       allow(service).to receive(:processable_fields).and_call_original
@@ -175,19 +175,19 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
     end
   end
 
-  describe 'filter_out_excluded_fields' do
+  describe "filter_out_excluded_fields" do
     let(:metadata) do
       {
         foo: :bar,
         bar: :baz,
         empty_string: "",
         empty_string_array: [""],
-        exclude: 'true',
-        include: 'true'
+        exclude: "true",
+        include: "true"
       }
     end
     let(:excluded_fields) { [:bar] }
-    let(:excluded_fields_with_value) { { exclude: 'true', include: 'false' } }
+    let(:excluded_fields_with_value) { { exclude: "true", include: "false" } }
     let(:result) { service.send(:processable_fields, metadata) }
 
     before do
@@ -195,12 +195,12 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       allow(described_class).to receive(:excluded_fields_with_value).and_return(excluded_fields_with_value)
     end
 
-    it 'removes the excluded fields from the hash param based on EXCLUDED_FIELDS' do
+    it "removes the excluded fields from the hash param based on EXCLUDED_FIELDS" do
       expect(result.keys).to include(:foo)
       expect(result.keys).not_to include(:bar)
     end
 
-    it 'removes the excluded fields from the hash param based on EXCLUDED_FIELDS_WITH_VALUES' do
+    it "removes the excluded fields from the hash param based on EXCLUDED_FIELDS_WITH_VALUES" do
       expect(result.keys).not_to include(:exclude)
     end
 
@@ -208,13 +208,13 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       expect(result.keys).to include(:include)
     end
 
-    it 'removes empty fields and empty strings' do
+    it "removes empty fields and empty strings" do
       expect(result.keys).not_to include(:empty_string)
       expect(result.keys).not_to include(:empty_string_array)
     end
   end
 
-  describe 'rename_fields' do
+  describe "rename_fields" do
     let(:metadata) { { foo: :bar, bar: :baz } }
     let(:renamed_fields) { { foo: :fooz, bar: :barz } }
 
@@ -222,7 +222,7 @@ RSpec.describe HykuAddons::Validations::EntryValidationService, type: :model do
       allow(described_class).to receive(:renamed_fields).and_return(renamed_fields)
     end
 
-    it 'renames the fields using the RENAMED_FIELDS map' do
+    it "renames the fields using the RENAMED_FIELDS map" do
       result = service.send(:rename_fields, metadata)
       expect(result).to eq(fooz: :bar, barz: :baz)
     end

--- a/spec/services/hyku_addons/validations/redlands_csv_entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/redlands_csv_entry_validation_service_spec.rb
@@ -2,8 +2,8 @@
 require "rails_helper"
 
 RSpec.describe HykuAddons::Validations::RedlandsEntryValidationService, type: :model do
-  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: 'Complete', id: 1, identifier: '123') }
-  let(:account) { create(:account, name: 'tenant', cname: 'example.com') }
+  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: "Complete", id: 1, identifier: "123") }
+  let(:account) { create(:account, name: "tenant", cname: "example.com") }
 
   let(:service) { described_class.new(account, entry) }
 
@@ -26,32 +26,32 @@ RSpec.describe HykuAddons::Validations::RedlandsEntryValidationService, type: :m
   # rubocop:disable RSpec/EmptyExampleGroup
   describe "validate" do
     context "with a correctly imported CSV file" do
-      let(:user) { create(:user, email: 'test@example.com') }
+      let(:user) { create(:user, email: "test@example.com") }
       # let! is needed below to ensure that this user is created for file attachment because this is the depositor in the CSV fixtures
-      let(:depositor) { create(:user, email: 'batchuser@example.com') }
+      let(:depositor) { create(:user, email: "batchuser@example.com") }
       let(:importer) do
         create(:bulkrax_importer_csv,
                user: user,
                field_mapping: Bulkrax.field_mappings["HykuAddons::CsvParser"],
                parser_klass: "HykuAddons::CsvParser",
-               parser_fields: { 'import_file_path' => import_batch_file },
+               parser_fields: { "import_file_path" => import_batch_file },
                limit: 0)
       end
-      let(:import_batch_file) { 'spec/fixtures/csv/pacific_articles.metadata.csv' }
+      let(:import_batch_file) { "spec/fixtures/csv/pacific_articles.metadata.csv" }
     end
     # rubocop:enable RSpec/EmptyExampleGroup
   end
 
-  describe 'filter_out_excluded_fields' do
+  describe "filter_out_excluded_fields" do
     let(:metadata) do
       described_class.excluded_fields
                      .each_with_object("")
                      .to_h.merge(foo: :bar)
     end
-    let(:excluded_fields_with_values) { { exclude: 'true', include: 'false' } }
+    let(:excluded_fields_with_values) { { exclude: "true", include: "false" } }
     let(:result) { service.send(:processable_fields, metadata) }
 
-    it 'keeps attrs not listed' do
+    it "keeps attrs not listed" do
       expect(result.keys).to include(:foo)
     end
 

--- a/spec/services/hyku_addons/validations/solr_entry_validation_service_spec.rb
+++ b/spec/services/hyku_addons/validations/solr_entry_validation_service_spec.rb
@@ -2,14 +2,14 @@
 require "rails_helper"
 
 RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model do
-  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: 'Complete', id: 1, identifier: '123') }
-  let(:account) { create(:account, name: 'tenant', cname: 'example.com') }
+  let(:entry)   { instance_double(HykuAddons::CsvEntry, status: "Complete", id: 1, identifier: "123") }
+  let(:account) { create(:account, name: "tenant", cname: "example.com") }
 
   let(:valid_service_attrs) do
     {
-      base_url: 'somewhere',
-      username: 'someone',
-      password: 'secret'
+      base_url: "somewhere",
+      username: "someone",
+      password: "secret"
     }.with_indifferent_access
   end
 
@@ -62,13 +62,13 @@ RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model
   end
 
   describe "source_metadata" do
-    context 'using HTTP Basic Auth' do
+    context "using HTTP Basic Auth" do
       before do
         allow(HykuAddons::BlacklightWorkJsonService).to receive(:new)
           .and_return(instance_double(HykuAddons::BlacklightWorkJsonService, fetch: {}))
       end
 
-      it 'uses a BlacklightWorkJsonService' do
+      it "uses a BlacklightWorkJsonService" do
         service.source_metadata
         expect(HykuAddons::BlacklightWorkJsonService).to have_received(:new).with(
           valid_service_attrs[:base_url], valid_service_attrs[:username], valid_service_attrs[:password]
@@ -76,11 +76,11 @@ RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model
       end
     end
 
-    context 'using cookies' do
+    context "using cookies" do
       let(:valid_service_attrs) do
         {
-          base_url: 'somewhere',
-          cookie: 'foo'
+          base_url: "somewhere",
+          cookie: "foo"
         }.with_indifferent_access
       end
 
@@ -89,7 +89,7 @@ RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model
           .and_return(instance_double(HykuAddons::BlacklightWorkJsonCookieService, fetch: {}))
       end
 
-      it 'uses a BlacklightWorkJsonCookieService' do
+      it "uses a BlacklightWorkJsonCookieService" do
         service.source_metadata
         expect(HykuAddons::BlacklightWorkJsonCookieService).to have_received(:new)
           .with(valid_service_attrs[:base_url], valid_service_attrs[:cookie])
@@ -97,37 +97,37 @@ RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model
     end
   end
 
-  describe 'reevaluate_fields' do
+  describe "reevaluate_fields" do
     let(:reevaluation_result) { service.send(:reevaluate_fields, metadata) }
 
-    describe 'reevaluate_creator_tesim' do
+    describe "reevaluate_creator_tesim" do
       let(:metadata) do
         {
           creator_tesim: [[{
-            creator_role: 'Role',
-            creator_institutional_relationship: 'Relationship'
+            creator_role: "Role",
+            creator_institutional_relationship: "Relationship"
           }].to_json]
         }
       end
       let(:expected_transform) do
         [
           {
-            creator_organization_name: '',
-            creator_organisation_name: '',
-            creator_given_name: '',
-            creator_middle_name: '',
-            creator_family_name: '',
-            creator_name_type: '',
-            creator_orcid: '',
-            creator_isni: '',
-            creator_ror: '',
-            creator_grid: '',
-            creator_wikidata: '',
-            creator_suffix: '',
-            creator_role: ['Role'],
-            creator_institutional_relationship: ['Relationship'],
-            creator_position: '0',
-            creator_institution: ''
+            creator_organization_name: "",
+            creator_organisation_name: "",
+            creator_given_name: "",
+            creator_middle_name: "",
+            creator_family_name: "",
+            creator_name_type: "",
+            creator_orcid: "",
+            creator_isni: "",
+            creator_ror: "",
+            creator_grid: "",
+            creator_wikidata: "",
+            creator_suffix: "",
+            creator_role: ["Role"],
+            creator_institutional_relationship: ["Relationship"],
+            creator_position: "0",
+            creator_institution: ""
           }.with_indifferent_access
         ]
       end
@@ -137,33 +137,33 @@ RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model
       end
     end
 
-    describe 'reevaluate_contributor_tesim' do
+    describe "reevaluate_contributor_tesim" do
       let(:metadata) do
         {
           contributor_tesim: [[{
-            contributor_institutional_relationship: 'Relationship'
+            contributor_institutional_relationship: "Relationship"
           }].to_json]
         }
       end
       let(:expected_transform) do
         [
           {
-            contributor_organization_name: '',
-            contributor_organisation_name: '',
-            contributor_given_name: '',
-            contributor_middle_name: '',
-            contributor_family_name: '',
-            contributor_name_type: '',
-            contributor_orcid: '',
-            contributor_isni: '',
-            contributor_ror: '',
-            contributor_grid: '',
-            contributor_wikidata: '',
-            contributor_suffix: '',
-            contributor_institutional_relationship: ['Relationship'],
-            contributor_position: '0',
+            contributor_organization_name: "",
+            contributor_organisation_name: "",
+            contributor_given_name: "",
+            contributor_middle_name: "",
+            contributor_family_name: "",
+            contributor_name_type: "",
+            contributor_orcid: "",
+            contributor_isni: "",
+            contributor_ror: "",
+            contributor_grid: "",
+            contributor_wikidata: "",
+            contributor_suffix: "",
+            contributor_institutional_relationship: ["Relationship"],
+            contributor_position: "0",
             contributor_role: [],
-            contributor_institution: ''
+            contributor_institution: ""
           }.with_indifferent_access
         ]
       end
@@ -173,45 +173,45 @@ RSpec.describe HykuAddons::Validations::SolrEntryValidationService, type: :model
       end
     end
 
-    describe 'date_published_tesim' do
-      let(:metadata) { { date_published_tesim: ['2021-01-01'] } }
+    describe "date_published_tesim" do
+      let(:metadata) { { date_published_tesim: ["2021-01-01"] } }
 
       it "makes the reevaluation" do
-        expect(reevaluation_result).to eq(date_published_tesim: ['2021-1-1'])
+        expect(reevaluation_result).to eq(date_published_tesim: ["2021-1-1"])
       end
     end
 
-    describe 'reevaluate_has_model_ssim' do
-      let(:metadata) { { has_model_ssim: ['Pacific BookWork Work'] } }
+    describe "reevaluate_has_model_ssim" do
+      let(:metadata) { { has_model_ssim: ["Pacific BookWork Work"] } }
 
       it "makes the reevaluation" do
-        expect(reevaluation_result).to eq(has_model_ssim: ['PacificBook'])
+        expect(reevaluation_result).to eq(has_model_ssim: ["PacificBook"])
       end
     end
 
-    describe 'reevaluate_admin_set_tesim' do
-      context 'with mappable values' do
-        let(:metadata) { { admin_set_tesim: ['Default Admin Set'] } }
+    describe "reevaluate_admin_set_tesim" do
+      context "with mappable values" do
+        let(:metadata) { { admin_set_tesim: ["Default Admin Set"] } }
 
         it "makes the reevaluation" do
-          expect(reevaluation_result).to eq(admin_set_tesim: ['Default'])
+          expect(reevaluation_result).to eq(admin_set_tesim: ["Default"])
         end
       end
 
-      context 'with other admin sets' do
-        let(:metadata) { { admin_set_tesim: ['Foo'] } }
+      context "with other admin sets" do
+        let(:metadata) { { admin_set_tesim: ["Foo"] } }
 
         it "changes nothing" do
-          expect(reevaluation_result).to eq(admin_set_tesim: ['Foo'])
+          expect(reevaluation_result).to eq(admin_set_tesim: ["Foo"])
         end
       end
     end
 
-    describe 'reevaluate_human_readable_type_tesim' do
-      let(:metadata) { { human_readable_type_tesim: ['Pacific Book Work'] } }
+    describe "reevaluate_human_readable_type_tesim" do
+      let(:metadata) { { human_readable_type_tesim: ["Pacific Book Work"] } }
 
       it "makes the reevaluation" do
-        expect(reevaluation_result).to eq(human_readable_type_tesim: ['Pacific Book'])
+        expect(reevaluation_result).to eq(human_readable_type_tesim: ["Pacific Book"])
       end
     end
   end

--- a/spec/system/hyku_addons/edit_account_spec.rb
+++ b/spec/system/hyku_addons/edit_account_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Proprietor Edit Account Page', type: :system do
+RSpec.describe "Proprietor Edit Account Page", type: :system do
   let(:user) { FactoryBot.create(:admin) }
   let(:full_account) { create(:account) }
   let!(:account) { create(:account, search_only: true, full_account_ids: [full_account.id]) }
@@ -15,16 +15,16 @@ RSpec.describe 'Proprietor Edit Account Page', type: :system do
     Capybara.default_host = "http://#{account.cname}"
   end
 
-  describe 'shared search checkbox' do
-    xit 'can display checkbox for shared_search' do
+  describe "shared search checkbox" do
+    xit "can display checkbox for shared_search" do
       visit routes.edit_proprietor_account_url(account.id)
-      expect(find_field(id: 'account_search_only')).to be_checked
-      expect(page).to have_content('Search only')
+      expect(find_field(id: "account_search_only")).to be_checked
+      expect(page).to have_content("Search only")
     end
 
-    xit 'can display add to account text' do
+    xit "can display add to account text" do
       visit routes.new_proprietor_account_url
-      expect(page).to have_content('Add account to search')
+      expect(page).to have_content("Add account to search")
     end
   end
 end

--- a/spec/system/hyku_addons/hyku_addons_account_settings_spec.rb
+++ b/spec/system/hyku_addons/hyku_addons_account_settings_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'AccountSettings', type: :system do
+RSpec.describe "AccountSettings", type: :system do
   let(:user) { FactoryBot.create(:admin) }
   let!(:account) { create(:account) }
   before do
@@ -15,52 +15,52 @@ RSpec.describe 'AccountSettings', type: :system do
     account.switch!
   end
 
-  describe 'Account settings index page' do
-    it 'can display various edit links' do
+  describe "Account settings index page" do
+    it "can display various edit links" do
       visit hyku_addons.admin_account_settings_url
-      expect(page).to have_selector('h1')
-      expect(page).to have_selector 'h1', visible: true, text: /Account Settings/
-      expect(page).to have_link('Edit Contact email')
+      expect(page).to have_selector("h1")
+      expect(page).to have_selector "h1", visible: true, text: /Account Settings/
+      expect(page).to have_link("Edit Contact email")
     end
 
     it "can display single text field for edit" do
-      visit hyku_addons.edit_admin_account_setting_url(id: account, partial_name: 'render_text_fields', field_name: 'contact_email')
+      visit hyku_addons.edit_admin_account_setting_url(id: account, partial_name: "render_text_fields", field_name: "contact_email")
       expect(page).to have_http_status(:ok)
       expect(page).to have_css("label", text: "Contact email")
     end
 
     it "can display single array field for edit" do
-      visit hyku_addons.edit_admin_account_setting_url(id: account, partial_name: 'render_array_list', field_name: 'weekly_email_list')
+      visit hyku_addons.edit_admin_account_setting_url(id: account, partial_name: "render_array_list", field_name: "weekly_email_list")
       expect(page).to have_http_status(:ok)
       expect(page).to have_css("label", text: "Weekly email list")
     end
 
     it "can display hash fields for edit" do
-      visit hyku_addons.edit_admin_account_setting_url(id: account, partial_name: 'render_hash_settings', field_name: 'smtp_settings')
+      visit hyku_addons.edit_admin_account_setting_url(id: account, partial_name: "render_hash_settings", field_name: "smtp_settings")
       expect(page).to have_http_status(:ok)
       expect(page).to have_css("label", text: "Smtp settings")
     end
   end
 
-  describe 'Single settings key' do
+  describe "Single settings key" do
     context "Display in-place edit form for single key" do
-      it 'Display in-place edit' do
-        visit hyku_addons.edit_admin_account_setting_url(id: account.id, partial_name: 'render_text_fields', field_name: 'contact_email')
-        expect(page).to have_content('email')
-        expect(find_field('account[settings][contact_email]').value).to eq account.settings['contact_email']
-        expect(page).to have_link('Back')
-        expect(page).to have_selector(:link_or_button, 'Save changes')
+      it "Display in-place edit" do
+        visit hyku_addons.edit_admin_account_setting_url(id: account.id, partial_name: "render_text_fields", field_name: "contact_email")
+        expect(page).to have_content("email")
+        expect(find_field("account[settings][contact_email]").value).to eq account.settings["contact_email"]
+        expect(page).to have_link("Back")
+        expect(page).to have_selector(:link_or_button, "Save changes")
       end
     end
 
     context "Update single settings key" do
-      it 'save contact_email' do
-        visit hyku_addons.edit_admin_account_setting_url(id: account.id, partial_name: 'render_text_fields', field_name: 'contact_email')
-        expect(find_field('account[settings][contact_email]').value).to eq account.settings['contact_email']
-        find_field('account[settings][contact_email]').set 'do@do.com'
-        click_button 'Save changes'
+      it "save contact_email" do
+        visit hyku_addons.edit_admin_account_setting_url(id: account.id, partial_name: "render_text_fields", field_name: "contact_email")
+        expect(find_field("account[settings][contact_email]").value).to eq account.settings["contact_email"]
+        find_field("account[settings][contact_email]").set "do@do.com"
+        click_button "Save changes"
         account.reload
-        expect(account.settings['contact_email']).to eq('do@do.com')
+        expect(account.settings["contact_email"]).to eq("do@do.com")
       end
     end
   end
@@ -69,23 +69,23 @@ RSpec.describe 'AccountSettings', type: :system do
     context "Display page for all settings" do
       it "Can visit page to edit multiple setting keys" do
         visit hyku_addons.admin_account_settings_url
-        click_on 'Edit all fields'
-        expect(page).to have_content('Editing Account Settings')
-        expect(page).to have_link('Back')
-        expect(page).to have_selector(:link_or_button, 'Save changes')
+        click_on "Edit all fields"
+        expect(page).to have_content("Editing Account Settings")
+        expect(page).to have_link("Back")
+        expect(page).to have_selector(:link_or_button, "Save changes")
       end
     end
 
     context "Update multiple settings keys" do
       it "can save multiple settings keys" do
         visit hyku_addons.admin_account_settings_url
-        click_on 'Edit all fields'
-        find_field('account[settings][contact_email]').set 'do@do.com'
-        find_field('account[settings][weekly_email_list][]').set 'wema@we.yahoo.com ba@bl.uk'
-        click_button 'Save changes'
+        click_on "Edit all fields"
+        find_field("account[settings][contact_email]").set "do@do.com"
+        find_field("account[settings][weekly_email_list][]").set "wema@we.yahoo.com ba@bl.uk"
+        click_button "Save changes"
         account.reload
-        expect(account.settings['contact_email']).to eq('do@do.com')
-        expect(account.settings['weekly_email_list']).to eq ["wema@we.yahoo.com", "ba@bl.uk"]
+        expect(account.settings["contact_email"]).to eq("do@do.com")
+        expect(account.settings["weekly_email_list"]).to eq ["wema@we.yahoo.com", "ba@bl.uk"]
       end
     end
   end

--- a/spec/system/hyku_addons/new_account_spec.rb
+++ b/spec/system/hyku_addons/new_account_spec.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'rails_helper'
+require "rails_helper"
 
-RSpec.describe 'Proprietor New Account Page', type: :system do
+RSpec.describe "Proprietor New Account Page", type: :system do
   let(:user) { FactoryBot.create(:admin) }
   let(:full_account) { create(:account) }
   let!(:account) { create(:account, search_only: true) }
@@ -14,23 +14,23 @@ RSpec.describe 'Proprietor New Account Page', type: :system do
     Capybara.default_host = "http://#{account.cname}"
   end
 
-  describe 'shared search checkbox' do
-    xit 'can display checkbox for shared_search' do
+  describe "shared search checkbox" do
+    xit "can display checkbox for shared_search" do
       visit routes.new_proprietor_account_url
-      expect(page).to have_content('Search only')
-      expect(find_field(id: 'account_search_only')).not_to be_checked
+      expect(page).to have_content("Search only")
+      expect(find_field(id: "account_search_only")).not_to be_checked
     end
 
-    xit 'can check shared_search checkbox' do
+    xit "can check shared_search checkbox" do
       visit routes.new_proprietor_account_url
-      check 'account_search_only'
-      expect(find_field(id: 'account_search_only')).to be_checked
+      check "account_search_only"
+      expect(find_field(id: "account_search_only")).to be_checked
     end
 
-    xit 'can display add to account text' do
+    xit "can display add to account text" do
       visit routes.new_proprietor_account_url
-      check 'account_search_only'
-      expect(page).to have_content('Add account to search')
+      check "account_search_only"
+      expect(page).to have_content("Add account to search")
     end
   end
 end

--- a/spec/tasks/hyku_addons/rake_spec.rb
+++ b/spec/tasks/hyku_addons/rake_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-require 'rake'
+require "rake"
 
 RSpec.describe "HykuAddons Rake tasks" do
   before(:all) do
     Rails.application.load_tasks
   end
 
-  describe 'hyku:account:create_shared' do
-    let(:account_1) { create(:account, name: 'account_1') }
-    let(:account_2) { create(:account, name: 'account_2') }
+  describe "hyku:account:create_shared" do
+    let(:account_1) { create(:account, name: "account_1") }
+    let(:account_2) { create(:account, name: "account_2") }
     let(:account) do
-      build(:account, name: 'sample', search_only: true, full_account_ids: [account_1.id, account_2.id])
+      build(:account, name: "sample", search_only: true, full_account_ids: [account_1.id, account_2.id])
     end
 
     after do
@@ -19,41 +19,41 @@ RSpec.describe "HykuAddons Rake tasks" do
       account_2.destroy
     end
 
-    it 'raises error with no tenant_list' do
-      expect { run_task('hyku:account:create_shared', 'sample', '', 'sample.hyku.docker', '') }.to raise_error(ArgumentError, /Provide a list of tenants seperated by commas as last argument/)
+    it "raises error with no tenant_list" do
+      expect { run_task("hyku:account:create_shared", "sample", "", "sample.hyku.docker", "") }.to raise_error(ArgumentError, /Provide a list of tenants seperated by commas as last argument/)
     end
 
-    context 'with valid parameters' do
+    context "with valid parameters" do
       let(:create_account) { instance_double(CreateAccount) }
       let(:client) { double }
       let(:uuid) { SecureRandom.uuid }
 
       before do
         allow(Blacklight.default_index).to receive(:connection).and_return(client)
-        allow(client).to receive(:get).and_return('collections' => [account.tenant])
-        allow(Apartment::Tenant.adapter).to receive(:connect_to_new).and_return('')
+        allow(client).to receive(:get).and_return("collections" => [account.tenant])
+        allow(Apartment::Tenant.adapter).to receive(:connect_to_new).and_return("")
       end
 
-      it 'can create a shared search tenant' do
+      it "can create a shared search tenant" do
         allow(create_account).to receive(:save).and_return(account)
 
-        run_task('hyku:account:create_shared', 'sample', uuid, 'sample.hyku.docker', account_1.id, account_2.id)
+        run_task("hyku:account:create_shared", "sample", uuid, "sample.hyku.docker", account_1.id, account_2.id)
 
         expect(account.full_account_ids).to eq [account_1.id, account_2.id]
         expect(account.search_only?).to be_truthy
       end
     end
 
-    context 'account is not valid?' do
-      let(:bad_uuid) { 'd8c8a00a-dd0d-4db1-be93-f48eac2bb5edc' }
+    context "account is not valid?" do
+      let(:bad_uuid) { "d8c8a00a-dd0d-4db1-be93-f48eac2bb5edc" }
       let(:bad_account) do
-        build(:account, name: 'sample', search_only: true, full_account_ids: [account_1.id, account_2.id])
+        build(:account, name: "sample", search_only: true, full_account_ids: [account_1.id, account_2.id])
       end
 
-      it 'raises error with bad uuid' do
+      it "raises error with bad uuid" do
         bad_account.tenant = bad_uuid
         bad_account.valid?
-        expect { run_task('hyku:account:create_shared', 'search1', 'd8c8a00a-dd0d-4db1-be93-f48eac2bb5edc', 'dashboard.search1.ubiquityrepo-ah.website', account_1.id) }
+        expect { run_task("hyku:account:create_shared", "search1", "d8c8a00a-dd0d-4db1-be93-f48eac2bb5edc", "dashboard.search1.ubiquityrepo-ah.website", account_1.id) }
           .to raise_error(StandardError, "The following errors occurred - #{bad_account.errors.messages}")
       end
     end


### PR DESCRIPTION
Your dream/wish/nightmare has come true.

Update rubocop config to enforce double quotes 
For safety, I have applied this only to the test suite.  All tests updated tests still pass.

