### PR TITLE
Parses Funder JSON

### DIFF
--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -47,7 +47,7 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
     json.has_public_files work.file_set_presenters.any? { |fsp| fsp.solr_document.public? }
   end
 
-  funder = work.try(:solr_document)&.to_h&.dig('funder_tesim')
+  funder = work.try(:solr_document)&.to_h&.dig('funder_tesim').try(:first)
   json.funder funder.present? ? JSON.parse(funder) : []
 
   json.funder_project_ref work.try(:solr_document)&.to_h&.dig('fndr_project_ref_tesim')

--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -46,7 +46,10 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
     json.has_registered_files work.file_set_presenters.any? { |fsp| fsp.solr_document.registered? }
     json.has_public_files work.file_set_presenters.any? { |fsp| fsp.solr_document.public? }
   end
-  json.funder work.try(:solr_document)&.to_h&.dig('funder_tesim')
+
+  funder = work.try(:solr_document)&.to_h&.dig('funder_tesim')
+  json.funder funder.present? ? JSON.parse(funder) : []
+
   json.funder_project_ref work.try(:solr_document)&.to_h&.dig('fndr_project_ref_tesim')
   json.funding_description work.try(:solr_document)&.to_h&.dig('funding_description_tesim')
   json.georeferenced work.try(:solr_document)&.to_h&.dig('georeferenced_tesim')

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
   end
   let(:eissn) { "1234-5678" }
   let(:fndr_project_ref) { "test" }
+  let(:funder) do
+    {
+      funder_name: "National Science Foundation",
+      funder_doi: "10.1594",
+      funder_isni: "000000012146438X",
+      funder_ror: "03yrm5c26",
+      funder_award: ["I382u7378348"]
+    }
+  end
   let(:institution1) { "British Library" }
   let(:isbn) { "9781770460621" }
   let(:issn) { "0987654321" }
@@ -101,6 +110,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
       editor: [[editor1].to_json],
       eissn: eissn,
       fndr_project_ref: [fndr_project_ref],
+      funder: [[funder].to_json],
       institution: [institution1],
       isbn: isbn,
       issn: issn,
@@ -184,7 +194,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                            "has_registered_files" => false,
                                            "has_public_files" => false
                                          },
-                                         "funder" => nil,
+                                         "funder" => [],
                                          "funder_project_ref" => nil,
                                          "funding_description" => nil,
                                          "georeferenced" => nil,
@@ -206,6 +216,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                          "location" => nil,
                                          "longitude" => nil,
                                          "medium" => nil,
+                                         "mentor" => nil,
                                          "mesh" => nil,
                                          "official_link" => nil,
                                          "official_url" => nil,
@@ -310,7 +321,11 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                            "event_title" => nil,
                                            "extent" => nil,
                                            "files" => { "has_private_files" => false, "has_public_files" => false, "has_registered_files" => false },
-                                           "funder" => nil,
+                                           "funder" => [{ "funder_name" => "National Science Foundation",
+                                                          "funder_doi" => "10.1594",
+                                                          "funder_isni" => "000000012146438X",
+                                                          "funder_ror" => "03yrm5c26",
+                                                          "funder_award" => ["I382u7378348"] }],
                                            "funder_project_ref" => ["test"],
                                            "funding_description" => nil,
                                            "georeferenced" => nil,
@@ -332,6 +347,7 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
                                            "location" => nil,
                                            "longitude" => nil,
                                            "medium" => nil,
+                                           "mentor" => nil,
                                            "mesh" => nil,
                                            "official_link" => ["http://test-url.com"],
                                            "official_url" => nil,


### PR DESCRIPTION
Funder information is being presented as a JSON string on the frontend SWP so I am sending the funder as parsed JSON to match the other JSON fields 