### PR TITLE
Ensure each test only processes relevant jobs

### DIFF
--- a/spec/features/bulkrax_import_spec.rb
+++ b/spec/features/bulkrax_import_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
+RSpec.describe "Bulkrax import", clean: true do
   let(:user) { create(:user, email: "test@example.com") }
   # let! is needed below to ensure that this user is created for file attachment because this is the depositor in the CSV fixtures
   let!(:depositor) { create(:user, email: "batchuser@example.com") }
@@ -113,10 +113,12 @@ RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
       end
 
       it "imports files" do
-        # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
-        ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-        importer.import_works
+        perform_enqueued_jobs(only: [AttachFilesToWorkJob, IngestJob, FileSetAttachedEventJob]) do
+          importer.import_works
+        end
+
         work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
+
         expect(work.file_sets.size).to eq 1
         expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
         expect(work.file_sets.first.visibility).to eq "open"
@@ -142,10 +144,12 @@ RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
         end
 
         it "imports files" do
-          # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
-          ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-          importer.import_works
+          perform_enqueued_jobs(only: [AttachFilesToWorkJob, IngestJob, FileSetAttachedEventJob]) do
+            importer.import_works
+          end
+
           work = PacificArticle.find("c109b1ff-6d9a-4498-b86c-190e7dcbe2e0")
+
           expect(work.file_sets.size).to eq 1
           expect(work.file_sets.first.original_file.file_name).to eq ["nypl-hydra-of-lerna.jpg"]
         end
@@ -155,9 +159,10 @@ RSpec.describe "Bulkrax import", clean: true, perform_enqueued: true do
         let(:import_batch_file) { "spec/fixtures/csv/generic_work.file_set.csv" }
 
         it "imports files" do
-          # For some reason this has to be explictly set here and the meta tag in the top-most describe isn't sticking
-          ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
-          importer.import_works
+          perform_enqueued_jobs(only: [AttachFilesToWorkJob, IngestJob, FileSetAttachedEventJob]) do
+            importer.import_works
+          end
+
           work = GenericWork.first
           expect(work.visibility).to eq "open"
           expect(work.file_sets.size).to eq 3

--- a/spec/features/hyrax_doi_spec.rb
+++ b/spec/features/hyrax_doi_spec.rb
@@ -130,60 +130,29 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
 
     context "when the user selects `findable`" do
       let(:new_title) { "New work title" }
-      let(:doi) { "#{prefix}/kgkc-nn31" }
 
-      let(:response_fixture) { File.read Rails.root.join("..", "fixtures", "datacite", "put_metadata.xml") }
-      let(:common_headers) do
-        {
-          "Accept": "*/*",
-          "Accept-Encoding": "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
-          "Authorization": "Basic VkpLQS5KQ1JYWkctTE9DQUw6cGFzc3dvcmQ=",
-          "User-Agent": "Faraday v0.17.4"
-        }
-      end
-      let(:json_headers) do
-        common_headers.merge("Content-Type": "application/vnd.api+json")
-      end
-      let(:xml_headers) do
-        common_headers.merge("Content-Type": "application/xml;charset=UTF-8")
-      end
-      let(:text_headers) do
-        common_headers.merge("Content-Type": "text/plain;charset=UTF-8")
+      it "redirects the user to the works page" do
+        fill_in_form(new_title)
+
+        expect(page).to have_selector("h1", text: "Work", wait: 10)
+        expect(page).to have_selector("h2", text: new_title)
       end
 
