### PR TITLE
Add tests for JsonFieldsActor and CollectionForm

### DIFF
--- a/spec/actors/hyku_addons/actors/json_fields_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/json_fields_actor_spec.rb
@@ -33,6 +33,10 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
       it "passes non-json fields through" do
         expect(env.attributes[:title]).to eq(transformed_attributes["title"])
       end
+
+      it "sets the attributes of the work" do
+        expect(work.title).to eq(transformed_attributes["title"])
+      end
     end
 
     context "with multiple valid json fields" do
@@ -56,6 +60,11 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
       it "adds them all" do
         expect(env.attributes).to eq(transformed_attributes)
       end
+
+      it "sets the attributes of the work" do
+        expect(work.creator).to eq(transformed_attributes["creator"])
+        expect(work.editor).to eq(transformed_attributes["editor"])
+      end
     end
 
     context "with blank or empty attributes" do
@@ -77,6 +86,11 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
       it "turns fields into null or adds empty arrays" do
         expect(env.attributes).to eq(transformed_attributes)
       end
+
+      it "sets the attributes of the work" do
+        expect(work.creator).to be_empty
+        expect(work.editor).to eq(transformed_attributes["editor"])
+      end
     end
 
     context "with no name type" do
@@ -94,6 +108,10 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
 
       it "adds the attributes" do
         expect(env.attributes).to eq(transformed_attributes)
+      end
+
+      it "sets the attributes of the work" do
+        expect(work.editor).to eq(transformed_attributes["editor"])
       end
     end
 
@@ -121,6 +139,10 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
       it "recurses through them" do
         expect(env.attributes).to eq(transformed_attributes)
       end
+
+      it "sets the attributes of the work" do
+        expect(work.creator).to eq(transformed_attributes["creator"])
+      end
     end
   end
 
@@ -139,6 +161,10 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
 
       it "passes non-json fields through" do
         expect(env.attributes[:title]).to eq(transformed_attributes["title"])
+      end
+
+      it "updates the attributes of the work" do
+        expect(work.title).to eq(transformed_attributes["title"])
       end
     end
 
@@ -175,6 +201,11 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
       it "adds them all" do
         expect(env.attributes).to eq(transformed_attributes)
       end
+
+      it "updates the attributes of the work" do
+        expect(work.creator).to eq(transformed_attributes["creator"])
+        expect(work.editor).to eq(transformed_attributes["editor"])
+      end
     end
 
     context "with blank or empty attributes" do
@@ -214,6 +245,11 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
       it "turns fields into null or adds empty arrays" do
         expect(env.attributes).to eq(transformed_attributes)
       end
+
+      it "updates the attributes of the work" do
+        expect(work.creator).to be_empty
+        expect(work.editor).to eq(transformed_attributes["editor"])
+      end
     end
 
     context "with no name type" do
@@ -242,6 +278,10 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
 
       it "adds the attributes" do
         expect(env.attributes).to eq(transformed_attributes)
+      end
+
+      it "updates the attributes of the work" do
+        expect(work.editor).to eq(transformed_attributes["editor"])
       end
     end
 
@@ -279,6 +319,10 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
 
       it "recurses through them" do
         expect(env.attributes).to eq(transformed_attributes)
+      end
+
+      it "updates the attributes of the work" do
+        expect(work.creator).to eq(transformed_attributes["creator"])
       end
     end
   end

