### PR TITLE
refactor reindex_available_works_job & reindex_model_jobs to accept ids for works to index

### DIFF
--- a/app/jobs/hyku_addons/reindex_available_works_job.rb
+++ b/app/jobs/hyku_addons/reindex_available_works_job.rb
@@ -1,8 +1,16 @@
 # frozen_string_literal: true
+
+# call with
+# HykuAddons::ReindexAvailableWorksJob.perform_now(['repo.hyku.docker'], cname_doi_mint: ["repo.hyku.docker"] )
+#
+# HykuAddons::ReindexAvailableWorksJob.perform_now(['repo.hyku.docker'])
+
 module HykuAddons
   class ReindexAvailableWorksJob < ApplicationJob
     # cnames is an array
-    def perform(cnames)
+    def perform(cnames, cname_doi_mint: [])
+      @cname_doi_mint = cname_doi_mint
+
       cnames.each do |name|
         cname = cnames.delete(name)
         reindex(cname)
@@ -21,7 +29,8 @@ module HykuAddons
           next unless klass.count.positive?
 
           Rails.logger.debug "==== Queue ReindexModelJob for #{klass} ==="
-          HykuAddons::ReindexModelJob.perform_later(model_class, cname)
+          HykuAddons::ReindexModelJob.perform_later(model_class, cname, options: { cname_doi_mint: @cname_doi_mint }) if @cname_doi_mint.include?(cname)
+          HykuAddons::ReindexModelJob.perform_later(model_class, cname) unless @cname_doi_mint.include?(cname)
         end
       end
   end

--- a/app/jobs/hyku_addons/reindex_available_works_job.rb
+++ b/app/jobs/hyku_addons/reindex_available_works_job.rb
@@ -12,8 +12,7 @@ module HykuAddons
       @cname_doi_mint = cname_doi_mint
 
       cnames.each do |name|
-        cname = cnames.delete(name)
-        reindex(cname)
+        reindex(cnames.delete(name))
       end
     end
 
@@ -29,8 +28,7 @@ module HykuAddons
           next unless klass.count.positive?
 
           Rails.logger.debug "==== Queue ReindexModelJob for #{klass} ==="
-          HykuAddons::ReindexModelJob.perform_later(model_class, cname, options: { cname_doi_mint: @cname_doi_mint }) if @cname_doi_mint.include?(cname)
-          HykuAddons::ReindexModelJob.perform_later(model_class, cname) unless @cname_doi_mint.include?(cname)
+          HykuAddons::ReindexModelJob.perform_later(model_class, cname, options: { cname_doi_mint: @cname_doi_mint })
         end
       end
   end

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -1,43 +1,38 @@
 # frozen_string_literal: true
+
+# call with
+#  use_work_ids an array is just for testing a few ids
+# HykuAddons::ReindexModelJob.perform_now("GenericWork", "repo.hyku.docker", limit: 1, options: { cname_doi_mint: ["repo.hyku.docker"], use_work_ids: ["15b3c16b-8183-4d2a-86ef-d144176fa0c8"]} )
+#
+# HykuAddons::ReindexAvailableWorksJob.perform_later(["repo.hyku.docker"], options: { cname_doi_mint: ["repo.hyku.docker"]} )
+
 module HykuAddons
   class ReindexModelJob < ApplicationJob
-    queue_as :reindex
-
     rescue_from Hyrax::DOI::DataCiteClient::Error, Ldp::Gone, Ldp::HttpError, RSolr::Error::Http, RSolr::Error::ConnectionRefused do |exception|
       Rails.logger.debug exception.inspect
       retry_job(wait: 5.minutes)
     end
 
-    def perform(klass, cname, limit: 25, page: 1, cname_doi_mint: [])
+    def perform(klass, cname, limit: 25, page: 1, options: {})
+      options ||= options || { cname_doi_mint: [], use_work_ids: [] }
       # for whatever in private methods reason without assigning it to instamce variable it throws undefined local variable
