### PR TITLE
switch find_by with activerecord exists?

### DIFF
--- a/app/presenters/concerns/hyku_addons/collection_presenter_override.rb
+++ b/app/presenters/concerns/hyku_addons/collection_presenter_override.rb
@@ -7,8 +7,7 @@ module HykuAddons
     def collection_type
       work_cname = @solr_document.to_h["account_cname_tesim"]
       account_cname = Array.wrap(work_cname).first
-      @check_cname_exists = Account.exists?(cname: account_cname)
-      return super unless @check_cname_exists.present?
+      return super unless Account.exists?(cname: account_cname)
 
       AccountElevator.switch!(account_cname) if account_cname.present?
       @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)

--- a/app/presenters/concerns/hyku_addons/collection_presenter_override.rb
+++ b/app/presenters/concerns/hyku_addons/collection_presenter_override.rb
@@ -7,8 +7,8 @@ module HykuAddons
     def collection_type
       work_cname = @solr_document.to_h["account_cname_tesim"]
       account_cname = Array.wrap(work_cname).first
-      @all_cname = Account.all.map(&:cname)
-      return super unless @all_cname.include? account_cname
+      @check_cname_exists = Account.exists?(cname: account_cname)
+      return super unless @check_cname_exists.present?
 
       AccountElevator.switch!(account_cname) if account_cname.present?
       @collection_type ||= Hyrax::CollectionType.find_by_gid!(collection_type_gid)


### PR DESCRIPTION
Performance improvement because using Benchmark.measure to compare **Account.all.map(&:cname)** and **Account.exists?(cname: account_cname)** showed the latter was about 2o times faster