### PR TITLE
set config for solr repository class

### DIFF
--- a/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
@@ -7,6 +7,8 @@ module HykuAddons
       append_before_action :routing_error_unless_feature_enabled, only: :oai
 
       configure_blacklight do |config|
+        config.repository_class = Blacklight::Solr::Repository
+
         # Re-configure facet fields
         config.facet_fields = {}
         config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5


### PR DESCRIPTION
This is a quick attempt to fix:
   
        RuntimeError, 'The value for :adapter was not found in the blacklight.yml config'
        
by setting a config value for the Solr repository class.