### PR TITLE
Flaky Hyrax::DOI::RegisterDOIJob fix?

### DIFF
--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -1,9 +1,4 @@
 # frozen_string_literal: true
-FactoryBot.define do
-  factory :datacite_endpoint do
-    options { Hash.new(mode: "test", prefix: "10.1234", username: "user123", password: "pass123") }
-  end
-end
 
 FactoryBot.modify do
   factory :account do
@@ -25,6 +20,17 @@ FactoryBot.modify do
     end
     data do
       {}
+    end
+
+    trait(:with_datacite_endpoint) do
+      transient do
+        datacite_endpoint
+      end
+
+      after(:create) do |account|
+        account.create_datacite_endpoint(account.datacite_endpoint.options)
+        account.save
+      end
     end
   end
 end

--- a/spec/factories/accounts.rb
+++ b/spec/factories/accounts.rb
@@ -21,16 +21,5 @@ FactoryBot.modify do
     data do
       {}
     end
-
-    trait(:with_datacite_endpoint) do
-      transient do
-        datacite_endpoint
-      end
-
-      after(:create) do |account|
-        account.create_datacite_endpoint(account.datacite_endpoint.options)
-        account.save
-      end
-    end
   end
 end

--- a/spec/factories/datacite_endpoint.rb
+++ b/spec/factories/datacite_endpoint.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :datacite_endpoint do
+    options { Hash.new(mode: "test", prefix: "10.1234", username: "user123", password: "pass123") }
+  end
+end

--- a/spec/features/hyrax_doi_spec.rb
+++ b/spec/features/hyrax_doi_spec.rb
@@ -34,26 +34,18 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
     )
   end
 
-  let(:prefix) { datacite_endpoint.options["prefix"] }
+  let(:prefix) { "10.23716" }
   let(:cname) { "123456789" }
 
-  let(:datacite_endpoint) do
-    create(:datacite_endpoint, options:
-      {
-        mode: :test,
-        prefix: "10.23716",
-        username: "VJKA.JCRXZG-LOCAL",
-        password: "password"
-      })
-  end
-
-  let!(:account) { create(:account, :with_datacite_endpoint, datacite_endpoint: datacite_endpoint, cname: cname) }
+  let!(:account) { create(:account, cname: cname) }
   let!(:site) { Site.create(account: account) }
 
   before do
     allow(Site).to receive(:instance).and_return(site)
     allow(Flipflop).to receive(:enabled?).and_call_original
     allow(Flipflop).to receive(:enabled?).with(:doi_minting).and_return(true)
+
+    account.build_datacite_endpoint(mode: "test", prefix: prefix, username: "VJKA.JCRXZG-LOCAL", password: "password")
 
     # NOTE: Because Hyrax::DOI is build for Hyrax and not a multitenant environment, the datacite_endpoint data is
     # assigned in class varibles when switch! is called in the engine. Because I can"t seem to mock those varibles

--- a/spec/features/hyrax_doi_spec.rb
+++ b/spec/features/hyrax_doi_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 
 RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true do
   let(:user) { create(:user) }
-  let!(:account) { create(:account) }
   let(:attributes) do
     {
       title: ["Work title"],
@@ -36,6 +35,7 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
   end
 
   let(:prefix) { "10.23716" }
+
   let(:datacite_endpoint_attributes) do
     {
       mode: :test,
@@ -44,12 +44,14 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
       password: "password"
     }
   end
-  let(:account) do
+
+  let!(:account) do
     account = create(:account)
     account.create_datacite_endpoint(datacite_endpoint_attributes)
     account.save
     account
   end
+
   let(:site) { Site.create(account: account) }
 
   before do

--- a/spec/features/hyrax_doi_spec.rb
+++ b/spec/features/hyrax_doi_spec.rb
@@ -34,25 +34,21 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
     )
   end
 
-  let(:prefix) { "10.23716" }
+  let(:prefix) { datacite_endpoint.options["prefix"] }
+  let(:cname) { "123456789" }
 
-  let(:datacite_endpoint_attributes) do
-    {
-      mode: :test,
-      prefix: prefix,
-      username: "VJKA.JCRXZG-LOCAL",
-      password: "password"
-    }
+  let(:datacite_endpoint) do
+    create(:datacite_endpoint, options:
+      {
+        mode: :test,
+        prefix: "10.23716",
+        username: "VJKA.JCRXZG-LOCAL",
+        password: "password"
+      })
   end
 
-  let!(:account) do
-    account = create(:account)
-    account.create_datacite_endpoint(datacite_endpoint_attributes)
-    account.save
-    account
-  end
-
-  let(:site) { Site.create(account: account) }
+  let!(:account) { create(:account, :with_datacite_endpoint, datacite_endpoint: datacite_endpoint, cname: cname) }
+  let!(:site) { Site.create(account: account) }
 
   before do
     allow(Site).to receive(:instance).and_return(site)
@@ -115,8 +111,8 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
     )
 
     # Ensure that the _url methods have a host when creating XML data
-    Capybara.default_host = "http://#{account.cname}"
-    default_url_options[:host] = "http://#{account.cname}"
+    Capybara.default_host = "http://#{cname}"
+    default_url_options[:host] = "http://#{cname}"
 
     login_as user
   end
@@ -176,7 +172,7 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
 
         # Register the URL
         stub_request(:put, "https://mds.test.datacite.org/doi/#{doi}")
-          .with(body: "doi=#{doi}\nurl=http://#{account.cname}/concern/generic_works/#{work.id}", headers: text_headers)
+          .with(body: "doi=#{doi}\nurl=http://#{cname}/concern/generic_works/#{work.id}", headers: text_headers)
           .to_return(status: 201, body: "", headers: {})
       end
 


### PR DESCRIPTION
`Hyrax::DOI::RegisterDOIJob` regularly fails because the `cname` attribute of `account` has not been set.  Since we are not particularly concerned about this being randomised for this test, we can fix it first and create an account with a matching `cname`.  Then the `cname` will always have a value and this test hopefully will stop failing.

### Work completed
- [ ] Remove double definition of account
- [ ] Fix cname value
- [ ] Refactor test for brevity
- [ ] Refactor factories