-      before do
-        # The initial request to create_draft_doi
-        stub_request(:post, "https://api.test.datacite.org/dois")
-          .with(body: { "data": { "type": "dois", "attributes": { "prefix": prefix } } }.to_json, headers: json_headers)
-          .to_return(status: 201, body: { "data": { "id": doi, "type": "dois", "attributes": {} } }.to_json, headers: {})
-
-        # Send the work data to datacite
-        stub_request(:put, "https://mds.test.datacite.org/metadata/#{doi}")
-          .with(body: response_fixture, headers: xml_headers)
-          .to_return(status: 201, body: "", headers: {})
-
-        # Register the URL
-        stub_request(:put, "https://mds.test.datacite.org/doi/#{doi}")
-          .with(body: "doi=#{doi}\nurl=http://#{cname}/concern/generic_works/#{work.id}", headers: text_headers)
-          .to_return(status: 201, body: "", headers: {})
-      end
-
-      it "mints a DOI" do
-        perform_enqueued_jobs(only: Hyrax::DOI::RegisterDOIJob) do
-          choose "Findable"
-          choose "generic_work_visibility_open"
-          check "agreement"
-
-          find("a[role=tab]", text: "Description").click
-          fill_in("Title", with: new_title)
-          find("input[type=submit]").click
-
-          # Ensure we end up on the right page
-          expect(page).to have_selector("h1", text: "Work", wait: 10)
-          expect(page).to have_selector("h2", text: new_title)
-          expect(page).to have_selector("a", text: "https://doi.org/#{doi}")
-        end
+      it "enqueues a job to mint the DOI" do
+        expect { fill_in_form(new_title) }.to have_enqueued_job(Hyrax::DOI::RegisterDOIJob).with(work.reload, registrar: "datacite", registrar_opts: {})
       end
     end
   end
+
+  private
+
+    def fill_in_form(title)
+      choose "Findable"
+      choose "generic_work_visibility_open"
+      check "agreement"
+
+      find("a[role=tab]", text: "Description").click
+      fill_in("Title", with: title)
+      find("input[type=submit]").click
+    end
 end

--- a/spec/features/hyrax_doi_spec.rb
+++ b/spec/features/hyrax_doi_spec.rb
@@ -169,7 +169,7 @@ RSpec.describe "Minting a DOI for an existing work", multitenant: true, js: true
       end
 
       it "mints a DOI" do
-        perform_enqueued_jobs do
+        perform_enqueued_jobs(only: Hyrax::DOI::RegisterDOIJob) do
           choose "Findable"
           choose "generic_work_visibility_open"
           check "agreement"

--- a/spec/jobs/import_mode_spec.rb
+++ b/spec/jobs/import_mode_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe HykuAddons::ImportMode, perform_enqueued_jobs: true do
+RSpec.describe HykuAddons::ImportMode do
   before do
     allow(Apartment::Tenant).to receive(:current).and_return("x")
     allow(Account).to receive(:find_by).with(tenant: "x").and_return(account)

--- a/spec/jobs/reindex_available_works_job_spec.rb
+++ b/spec/jobs/reindex_available_works_job_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe HykuAddons::ReindexAvailableWorksJob, perform_enqueued_jobs: true do
+RSpec.describe HykuAddons::ReindexAvailableWorksJob do
   let(:account) { create(:account) }
   let(:work) { create(:work) }
   let(:site) { instance_double(Site) }
@@ -22,7 +22,6 @@ RSpec.describe HykuAddons::ReindexAvailableWorksJob, perform_enqueued_jobs: true
   end
 
   it "#perform_now can enqueue model for reindex" do
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     expect { described_class.perform_now([account.cname]) }.not_to have_enqueued_job(described_class)
   end
 end

--- a/spec/jobs/reindex_available_works_job_spec.rb
+++ b/spec/jobs/reindex_available_works_job_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe HykuAddons::ReindexAvailableWorksJob do
   let(:site) { instance_double(Site) }
 
   before do
-    ActiveJob::Base.queue_adapter = :test
     allow(site).to receive(:available_works).and_return([work.class.to_s])
 
     allow(Apartment::Tenant).to receive(:switch!).with(account.tenant) do |&block|
@@ -17,11 +16,11 @@ RSpec.describe HykuAddons::ReindexAvailableWorksJob do
     Apartment::Tenant.switch!(account.tenant) { work }
   end
 
-  it "#perform_later can enqueue model for reindex" do
+  it "#perform_later can enqueue available works job" do
     expect { described_class.perform_later([account.cname]) }.to have_enqueued_job(described_class)
   end
 
-  it "#perform_now can enqueue model for reindex" do
-    expect { described_class.perform_now([account.cname]) }.not_to have_enqueued_job(described_class)
+  it "#perform_now will enqueue each model for reindex" do
+    expect { described_class.perform_now([account.cname]) }.to have_enqueued_job(HykuAddons::ReindexModelJob).at_least(:once)
   end
 end

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-RSpec.describe HykuAddons::ReindexModelJob, perform_enqueued_jobs: true do
+RSpec.describe HykuAddons::ReindexModelJob do
   let(:account) { create(:account) }
   let(:work) { create(:work) }
 
   before do