-      @cname_doi_mint = cname_doi_mint
+      @cname_doi_mint = options[:cname_doi_mint]
+      @use_work_ids = options[:use_work_ids]
       @cname = cname
+      @limit = limit
+      @page = page
+      @klass = klass
       AccountElevator.switch!(cname)
 
-      Rails.logger.debug "=== Starting to reindex #{klass} in #{cname} ==="
-
-      offset = (page - 1) * limit
-
-      # When the offset becomes too large, no records would be found
-      works =  klass.constantize.where("title_tesim:*").limit(limit).offset(offset)
-
-      # with calling to_a it always returns true, even when no records found
-      if works.to_a.any?
-        reindex_works(works)
-
-        new_page_count = page.to_i + 1
-
-        # Re-enqueue
-        ReindexModelJob.perform_later(klass, cname, page: new_page_count)
-      end
-
-      Rails.logger.debug "=== Completed reindex of #{klass} in #{cname} ==="
+      offset = (page - 1) * @limit
+      work_class = klass.constantize
+      fetch_work_using_ids(work_class) if @use_work_ids.present?
+      reindex_and_mint_work(work_class, offset) unless @use_work_ids.present?
     end
 
     private
 
       def reindex_works(works)
-        # works.each(&:update_index)
         works.each do |work|
           mint_doi(work) if @cname_doi_mint.present? && @cname_doi_mint.include?(@cname)
 
@@ -51,9 +46,37 @@ module HykuAddons
       def mint_doi(work)
         return if work.doi.present?
 
-        work.update(doi_status_when_public: "findable")
+        Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
+        work.update(doi_status_when_public: "findable", visibility: "open")
         register_doi = Hyrax::DOI::DataCiteRegistrar.new.register!(object: work)
         work.update(doi: [register_doi.identifier])
+      end
+
+      def fetch_work_using_ids(klass)
+        @use_work_ids.map do |id|
+          work = klass.find(id)
+          Rails.logger.debug "=== updating index with #{id}for #{work&.title&.to_a&.first} ===="
+          mint_doi(work) if @cname_doi_mint.present? && @cname_doi_mint.include?(@cname)
+          work.save
+        end
+      end
+
+      # When the offset becomes too large, no records would be found
+      def reindex_and_mint_work(work_class, offset)
+        works = work_class.where("title_tesim:*").limit(@limit).offset(offset)
+        return unless works&.to_a&.any?
+
+        Rails.logger.debug "=== Starting to reindex #{@klass} in #{@cname} ==="
+
+        # with calling to_a it always returns true, even when no records found
+        reindex_works(works)
+
+        new_page_count = @page.to_i + 1
+
+        # Re-enqueue
+        ReindexModelJob.perform_later(@klass, @cname, @limit, page: new_page_count, cname_doi_mint: @cname_doi_mint)
+        sleep(0.5)
+        Rails.logger.debug "=== Completed reindex of #{@klass} in #{@cname} ==="
       end
   end
 end

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -47,7 +47,7 @@ module HykuAddons
         return if work.doi.present?
 
         Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
-        work.update(doi_status_when_public: "findable", visibility: "open")
+        work.update(doi_status_when_public: "findable")
         register_doi = Hyrax::DOI::DataCiteRegistrar.new.register!(object: work)
         work.update(doi: [register_doi.identifier])
       end

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -71,11 +71,8 @@ module HykuAddons
         # with calling to_a it always returns true, even when no records found
         reindex_works(works)
 
-        new_page_count = @page.to_i + 1
-
         # Re-enqueue
-        ReindexModelJob.perform_later(@klass, @cname, @limit, page: new_page_count, cname_doi_mint: @cname_doi_mint)
-        sleep(0.5)
+        ReindexModelJob.perform_later(@klass, @cname, @limit, page: @page.to_i + 1, cname_doi_mint: @cname_doi_mint)
         Rails.logger.debug "=== Completed reindex of #{@klass} in #{@cname} ==="
       end
   end

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
-# call with
 #  use_work_ids an array is just for testing a few ids
