### PR TITLE
Speed up the getter methods for ISNI and ROR

### DIFF
--- a/app/services/hyku_addons/current_he_institution_service.rb
+++ b/app/services/hyku_addons/current_he_institution_service.rb
@@ -16,10 +16,10 @@ module HykuAddons
 
     protected
 
-    # This method accesses a private method on the authority which returns the raw yaml data as an array of hashes
-    # without removing elements. This means we can increase the speed with which we get different sets of keys
-    def quick_active_elements
-      authority.send(:terms).select { |a| a["active"] == true }
-    end
+      # This method accesses a private method on the authority which returns the raw yaml data as an array of hashes
+      # without removing elements. This means we can increase the speed with which we get different sets of keys
+      def quick_active_elements
+        authority.send(:terms).select { |a| a["active"] == true }
+      end
   end
 end

--- a/app/services/hyku_addons/current_he_institution_service.rb
+++ b/app/services/hyku_addons/current_he_institution_service.rb
@@ -1,16 +1,25 @@
 # frozen_string_literal: true
+
 module HykuAddons
   class CurrentHeInstitutionService < HykuAddons::QaSelectService
     def initialize(model: nil)
-      super('current_he_institution', model: model)
+      super("current_he_institution", model: model)
     end
 
     def select_active_options_isni
-      select_active_options.map { |e| authority.find(e[1])[:isni] }
+      quick_active_elements.map { |a| a["isni"] }
     end
 
     def select_active_options_ror
-      select_active_options.map { |e| authority.find(e[1])[:ror] }
+      quick_active_elements.map { |a| a["ror"] }
+    end
+
+    protected
+
+    # This method accesses a private method on the authority which returns the raw yaml data as an array of hashes
+    # without removing elements. This means we can increase the speed with which we get different sets of keys
+    def quick_active_elements
+      authority.send(:terms).select { |a| a["active"] == true }
     end
   end
 end

--- a/spec/fixtures/yaml/current_he_institution.yml
+++ b/spec/fixtures/yaml/current_he_institution.yml
@@ -1,0 +1,22 @@
+terms:
+  - id: Bognor Regis University
+    term: Bognor Regis University
+    isni: 1234 5678 9012 3456
+    ror: https://ror.org/bognor1
+    active: true
+  - id: Aberystwyth University
+    term: Aberystwyth University
+    isni: 0000 0001 2168 2483
+    ror: https://ror.org/015m2p889
+    active: true
+  - id: Anglia Ruskin University
+    term: Anglia Ruskin University
+    isni: 0000 0001 2299 5510
+    ror: https://ror.org/0009t4v78
+    active: true
+  - id: Bangor University
+    term: Bangor University
+    isni: 0000 0001 1882 0937
+    ror: https://ror.org/006jb1a24
+    active: false
+

--- a/spec/services/hyku_addons/current_he_institution_service_spec.rb
+++ b/spec/services/hyku_addons/current_he_institution_service_spec.rb
@@ -4,19 +4,10 @@ require "rails_helper"
 RSpec.describe HykuAddons::CurrentHeInstitutionService do
   subject(:authority) { described_class.new(model: model) }
   let(:model) { UbiquityTemplateWork }
-
-  let(:account) { build(:account, name: "tenant") }
-  let(:site) { Site.new(account: account) }
+  let(:fixtures_path) { HykuAddons::Engine.root.join("spec", "fixtures", "yaml").to_s }
 
   before do
-    allow(Site).to receive(:instance).and_return(site)
-
-    # Override the path/filename to use our fixture
-    Qa::Authorities::Local::FileBasedAuthority.class_eval do
-      def subauthority_filename
-        File.join(HykuAddons::Engine.root.join("spec", "fixtures", "yaml"), "#{subauthority}.yml")
-      end
-    end
+    allow(Qa::Authorities::Local).to receive(:subauthorities_path).and_return(fixtures_path)
   end
 
   describe "#select_active_options_isni" do

--- a/spec/services/hyku_addons/current_he_institution_service_spec.rb
+++ b/spec/services/hyku_addons/current_he_institution_service_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe HykuAddons::CurrentHeInstitutionService do
+  subject(:authority) { described_class.new(model: model) }
+  let(:model) { UbiquityTemplateWork }
+
+  let(:account) { build(:account, name: "tenant") }
+  let(:site) { Site.new(account: account) }
+
+  before do
+    allow(Site).to receive(:instance).and_return(site)
+
+    # Override the path/filename to use our fixture
+    Qa::Authorities::Local::FileBasedAuthority.class_eval do
+      def subauthority_filename
+        File.join(HykuAddons::Engine.root.join("spec", "fixtures", "yaml"), "#{subauthority}.yml")
+      end
+    end
+  end
+
+  describe "#select_active_options_isni" do
+    let(:active_isnis) { authority.select_active_options_isni }
+
+    it "will be default terms" do
+      expect(active_isnis).to be_a(Array)
+    end
+
+    it "returns the correct ISNI" do
+      expect(active_isnis).to eq(["1234 5678 9012 3456", "0000 0001 2168 2483", "0000 0001 2299 5510"])
+    end
+
+    it "returns the correct number of ISNIs" do
+      expect(active_isnis.count).to eq(3)
+    end
+  end
+
+  describe "#select_active_options_ror" do
+    let(:active_rors) { authority.select_active_options_ror }
+
+    it "will be default terms" do
+      expect(active_rors).to be_a(Array)
+    end
+
+    it "returns the correct ROR" do
+      expect(active_rors).to eq(["https://ror.org/bognor1", "https://ror.org/015m2p889", "https://ror.org/0009t4v78"])
+    end
+
+    it "returns the correct number of RORs" do
+      expect(active_rors.count).to eq(3)
+    end
+  end
+
+  describe "#quick_active_elements" do
+    let(:active_elements) { authority.send(:quick_active_elements) }
+
+    it "returns an array of hashes" do
+      expect(active_elements).to be_a(Array)
+      expect(active_elements.map(&:class).uniq).to eq([ActiveSupport::HashWithIndifferentAccess])
+    end
+
+    it "has the correct keys in the hashes" do
+      expect(active_elements.first.keys).to match_array(["id", "term", "isni", "ror", "active"])
+    end
+  end
+end


### PR DESCRIPTION
The previous method used a `find` method within a loop that would iterate over each of the items for each of the loop iterations, so took about 1.5 seconds for each time the value was requested. 

```
          user       system     total      real
legacy    1.577007   0.016105   1.593112   (1.593188)
improved  0.000095   0.000000   0.000095   (0.000096)
```