### PR TITLE
Ensure annotation not turned on by default

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -38,6 +38,6 @@ Flipflop.configure do
           description: "Turns on cross tenant shared search."
   
   feature :annotation,
-          default: true,
+          default: false,
           description: "Turns on links to hypothes.is PDF viewer"
 end


### PR DESCRIPTION
Small PR to change the default setting on annotation, which should be off by default.