### PR TITLE
ensure job requeues have the correct paramters

### DIFF
--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -13,10 +13,10 @@ module HykuAddons
 
     # rubocop:disable Metrics/MethodLength
     def perform(klass, cname, limit: 25, page: 1, options: {})
-      options = options.presence || { cname_doi_mint: [], use_work_ids: [] }
+      @options = options.presence || { cname_doi_mint: [], use_work_ids: [] }
       # for whatever in private methods reason without assigning it to instamce variable it throws undefined local variable
-      @cname_doi_mint = options[:cname_doi_mint]
-      @use_work_ids = options[:use_work_ids]
+      @cname_doi_mint = @options[:cname_doi_mint]
+      @use_work_ids = @options[:use_work_ids]
       @cname = cname
       @limit = limit
       @page = page
@@ -83,7 +83,7 @@ module HykuAddons
         reindex_works(works)
 
         # Re-enqueue
-        ReindexModelJob.perform_later(@klass, @cname, @limit, page: @page.to_i + 1, cname_doi_mint: @cname_doi_mint)
+        ReindexModelJob.perform_later(@klass, @cname, limit: @limit, page: @page.to_i + 1, options: @options)
         Rails.logger.debug "=== Completed reindex of #{@klass} in #{@cname} ==="
       end
   end

--- a/spec/jobs/reindex_available_works_job_spec.rb
+++ b/spec/jobs/reindex_available_works_job_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe HykuAddons::ReindexAvailableWorksJob, type: :job do
     expect { described_class.perform_later([account.cname]) }.to have_enqueued_job(described_class).with([account.cname])
   end
 
-  it "can enqueue ReindexModelJob with correct paramters" do
+  it "can enqueue ReindexModelJob with correct parameters" do
     expect do
       described_class.perform_now([account.cname], cname_doi_mint: [account.cname])
     end.to have_enqueued_job(HykuAddons::ReindexModelJob).at_least(:once)

--- a/spec/jobs/reindex_model_job_spec.rb
+++ b/spec/jobs/reindex_model_job_spec.rb
@@ -69,4 +69,14 @@ RSpec.describe HykuAddons::ReindexModelJob, type: :job do
       expect(pending_review_work.reload.doi_status_when_public).to be_nil
     end
   end
+
+  context "should requeue" do
+    it "self(ReindexModelJob) with valid parameters" do
+      new_options = options.slice(:cname_doi_mint)
+      expect do
+        described_class.perform_now(work.class.to_s, account.cname, limit: 1, options: new_options)
+      end.to have_enqueued_job(HykuAddons::ReindexModelJob).at_least(:once)
+                                                           .with(work.class.to_s, account.cname, limit: 1, page: 2, options: { cname_doi_mint: [account.cname] })
+    end
+  end
 end


### PR DESCRIPTION
The ReindexModelJob re-queues itself but was not doing so with the right parameters.  This adds a test to catch such issues next time.