--- a/spec/actors/hyku_addons/actors/json_fields_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/json_fields_actor_spec.rb
@@ -1,0 +1,285 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe HykuAddons::Actors::JSONFieldsActor do
+  let(:ability) { ::Ability.new(user) }
+  let(:env) { env_class.new(work, ability, attributes) }
+  let(:terminator) { Hyrax::Actors::Terminator.new }
+  let(:user) { build(:user) }
+  let(:work) { create(:generic_work) }
+  let(:env_class) { Hyrax::Actors::Environment }
+  let(:attributes) { {} }
+
+  let(:middleware) do
+    stack = ActionDispatch::MiddlewareStack.new.tap do |middleware|
+      middleware.use described_class
+      middleware.use Hyrax::Actors::ModelActor
+    end
+
+    stack.build(terminator)
+  end
+
+  describe "#create" do
+    before do
+      allow(terminator).to receive(:create).with(env)
+      middleware.create(env)
+    end
+
+    context "non-json fields" do
+      let(:attributes) { { title: ["Moomin"] } }
+      let(:transformed_attributes) { { "title" => ["Moomin"] } }
+
+      it "passes non-json fields through" do
+        expect(env.attributes[:title]).to eq(transformed_attributes["title"])
+      end
+    end
+
+    context "with multiple valid json fields" do
+      let(:attributes) do
+        {
+          creator: [
+            { "creator_name_type" => "Personal", "creator_given_name" => "Liang", "creator_family_name" => "Gao" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Lidai", "creator_family_name" => "Wang" }
+          ],
+          editor: [
+            { "editor_name_type" => "Personal", "editor_given_name" => "Alexander A.", "editor_family_name" => "Oraevsky" },
+            { "editor_name_type" => "Personal", "editor_given_name" => "Lihong V.", "editor_family_name" => "Wang" }
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "creator" => ["[{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Liang\",\"creator_family_name\":\"Gao\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Lidai\",\"creator_family_name\":\"Wang\"}]"], "editor" => ["[{\"editor_name_type\":\"Personal\",\"editor_given_name\":\"Alexander A.\",\"editor_family_name\":\"Oraevsky\"},{\"editor_name_type\":\"Personal\",\"editor_given_name\":\"Lihong V.\",\"editor_family_name\":\"Wang\"}]"], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "current_he_institution" => [] }
+      end
+
+      it "adds them all" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+
+    context "with blank or empty attributes" do
+      let(:attributes) do
+        {
+          creator: [
+            {}
+          ],
+          editor: [
+            { "editor_name_type" => "Personal", "editor_given_name" => "Alexander A.", "editor_family_name" => nil }
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "editor" => ["[{\"editor_name_type\":\"Personal\",\"editor_given_name\":\"Alexander A.\",\"editor_family_name\":null}]"], "creator" => [], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "current_he_institution" => [] }
+      end
+
+      it "turns fields into null or adds empty arrays" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+
+    context "with no name type" do
+      let(:attributes) do
+        {
+          editor: [
+            { "editor_name_type" => "", "editor_given_name" => "Lihong V.", "editor_family_name" => "Wang" }
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "editor" => ["[{\"editor_name_type\":\"\",\"editor_given_name\":\"Lihong V.\",\"editor_family_name\":\"Wang\"}]"], "creator" => [], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "current_he_institution" => [] }
+      end
+
+      it "adds the attributes" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+
+    context "with nested fields" do
+      let(:attributes) do
+        {
+          creator: [
+            { "creator_name_type" => "Personal", "creator_given_name" => "Liang", "creator_family_name" => "Gao" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Lidai", "creator_family_name" => "Wang" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Chiye", "creator_family_name" => "Li" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Yan", "creator_family_name" => "Liu" },
+            creator: [
+              { "creator_name_type" => "Personal", "creator_given_name" => "Haixin", "creator_family_name" => "Ke" },
+              { "creator_name_type" => "Personal", "creator_given_name" => "Chi", "creator_family_name" => "Zhang" },
+              { "creator_name_type" => "Personal", "creator_given_name" => "Lihong V.", "creator_family_name" => "Wang" }
+            ]
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "creator" => ["[{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Liang\",\"creator_family_name\":\"Gao\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Lidai\",\"creator_family_name\":\"Wang\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Chiye\",\"creator_family_name\":\"Li\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Yan\",\"creator_family_name\":\"Liu\"},{\"creator\":[{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Haixin\",\"creator_family_name\":\"Ke\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Chi\",\"creator_family_name\":\"Zhang\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Lihong V.\",\"creator_family_name\":\"Wang\"}]}]"], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "editor" => [], "current_he_institution" => [] }
+      end
+
+      it "recurses through them" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+  end
+
+  describe "#update" do
+    let(:work) { create :generic_work, original_attributes }
+
+    before do
+      allow(terminator).to receive(:update).with(env)
+      middleware.update(env)
+    end
+
+    context "non-json fields" do
+      let(:original_attributes) { { title: ["Test Name"] } }
+      let(:attributes) { { title: ["Moomin"] } }
+      let(:transformed_attributes) { { "title" => ["Moomin"] } }
+
+      it "passes non-json fields through" do
+        expect(env.attributes[:title]).to eq(transformed_attributes["title"])
+      end
+    end
+
+    context "with multiple json fields" do
+      let(:original_attributes) do
+        {
+          creator: [
+            [{
+              creator_name_type: "Personal",
+              creator_given_name: "Johnny",
+              creator_family_name: "Testison"
+            }].to_json
+          ]
+        }
+      end
+
+      let(:attributes) do
+        {
+          creator: [
+            { "creator_name_type" => "Personal", "creator_given_name" => "Liang", "creator_family_name" => "Gao" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Lidai", "creator_family_name" => "Wang" }
+          ],
+          editor: [
+            { "editor_name_type" => "Personal", "editor_given_name" => "Alexander A.", "editor_family_name" => "Oraevsky" },
+            { "editor_name_type" => "Personal", "editor_given_name" => "Lihong V.", "editor_family_name" => "Wang" }
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "creator" => ["[{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Liang\",\"creator_family_name\":\"Gao\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Lidai\",\"creator_family_name\":\"Wang\"}]"], "editor" => ["[{\"editor_name_type\":\"Personal\",\"editor_given_name\":\"Alexander A.\",\"editor_family_name\":\"Oraevsky\"},{\"editor_name_type\":\"Personal\",\"editor_given_name\":\"Lihong V.\",\"editor_family_name\":\"Wang\"}]"], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "current_he_institution" => [] }
+      end
+
+      it "adds them all" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+
+    context "with blank or empty attributes" do
+      let(:original_attributes) do
+        {
+          creator: [
+            [{
+              creator_name_type: "Personal",
+              creator_given_name: "Johnny",
+              creator_family_name: "Testison"
+            }].to_json
+          ],
+          editor: [
+            [{
+              creator_name_type: "Personal",
+              creator_given_name: "Johnny",
+              creator_family_name: "Testison"
+            }].to_json
+          ]
+        }
+      end
+      let(:attributes) do
+        {
+          creator: [
+            {}
+          ],
+          editor: [
+            { "editor_name_type" => "Personal", "editor_given_name" => "Alexander A.", "editor_family_name" => nil }
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "editor" => ["[{\"editor_name_type\":\"Personal\",\"editor_given_name\":\"Alexander A.\",\"editor_family_name\":null}]"], "creator" => [], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "current_he_institution" => [] }
+      end
+
+      it "turns fields into null or adds empty arrays" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+
+    context "with no name type" do
+      let(:original_attributes) do
+        {
+          editor: [
+            [{
+              creator_name_type: "Personal",
+              creator_given_name: "Johnny",
+              creator_family_name: "Testison"
+            }].to_json
+          ]
+        }
+      end
+      let(:attributes) do
+        {
+          editor: [
+            { "editor_name_type" => "", "editor_given_name" => "Lihong V.", "editor_family_name" => "Wang" }
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "editor" => ["[{\"editor_name_type\":\"\",\"editor_given_name\":\"Lihong V.\",\"editor_family_name\":\"Wang\"}]"], "creator" => [], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "current_he_institution" => [] }
+      end
+
+      it "adds the attributes" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+
+    context "with nested fields" do
+      let(:original_attributes) do
+        {
+          creator: [
+            [{
+              creator_name_type: "Personal",
+              creator_given_name: "Johnny",
+              creator_family_name: "Testison"
+            }].to_json
+          ]
+        }
+      end
+      let(:attributes) do
+        {
+          creator: [
+            { "creator_name_type" => "Personal", "creator_given_name" => "Liang", "creator_family_name" => "Gao" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Lidai", "creator_family_name" => "Wang" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Chiye", "creator_family_name" => "Li" },
+            { "creator_name_type" => "Personal", "creator_given_name" => "Yan", "creator_family_name" => "Liu" },
+            creator: [
+              { "creator_name_type" => "Personal", "creator_given_name" => "Haixin", "creator_family_name" => "Ke" },
+              { "creator_name_type" => "Personal", "creator_given_name" => "Chi", "creator_family_name" => "Zhang" },
+              { "creator_name_type" => "Personal", "creator_given_name" => "Lihong V.", "creator_family_name" => "Wang" }
+            ]
+          ]
+        }
+      end
+
+      let(:transformed_attributes) do
+        { "creator" => ["[{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Liang\",\"creator_family_name\":\"Gao\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Lidai\",\"creator_family_name\":\"Wang\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Chiye\",\"creator_family_name\":\"Li\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Yan\",\"creator_family_name\":\"Liu\"},{\"creator\":[{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Haixin\",\"creator_family_name\":\"Ke\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Chi\",\"creator_family_name\":\"Zhang\"},{\"creator_name_type\":\"Personal\",\"creator_given_name\":\"Lihong V.\",\"creator_family_name\":\"Wang\"}]}]"], "contributor" => [], "funder" => [], "alternate_identifier" => [], "related_identifier" => [], "editor" => [], "current_he_institution" => [] }
+      end
+
+      it "recurses through them" do
+        expect(env.attributes).to eq(transformed_attributes)
+      end
+    end
+  end
+end

--- a/spec/actors/hyku_addons/actors/json_fields_actor_spec.rb
+++ b/spec/actors/hyku_addons/actors/json_fields_actor_spec.rb
@@ -189,9 +189,9 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
           ],
           editor: [
             [{
-              creator_name_type: "Personal",
-              creator_given_name: "Johnny",
-              creator_family_name: "Testison"
+              editor_name_type: "Personal",
+              editor_given_name: "Johnny",
+              editor_family_name: "Testison"
             }].to_json
           ]
         }
@@ -221,9 +221,9 @@ RSpec.describe HykuAddons::Actors::JSONFieldsActor do
         {
           editor: [
             [{
-              creator_name_type: "Personal",
-              creator_given_name: "Johnny",
-              creator_family_name: "Testison"
+              editor_name_type: "Personal",
+              editor_given_name: "Johnny",
+              editor_family_name: "Testison"
             }].to_json
           ]
         }

--- a/spec/forms/hyrax/collection_form_spec.rb
+++ b/spec/forms/hyrax/collection_form_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::Forms::CollectionForm do
+  let(:collection) { build :collection }
+  let(:form) { described_class.new(collection, nil, nil) }
+
+  describe "#required_fields" do
+    subject { form.required_fields }
+
+    it { is_expected.to eq [:title] }
+  end
+
+  describe "#terms" do
+    subject { form.terms }
+
+    it do
+      is_expected.to eq [
+        :resource_type, :title, :creator, :contributor, :description, :keyword, :license,
+        :publisher, :date_created, :subject, :language, :representative_id, :thumbnail_id,
+        :identifier, :based_near, :related_url, :visibility, :collection_type_gid
+      ]
+    end
+  end
+
+  describe "#primary_terms" do
+    subject { form.primary_terms }
+
+    it { is_expected.to eq([:title, :description]) }
+  end
+
+  describe "#secondary_terms" do
+    subject { form.secondary_terms }
+
+    it do
+      is_expected.to eq [
+        :creator, :contributor, :keyword, :license, :publisher, :date_created,
+        :subject, :language, :identifier, :based_near, :related_url, :resource_type
+      ]
+    end
+  end
+
+  describe ".model_attributes" do
+    subject(:model_attributes) { described_class.model_attributes(params) }
+
+    let(:params) { ActionController::Parameters.new(attributes) }
+    let(:attributes) do
+      {
+        title: ["foo"],
+        subject: ["bar"]
+      }
+    end
+
+    it "permits parameters" do
+      expect(model_attributes["title"]).to eq ["foo"]
+      expect(model_attributes["subject"]).to eq ["bar"]
+    end
+
+    context ".model_attributes" do
+      let(:params) do
+        ActionController::Parameters.new(
+          title: [""],
+          license: [""],
+          related_url: [""],
+          keyword: ["not_blank"],
+          creator: [
+            { "creator_name_type" => "Personal", "creator_given_name" => "Alice", "creator_family_name" => "Coltrane" },
+            {} # IS THIS CORRECT ?? IT IS NOT REMOVED
+          ],
+          contributor: [{}]
+        )
+      end
+
+      it "removes blank parameters" do
+        expect(model_attributes["title"]).to be_empty
+        expect(model_attributes["license"]).to be_empty
+        expect(model_attributes["keyword"]).to eq ["not_blank"]
+        expect(model_attributes["related_url"]).to be_empty
+        expect(model_attributes["contributor"]).to be_empty
+        expect(model_attributes["creator"]).to eq ["[{\"creator_given_name\":\"Alice\",\"creator_family_name\":\"Coltrane\",\"creator_name_type\":\"Personal\"},{}]"]
+      end
+    end
+  end
+end

--- a/spec/forms/hyrax/collection_form_spec.rb
+++ b/spec/forms/hyrax/collection_form_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Hyrax::Forms::CollectionForm do
           keyword: ["not_blank"],
           creator: [
             { "creator_name_type" => "Personal", "creator_given_name" => "Alice", "creator_family_name" => "Coltrane" },
-            {} # IS THIS CORRECT ?? IT IS NOT REMOVED
+            {}
           ],
           contributor: [{}]
         )


### PR DESCRIPTION
Add two tests to allow for refactoring of JsonFieldsActor into a service class.
Please comment on
1) blank/empty hashes appear not to be removed from array parameters, when one item in the array is not blank
2) Should there be examples around keys like "creator_name_type"? These appear to be filtered in some circumstances I am unclear about
3) Are the terms included in the CollectionForm spec correct
4) What behaviour should I have tested that is missing - I am not familiar with the purpose of these classes.