-# HykuAddons::ReindexModelJob.perform_now("GenericWork", "repo.hyku.docker", limit: 1, options: { cname_doi_mint: ["repo.hyku.docker"], use_work_ids: ["15b3c16b-8183-4d2a-86ef-d144176fa0c8"]} )
-#
-# HykuAddons::ReindexAvailableWorksJob.perform_later(["repo.hyku.docker"], options: { cname_doi_mint: ["repo.hyku.docker"]} )
+#  HykuAddons::ReindexModelJob.perform_now("GenericWork", "repo.hyku.docker", limit: 1, options: { cname_doi_mint: ["repo.hyku.docker"], use_work_ids: ["15b3c16b-8183-4d2a-86ef-d144176fa0c8"]} )
+#  HykuAddons::ReindexAvailableWorksJob.perform_later(["repo.hyku.docker"], options: { cname_doi_mint: ["repo.hyku.docker"]} )
 
 module HykuAddons
   class ReindexModelJob < ApplicationJob
@@ -13,6 +11,7 @@ module HykuAddons
       retry_job(wait: 5.minutes)
     end
 
+    # rubocop:disable Metrics/MethodLength
     def perform(klass, cname, limit: 25, page: 1, options: {})
       options ||= options || { cname_doi_mint: [], use_work_ids: [] }
       # for whatever in private methods reason without assigning it to instamce variable it throws undefined local variable
@@ -23,17 +22,21 @@ module HykuAddons
       @page = page
       @klass = klass
       AccountElevator.switch!(cname)
-
       offset = (page - 1) * @limit
       work_class = klass.constantize
-      fetch_work_using_ids(work_class) if @use_work_ids.present?
-      reindex_and_mint_work(work_class, offset) unless @use_work_ids.present?
+
+      if @use_work_ids.present?
+        fetch_work_using_ids(work_class)
+      else
+        reindex_and_mint_work(work_class, offset)
+      end
     end
 
     private
 
       def mint_doi(work)
         return if work.doi.present?
+
         Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
         work.update(doi_status_when_public: "findable")
         register_doi = Hyrax::DOI::DataCiteRegistrar.new.register!(object: work)

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -13,7 +13,7 @@ module HykuAddons
 
     # rubocop:disable Metrics/MethodLength
     def perform(klass, cname, limit: 25, page: 1, options: {})
-      options ||= options || { cname_doi_mint: [], use_work_ids: [] }
+      options = options.presence || { cname_doi_mint: [], use_work_ids: [] }
       # for whatever in private methods reason without assigning it to instamce variable it throws undefined local variable
       @cname_doi_mint = options[:cname_doi_mint]
       @use_work_ids = options[:use_work_ids]

--- a/spec/jobs/reindex_available_works_job_spec.rb
+++ b/spec/jobs/reindex_available_works_job_spec.rb
@@ -16,11 +16,14 @@ RSpec.describe HykuAddons::ReindexAvailableWorksJob do
     Apartment::Tenant.switch!(account.tenant) { work }
   end
 
-  it "#perform_later can enqueue available works job" do
-    expect { described_class.perform_later([account.cname]) }.to have_enqueued_job(described_class)
+  it "can enqueue job with correct parameters" do
+    expect { described_class.perform_later([account.cname]) }.to have_enqueued_job(described_class).with([account.cname])
   end
 
-  it "#perform_now will enqueue each model for reindex" do
-    expect { described_class.perform_now([account.cname]) }.to have_enqueued_job(HykuAddons::ReindexModelJob).at_least(:once)
+  it "can enqueue ReindexModelJob with correct paramters" do
+    expect do
+      described_class.perform_now([account.cname], cname_doi_mint: [account.cname])
+    end.to have_enqueued_job(HykuAddons::ReindexModelJob).at_least(:once)
+                                                         .with(work.class.to_s, account.cname, options: { cname_doi_mint: [account.cname] })
   end
 end

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -3,14 +3,12 @@
 RSpec.describe HykuAddons::ReindexModelJob do
   let(:account) { create(:account, cname: cname) }
   let(:work) { create(:work, doi: []) }
