### PR TITLE
Api should return cname as a string

### DIFF
--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 json.cache! [@account, :collections, collection.id, collection.solr_document[:_version_]] do
   json.uuid collection.id
-  json.cname @account.search_only? ? collection.try(:solr_document)&.to_h&.dig("account_cname_tesim") : @account.cname
+  json.cname @account.search_only? ? collection.try(:solr_document)&.to_h&.dig("account_cname_tesim").first : @account.cname
   json.date_created collection.date_created&.first
   json.date_published nil
   json.description collection.description&.first

--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -3,7 +3,7 @@
 # rubocop:disable Metrics/BlockLength
 json.cache! [@account, :collections, collection.id, collection.solr_document[:_version_]] do
   json.uuid collection.id
-  json.cname @account.search_only? ? collection.try(:solr_document)&.to_h&.dig("account_cname_tesim").first : @account.cname
+  json.cname @account.search_only? ? collection.try(:solr_document)&.to_h&.dig("account_cname_tesim")&.first : @account.cname
   json.date_created collection.date_created&.first
   json.date_published nil
   json.description collection.description&.first

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -18,7 +18,7 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
   json.buy_book work.try(:solr_document)&.to_h&.dig('buy_book_tesim')
   json.challenged work.try(:solr_document)&.to_h&.dig('challenged_tesim')
   json.citation work.try(:solr_document)&.to_h&.dig('citation_tesim')
-  json.cname @account.search_only? ? work.try(:solr_document)&.to_h&.dig("account_cname_tesim").first : @account.cname
+  json.cname @account.search_only? ? work.try(:solr_document)&.to_h&.dig("account_cname_tesim")&.first : @account.cname
   json.committee_member work.try(:solr_document)&.to_h&.dig('committee_member_tesim')
 
   creator = work.creator.try(:first)

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -18,7 +18,7 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
   json.buy_book work.try(:solr_document)&.to_h&.dig('buy_book_tesim')
   json.challenged work.try(:solr_document)&.to_h&.dig('challenged_tesim')
   json.citation work.try(:solr_document)&.to_h&.dig('citation_tesim')
-  json.cname @account.search_only? ? work.try(:solr_document)&.to_h&.dig("account_cname_tesim") : @account.cname
+  json.cname @account.search_only? ? work.try(:solr_document)&.to_h&.dig("account_cname_tesim").first : @account.cname
   json.committee_member work.try(:solr_document)&.to_h&.dig('committee_member_tesim')
 
   creator = work.creator.try(:first)

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
 
   describe "/work/:id" do
     let(:json_response) { JSON.parse(response.body) }
-    let(:cname) { (account.search_only? ? work.to_solr.dig("account_cname_tesim").first : account.cname) }
+    let(:cname) { (account.search_only? ? work.to_solr.dig("account_cname_tesim")&.first : account.cname) }
     context "when repository has content" do
       let(:work) { create(:work, visibility: "open") }
 

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
 
   describe "/work/:id" do
     let(:json_response) { JSON.parse(response.body) }
-
+    let(:cname) { (account.search_only? ? work.to_solr.dig("account_cname_tesim").first : account.cname) }
     context "when repository has content" do
       let(:work) { create(:work, visibility: "open") }
 
@@ -160,7 +160,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                          "buy_book" => nil,
                                          "challenged" => nil,
                                          "citation" => nil,
-                                         "cname" => account.cname,
+                                         "cname" => cname,
                                          "collections" => [],
                                          "committee_member" => nil,
                                          "contributor" => [],
@@ -263,6 +263,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
           work.save!
           get "/api/v1/tenant/#{account.tenant}/work/#{work.id}"
 
+          expect(json_response["cname"]).to be_a(String)
           expect(json_response).to include("abstract" => "Swedish comic about the adventures of the residents of Moominvalley.",
                                            "adapted_from" => nil,
                                            "additional_info" => ["Nothing to report"],
@@ -278,7 +279,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                            "buy_book" => nil,
                                            "challenged" => nil,
                                            "citation" => nil,
-                                           "cname" => (account.search_only? ? work.to_solr.dig("account_cname_tesim") : account.cname),
+                                           "cname" => cname,
                                            "collections" => [],
                                            "committee_member" => nil,
                                            "contributor" => [{ "contributor_family_name" => "Gnitset",


### PR DESCRIPTION
The Api is returning **cname** as an array which is a breaking change that makes the React frontend not to be able to show links in shared search result. This PR returns the cname as a string.