### PR TITLE
Local ImageMagick permissions for Post Script enabled documents

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,3 +51,5 @@ RUN bundle config build.nokogiri --use-system-libraries && \
     setuser app bundle install --jobs=4 --retry=3 && \
     chmod 777  -R .bundle/*  # Otherwise `app` owns this file and the host cannot run bundler commands
 
+RUN sed -i '/disable ghostscript format types/,+6d' /etc/ImageMagick-6/policy.xml
+


### PR DESCRIPTION
This hopefully fixes issues around rendering fileset thumbails locally and also a broken `create` redirect when a work is first saved. 