### PR TITLE
Hotfix/rescue blacklight error

### DIFF
--- a/app/controllers/concerns/hyku_addons/application_controller_override.rb
+++ b/app/controllers/concerns/hyku_addons/application_controller_override.rb
@@ -5,7 +5,21 @@ module HykuAddons
   module ApplicationControllerOverride
     extend ActiveSupport::Concern
 
+    included do
+      rescue_from RuntimeError, with: :blacklight_adapter_error
+    end
+
     private
+
+      # Try and resue the blacklight errors we have been seeing. However, this will likely either work, or move the
+      # error elsewhere within Sentry, so this should be considered a temporary fix at best.
+      def blacklight_adapter_error(error)
+        raise error unless error.message == "The value for :adapter was not found in the blacklight.yml config"
+
+        # I'm not 100% sure which to set, so I'm setting both
+        Blacklight.connection_config[:adapter] = "solr"
+        Blacklight.repository_class = Blacklight::Solr::Repository
+      end
 
       def require_active_account!
         return unless Settings.multitenancy.enabled

--- a/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
@@ -7,8 +7,6 @@ module HykuAddons
       append_before_action :routing_error_unless_feature_enabled, only: :oai
 
       configure_blacklight do |config|
-        config.repository_class = Blacklight::Solr::Repository
-
         # Re-configure facet fields
         config.facet_fields = {}
         config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5


### PR DESCRIPTION
Attempt to prevent "The value for :adapter was not found in the blacklight.yml config" errors by rescuing the error and setting the value of the `adapter`. This will likely still see errors, as to set the value, we need to see an error, in which case maybe we can try manually setting the values in the PR in a controller before action. 