### PR TITLE
reindex-job should not mint doi when the work is private or under review

### DIFF
--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -35,12 +35,17 @@ module HykuAddons
     private
 
       def mint_doi(work)
-        return if work.doi.present?
+        return if work.doi.present? || work.visibility != "open" || workflow_state(work)&.workflow_state_name != "deposited"
 
         Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
+
         work.update(doi_status_when_public: "findable")
         register_doi = Hyrax::DOI::DataCiteRegistrar.new.register!(object: work)
         work.update(doi: [register_doi.identifier])
+      end
+
+      def workflow_state(work)
+        @_workflow_state ||= Sipity::Entity.find_by(proxy_for_global_id: "gid://hyku/#{work.class}/#{work.id}")
       end
 
       def fetch_work_using_ids(klass)

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -35,13 +35,17 @@ module HykuAddons
     private
 
       def mint_doi(work)
-        return if work.doi.present? || work.visibility != "open" || workflow_state(work)&.workflow_state_name != "deposited"
+        return if can_mint_for?(work)
 
         Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
 
         work.update(doi_status_when_public: "findable")
         register_doi = Hyrax::DOI::DataCiteRegistrar.new.register!(object: work)
         work.update(doi: [register_doi.identifier])
+      end
+
+      def can_mint_for?(work)
+        work.doi.present? || work.visibility != "open" || workflow_state(work)&.workflow_state_name != "deposited"
       end
 
       def workflow_state(work)

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -2,11 +2,20 @@
 
 RSpec.describe HykuAddons::ReindexModelJob, type: :job do
   let(:account) { create(:account, cname: cname) }
-  let(:work) { create(:work, doi: []) }
+  let(:work) { create(:work, doi: [], visibility: "open") }
+  let(:private_work) { create(:work, title: ["private work"], doi: [], visibility: "restricted") }
+  let(:pending_review_work) { create(:work, title: ["pending_review work"], doi: [], visibility: "open") }
   let(:prefix) { "10.1234" }
   let(:cname) { "123abc" }
   let(:response_body) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "doi", "mint_doi_return_body.json")) }
   let(:options) { { cname_doi_mint: [account.cname], use_work_ids: [work.id] } }
+
+  let(:random_id) { SecureRandom.random_number(1_000_000) }
+  let(:workflow) { instance_double(Sipity::Workflow, id: random_id, name: "testing", permission_template: permission_template) }
+  let(:sipity_workflow_action) { instance_double(Sipity::WorkflowAction, id: random_id, name: "show", workflow_id: random_id) }
+  let(:permission_template) { instance_double(Hyrax::PermissionTemplate, id: random_id) }
+  let(:sipity_workflow_state) { instance_double(Sipity::WorkflowState, id: random_id, workflow: workflow, name: "deposited") }
+  let(:object) { OpenStruct.new(to_sipity_entity: sipity_entity, workflow_state_name: "deposited") }
 
   before do
     Hyrax::DOI::DataCiteRegistrar.username = "username"
@@ -24,11 +33,39 @@ RSpec.describe HykuAddons::ReindexModelJob, type: :job do
       block&.call
     end
 
-    Apartment::Tenant.switch!(account.tenant) { work }
+    Apartment::Tenant.switch!(account.tenant) do
+      work
+      private_work
+      pending_review_work
+    end
   end
 
-  it "sets doi_status_when_public to findable" do
-    described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: options)
-    expect(work.reload.doi_status_when_public).to eq "findable"
+  context "mint doi" do
+    let(:sipity_entity) { instance_double(Sipity::Entity, proxy_for_global_id: "gid://hyku/#{work.class}/#{work.id}", workflow_id: workflow.id, workflow_state: sipity_workflow_state) }
+
+    it "when work visibility is public & doi is not present" do
+      allow(Sipity::Entity).to receive(:find_by) { object }
+      described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: options)
+      expect(work.reload.doi_status_when_public).to eq "findable"
+    end
+  end
+
+  context "skip doi minting" do
+    let(:sipity_entity) { instance_double(Sipity::Entity, proxy_for_global_id: "gid://hyku/#{pending_review_work.class}/#{pending_review_work.id}", workflow_id: workflow.id, workflow_state: sipity_workflow_state) }
+
+    it "when work is private" do
+      options[:use_work_ids] = [private_work.id]
+      described_class.perform_now(private_work.class.to_s, account.cname, limit: 1, options: options)
+      expect(private_work.reload.doi_status_when_public).to be_nil
+    end
+
+    it "when work is pending_review" do
+      object.workflow_state_name = "pending_review"
+      allow(Sipity::Entity).to receive(:find_by) { object }
+      options[:use_work_ids] = [pending_review_work.id]
+
+      described_class.perform_now(pending_review_work.class.to_s, account.cname, limit: 1, options: options)
+      expect(pending_review_work.reload.doi_status_when_public).to be_nil
+    end
   end
 end

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe HykuAddons::ReindexModelJob, type: :job do
   let(:permission_template) { instance_double(Hyrax::PermissionTemplate, id: random_id) }
   let(:sipity_workflow_state) { instance_double(Sipity::WorkflowState, id: random_id, workflow: workflow, name: "deposited") }
   let(:object) { OpenStruct.new(to_sipity_entity: sipity_entity, workflow_state_name: "deposited") }
+  let(:sipity_entity) { instance_double(Sipity::Entity, proxy_for_global_id: gid, workflow_id: workflow.id, workflow_state: sipity_workflow_state) }
 
   before do
     Hyrax::DOI::DataCiteRegistrar.username = "username"
@@ -41,7 +42,7 @@ RSpec.describe HykuAddons::ReindexModelJob, type: :job do
   end
 
   context "mint doi" do
-    let(:sipity_entity) { instance_double(Sipity::Entity, proxy_for_global_id: "gid://hyku/#{work.class}/#{work.id}", workflow_id: workflow.id, workflow_state: sipity_workflow_state) }
+    let(:gid) { "gid://hyku/#{work.class}/#{work.id}" }
 
     it "when work visibility is public & doi is not present" do
       allow(Sipity::Entity).to receive(:find_by) { object }
@@ -51,7 +52,7 @@ RSpec.describe HykuAddons::ReindexModelJob, type: :job do
   end
 
   context "skip doi minting" do
-    let(:sipity_entity) { instance_double(Sipity::Entity, proxy_for_global_id: "gid://hyku/#{pending_review_work.class}/#{pending_review_work.id}", workflow_id: workflow.id, workflow_state: sipity_workflow_state) }
+    let(:gid) { "gid://hyku/#{pending_review_work.class}/#{pending_review_work.id}" }
 
     it "when work is private" do
       options[:use_work_ids] = [private_work.id]


### PR DESCRIPTION
This refactor prevents the ReindexModelJob from minting doi when a work is private or when the work is under review.