-  let(:second_work) { create(:work, title: ["another work"], doi: []) }
   let(:prefix) { "10.1234" }
   let(:cname) { "123abc" }
   let(:response_body) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "doi", "mint_doi_return_body.json")) }
   let(:options) { { cname_doi_mint: [account.cname], use_work_ids: [work.id] } }
 
   before do
-    GenericWork.all.map(&:destroy)
     Hyrax::DOI::DataCiteRegistrar.username = "username"
     Hyrax::DOI::DataCiteRegistrar.password = "password"
     Hyrax::DOI::DataCiteRegistrar.prefix = prefix
@@ -30,9 +28,7 @@ RSpec.describe HykuAddons::ReindexModelJob do
   end
 
   it "sets doi_status_when_public to findable" do
-    expect(work.doi).to be_empty
     described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: options)
-    work.reload
-    expect(work.doi_status_when_public).to eq "findable"
+    expect(work.reload.doi_status_when_public).to eq "findable"
   end
 end

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -1,11 +1,26 @@
 # frozen_string_literal: true
 
 RSpec.describe HykuAddons::ReindexModelJob do
-  let(:account) { create(:account) }
-  let(:work) { create(:work) }
+  let(:account) { create(:account, cname: cname) }
+  let(:work) { create(:work, doi: []) }
+  let(:second_work) { create(:work, title: ["another work"], doi: []) }
+  let(:prefix) { "10.1234" }
+  let(:cname) { "123abc" }
+  let(:response_body) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "doi", "mint_doi_return_body.json")) }
+  let(:options) { { cname_doi_mint: [account.cname], use_work_ids: [work.id] } }
 
   before do
-    allow(work.class).to receive(:reindex_everything)
+    GenericWork.all.map(&:destroy)
+    Hyrax::DOI::DataCiteRegistrar.username = "username"
+    Hyrax::DOI::DataCiteRegistrar.password = "password"
+    Hyrax::DOI::DataCiteRegistrar.prefix = prefix
+    Hyrax::DOI::DataCiteRegistrar.mode = :test
+
+    stub_request(:post, URI.join(Hyrax::DOI::DataCiteClient::TEST_BASE_URL, "dois"))
+      .with(body: "{\"data\":{\"type\":\"dois\",\"attributes\":{\"prefix\":\"#{prefix}\"}}}",
+            headers: { "Content-Type" => "application/vnd.api+json" },
+            basic_auth: ["username", "password"])
+      .to_return(status: 200, body: response_body)
 
     allow(Apartment::Tenant).to receive(:switch!).with(account.tenant) do |&block|
       block&.call
@@ -14,11 +29,10 @@ RSpec.describe HykuAddons::ReindexModelJob do
     Apartment::Tenant.switch!(account.tenant) { work }
   end
 
-  it "#perform_later can enqueue model for reindex later" do
-    expect { described_class.perform_later(work.class.to_s, account.cname) }.to have_enqueued_job(described_class).exactly(:once)
-  end
-
-  it "#perform_now will enqueue model for reindex" do
-    expect { described_class.perform_now(work.class.to_s, account.cname) }.to have_enqueued_job(described_class).exactly(:once)
+  it "sets doi_status_when_public to findable" do
+    expect(work.doi).to be_empty
+    described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: options)
+    work.reload
+    expect(work.doi_status_when_public).to eq "findable"
   end
 end


### PR DESCRIPTION
We need to be able to pass the cnames of tenants to mint doi to each requeue of the job class. 
Secondly, **Tom W** wants us to accept a few ids to mint doi for to test it is working on demo sites, that way we don't have to loop through all the works in a work type  just to test that doi minting can be triggered by the Sidekiq job unless we are running it against production.

In the test calling this:

    expect { described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: options) }.to change { work.doi_status_when_public }.to eq "findable"

 always  returns 
 
    expect X to have changed to eq "findable", but did not change 
 
Hence you will see that I used:

     described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: options)
     work.reload
     expect(work.doi_status_when_public).to eq "findable"
