### PR TITLE
Fix account behaviour spec failure

### DIFF
--- a/spec/factories/datacite_endpoint.rb
+++ b/spec/factories/datacite_endpoint.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :datacite_endpoint do
-    options { Hash.new(mode: "test", prefix: "10.1234", username: "user123", password: "pass123") }
+    options { Hash.new(mode: :test, prefix: "10.1234", username: "user123", password: "pass123") }
   end
 end

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -56,7 +56,6 @@ RSpec.describe HykuAddons::AccountBehavior do
   end
 
   describe "#switch" do
-    let!(:previous_datacite_mode) { Hyrax::DOI::DataCiteRegistrar.mode }
     let!(:previous_datacite_prefix) { Hyrax::DOI::DataCiteRegistrar.prefix }
     let!(:previous_datacite_username) { Hyrax::DOI::DataCiteRegistrar.username }
     let!(:previous_datacite_password) { Hyrax::DOI::DataCiteRegistrar.password }
@@ -87,7 +86,7 @@ RSpec.describe HykuAddons::AccountBehavior do
       account.switch do
         # no-op
       end
-      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq previous_datacite_mode
+      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq "test"
       expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq previous_datacite_prefix
       expect(Hyrax::DOI::DataCiteRegistrar.username).to eq previous_datacite_username
       expect(Hyrax::DOI::DataCiteRegistrar.password).to eq previous_datacite_password

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe HykuAddons::AccountBehavior do
       account.build_solr_endpoint(url: "http://example.com/solr/")
       account.build_fcrepo_endpoint(url: "http://example.com/fedora", base_path: "/dev")
       account.build_redis_endpoint(namespace: "foobaz")
-      account.build_datacite_endpoint(mode: "test", prefix: "10.1234", username: "user123", password: "pass123")
+      account.build_datacite_endpoint(mode: :test, prefix: "10.1234", username: "user123", password: "pass123")
       allow(Flipflop).to receive(:enabled?).with(:cache_api).and_return(cache_enabled)
       allow(Redis.current).to receive(:id).and_return "redis://localhost:6379/0"
       account.switch!
@@ -21,7 +21,7 @@ RSpec.describe HykuAddons::AccountBehavior do
     end
 
     it "switches the DataCite connection" do
-      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq "test"
+      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq :test
       expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq "10.1234"
       expect(Hyrax::DOI::DataCiteRegistrar.username).to eq "user123"
       expect(Hyrax::DOI::DataCiteRegistrar.password).to eq "pass123"
@@ -65,7 +65,7 @@ RSpec.describe HykuAddons::AccountBehavior do
       account.build_solr_endpoint(url: "http://example.com/solr/")
       account.build_fcrepo_endpoint(url: "http://example.com/fedora", base_path: "/dev")
       account.build_redis_endpoint(namespace: "foobaz")
-      account.build_datacite_endpoint(mode: "test", prefix: "10.1234", username: "user123", password: "pass123")
+      account.build_datacite_endpoint(mode: :test, prefix: "10.1234", username: "user123", password: "pass123")
     end
 
     after do
@@ -74,7 +74,7 @@ RSpec.describe HykuAddons::AccountBehavior do
 
     it "switches to the account-specific connection" do
       account.switch do
-        expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq "test"
+        expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq :test
         expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq "10.1234"
         expect(Hyrax::DOI::DataCiteRegistrar.username).to eq "user123"
         expect(Hyrax::DOI::DataCiteRegistrar.password).to eq "pass123"
@@ -86,7 +86,7 @@ RSpec.describe HykuAddons::AccountBehavior do
       account.switch do
         # no-op
       end
-      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq "test"
+      expect(Hyrax::DOI::DataCiteRegistrar.mode).to eq :test
       expect(Hyrax::DOI::DataCiteRegistrar.prefix).to eq previous_datacite_prefix
       expect(Hyrax::DOI::DataCiteRegistrar.username).to eq previous_datacite_username
       expect(Hyrax::DOI::DataCiteRegistrar.password).to eq previous_datacite_password


### PR DESCRIPTION
This is a possible fix for the flaky account_behaviour_spec.

In this commit https://github.com/ubiquitypress/hyku_addons/commit/ce74690d713d3e955535b63b515c7aefdfd523a1, the behaviour of `.reset!` was changed so that the mode is reset to `:test` rather than `nil`.  When `switch` (not `switch!` with a bang) is called and fails, then `reset!` is called (see source code [here](https://github.com/samvera/hyku/blob/v.2.1.0/app/models/account.rb#L94-L105)).  Hence the value of mode we should test for in the `it "resets the active connections back to the defaults"` test will always be `:test` not `nil`.  

Also it is worth noting that the config specifies the two valid values of mode are symbols not strings, but the test suite uses strings to setup the test objects, and so I have standardised this.