-    ActiveJob::Base.queue_adapter = :test
+    ActiveJob::Base.queue_adapter = :inline
     allow(work.class).to receive(:reindex_everything)
     allow(Apartment::Tenant).to receive(:switch!).with(account.tenant) do |&block|
       block&.call
@@ -19,7 +19,6 @@ RSpec.describe HykuAddons::ReindexModelJob, perform_enqueued_jobs: true do
   end
 
   it "#perform_now can enqueue model for reindex" do
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs = true
     expect { described_class.perform_now(work.class.to_s, account.cname) }.not_to have_enqueued_job(described_class)
   end
 end

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe HykuAddons::ReindexModelJob do
   let(:work) { create(:work) }
 
   before do
-    ActiveJob::Base.queue_adapter = :inline
     allow(work.class).to receive(:reindex_everything)
+
     allow(Apartment::Tenant).to receive(:switch!).with(account.tenant) do |&block|
       block&.call
     end
@@ -14,11 +14,11 @@ RSpec.describe HykuAddons::ReindexModelJob do
     Apartment::Tenant.switch!(account.tenant) { work }
   end
 
-  it "#perform_later can enqueue model for reindex" do
-    expect { described_class.perform_later(work.class.to_s, account.cname) }.to have_enqueued_job(described_class)
+  it "#perform_later can enqueue model for reindex later" do
+    expect { described_class.perform_later(work.class.to_s, account.cname) }.to have_enqueued_job(described_class).exactly(:once)
   end
 
-  it "#perform_now can enqueue model for reindex" do
-    expect { described_class.perform_now(work.class.to_s, account.cname) }.not_to have_enqueued_job(described_class)
+  it "#perform_now will enqueue model for reindex" do
+    expect { described_class.perform_now(work.class.to_s, account.cname) }.to have_enqueued_job(described_class).exactly(:once)
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,8 +79,6 @@ rescue ActiveRecord::PendingMigrationError => e
   exit 1
 end
 
-ActiveJob::Base.queue_adapter = :test
-
 RSpec.configure do |config|
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
@@ -134,17 +132,8 @@ RSpec.configure do |config|
   #   ActiveJob::Base.queue_adapter.filter = [JobClass]
   #
 
-  config.around(:example, :perform_enqueued) do |example|
-    ActiveJob::Base.queue_adapter.filter =
-      example.metadata[:perform_enqueued].try(:to_a)
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = true
-    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = true
-
-    example.run
-
-    ActiveJob::Base.queue_adapter.filter = nil
-    ActiveJob::Base.queue_adapter.perform_enqueued_jobs    = false
-    ActiveJob::Base.queue_adapter.perform_enqueued_at_jobs = false
+  config.before do
+    ActiveJob::Base.queue_adapter = :test
   end
 
   # Add support for conditional execution of specs

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -136,6 +136,10 @@ RSpec.configure do |config|
     ActiveJob::Base.queue_adapter = :test
   end
 
+  config.after do
+    clear_enqueued_jobs
+  end
+
   # Add support for conditional execution of specs
   config.include OptionalExample
 


### PR DESCRIPTION
Following on from the bug fix in [549](https://github.com/ubiquitypress/hyku_addons/pull/549), by applying the same refactoring to each place the pattern was present in the test suite.
Previously these tests processed *all* jobs that got enqueued.  Now, either test that the required job is enqueued with the correct parameter (and rely on the tests for that job to know the application will end up in the correct state) or run only those jobs required for the feature.

### Work completed
Remove `config.around(:example, :perform_enqueued)` config block
Ensure all outstanding tests are cleared at the end of each run
Refactor HyraxDoiSpec by splitting 'it mints a DOI' into three tests.  
-First test checks the user is redirected after the form is filled in.  
-Second test checks that the appropriate jobs are logged with the right parameters.
-Third test checks that if an existing work has a minted DOI then the link to it is displayed on its show page.
Refactor `ReindexAvailableWorksJob` and `ReindexModelJob` to take account of the fact that all jobs will not run
-These jobs both spawn more `ReindexModelJob`s.  So when `.perform_now` is run we should see instances of `ReindexModelJob` enqueued, and once instance of the spawning job performed.

@mankind could you please review this to confirm that I have understood the `ReindexAvailableWorksJob` and `ReindexModelJob` classes correctly.
