### PR TITLE
update api to return the correct cname

### DIFF
--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+# FIXME: many attributes here left nil so specs will pass
+json.cache! [@account, :collections, collection.id, collection.solr_document[:_version_]] do
+  json.uuid collection.id
+  json.cname @account.search_only? ? collection.try(:solr_document)&.to_h&.dig("account_cname_tesim") : @account.cname
+  json.date_created collection.date_created&.first
+  json.date_published nil
+  json.description collection.description&.first
+  json.keywords collection.keyword&.first
+  json.language collection.language&.first
+  json.license_for_api_tesim collection.license&.first
+  json.publisher collection.publisher&.first
+  json.related_url collection.related_url&.first
+  json.resource_type collection.resource_type&.first
+  json.rights_statements_for_api_tesim collection.solr_document.rights_statement&.first
+  json.thumbnail_base64_string nil
+  json.thumbnail_url collection.solr_document.thumbnail_path
+  if Hyrax::PresenterFactory.build_for(ids: [collection.solr_document.thumbnail_id], presenter_class: Hyrax::FileSetPresenter, presenter_args: [current_ability, request]).first&.solr_document&.public?
+    components = {
+      scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'),
+      host: @account.cname,
+      path: collection.thumbnail_path.split('?')[0],
+      query: collection.thumbnail_path.split('?')[1]
+    }
+    json.thumbnail_url URI::Generic.build(components).to_s
+  else
+    json.thumbnail_url nil
+  end
+  json.title collection.title&.first
+  json.type "collection"
+  json.visibility collection.visibility
+  json.volumes nil
+  json.total_works @total_works
+end
+
+if local_assigns[:include_works]
+  json.works do
+    json.partial! 'hyku/api/v1/work/work', collection: @works, as: :work, collection_docs: Array.wrap(@collection_member_search_results)
+  end
+end

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -18,7 +18,7 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
   json.buy_book work.try(:solr_document)&.to_h&.dig('buy_book_tesim')
   json.challenged work.try(:solr_document)&.to_h&.dig('challenged_tesim')
   json.citation work.try(:solr_document)&.to_h&.dig('citation_tesim')
-  json.cname @account.cname
+  json.cname @account.search_only? ? work.try(:solr_document)&.to_h&.dig("account_cname_tesim") : @account.cname
   json.committee_member work.try(:solr_document)&.to_h&.dig('committee_member_tesim')
 
   creator = work.creator.try(:first)

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -278,7 +278,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                            "buy_book" => nil,
                                            "challenged" => nil,
                                            "citation" => nil,
-                                           "cname" => account.cname,
+                                           "cname" => (account.search_only? ? work.to_solr.dig("account_cname_tesim") : account.cname),
                                            "collections" => [],
                                            "committee_member" => nil,
                                            "contributor" => [{ "contributor_family_name" => "Gnitset",


### PR DESCRIPTION
The api current fetches cname off the account object which makes the cname wrong when it is a search_only account used for shared search. 
This PR fetches the cname from the work when it is a search only account, so  that the cname in  a shared search result can point to the tenant that holds the work for the purpose of redirecting from the react frontend to the right tenant holding the work.