### PR TITLE
Fix Bulkrax Test Failures

### DIFF
--- a/spec/features/bulkrax_import_spec.rb
+++ b/spec/features/bulkrax_import_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
+RSpec.describe "Bulkrax import", clean: true do
   let(:user) { create(:user, email: "test@example.com") }
   # let! is needed below to ensure that this user is created for file attachment because this is the depositor in the CSV fixtures
   let!(:depositor) { create(:user, email: "batchuser@example.com") }
@@ -113,12 +113,14 @@ RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
       end
 
       it "imports files" do
-        # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
-        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-        importer.import_works
+        perform_enqueued_jobs(only: AttachFilesToWorkJob) do
+          importer.import_works
+        end
+
         work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
+
         expect(work.file_sets.size).to eq 1
-        expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
+        expect(work.file_sets.first.title).to eq ["nypl-hydra-of-lerna.jpg"]
         expect(work.file_sets.first.visibility).to eq "open"
       end
 
@@ -142,12 +144,14 @@ RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
         end
 
         it "imports files" do
-          # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
-          ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-          importer.import_works
+          perform_enqueued_jobs(only: AttachFilesToWorkJob) do
+            importer.import_works
+          end
+
           work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
+
           expect(work.file_sets.size).to eq 1
-          expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
+          expect(work.file_sets.first.title).to eq ["nypl-hydra-of-lerna.jpg"]
         end
       end
 
@@ -155,9 +159,10 @@ RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
         let(:import_batch_file) { "spec/fixtures/csv/generic_work.file_set.csv" }
 
         it "imports files" do
-          # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
-          ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-          importer.import_works
+          perform_enqueued_jobs(only: AttachFilesToWorkJob) do
+            importer.import_works
+          end
+
           work = GenericWork.first
           expect(work.visibility).to eq "open"
           expect(work.file_sets.size).to eq 3

--- a/spec/features/bulkrax_import_spec.rb
+++ b/spec/features/bulkrax_import_spec.rb
@@ -113,14 +113,14 @@ RSpec.describe "Bulkrax import", clean: true do
       end
 
       it "imports files" do
-        perform_enqueued_jobs(only: AttachFilesToWorkJob) do
+        perform_enqueued_jobs(only: [AttachFilesToWorkJob, IngestJob, FileSetAttachedEventJob]) do
           importer.import_works
         end
 
         work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
 
         expect(work.file_sets.size).to eq 1
-        expect(work.file_sets.first.title).to eq ["nypl-hydra-of-lerna.jpg"]
+        expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
         expect(work.file_sets.first.visibility).to eq "open"
       end
 
@@ -144,14 +144,14 @@ RSpec.describe "Bulkrax import", clean: true do
         end
 
         it "imports files" do
-          perform_enqueued_jobs(only: AttachFilesToWorkJob) do
+          perform_enqueued_jobs(only: [AttachFilesToWorkJob, IngestJob, FileSetAttachedEventJob]) do
             importer.import_works
           end
 
           work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
 
           expect(work.file_sets.size).to eq 1
-          expect(work.file_sets.first.title).to eq ["nypl-hydra-of-lerna.jpg"]
+          expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
         end
       end
 
@@ -159,7 +159,7 @@ RSpec.describe "Bulkrax import", clean: true do
         let(:import_batch_file) { "spec/fixtures/csv/generic_work.file_set.csv" }
 
         it "imports files" do
-          perform_enqueued_jobs(only: AttachFilesToWorkJob) do
+          perform_enqueued_jobs(only: [AttachFilesToWorkJob, IngestJob, FileSetAttachedEventJob]) do
             importer.import_works
           end
 


### PR DESCRIPTION
After an update to the Hyrax Hirmeos tests relating to Bulkrax were failing.  There may have been no issue with the Hyrax Hirmeos update, but because the Bulkrax test ran *all* jobs, it is entirely likely the Hirmeos ones failed because the test was not set up with the information required for those jobs to run.

The failing tests tested whether files were imported as part of a feature test which involves running two separate jobs.  Because the original author of this test could not get a special configuration feature to work, code was added to run all jobs in the queue.  This is bad practice, as jobs should be run in isolation.  This pattern is repeated throughout the test suite and needs to be removed.

### Work done
Remove unnecessary use of workaround to filter jobs and adjust queue adaptor
Add in block which specifies which related jobs should be run
