### PR TITLE
Alter CSS class

### DIFF
--- a/app/assets/stylesheets/hyku_addons/doi_tab.scss
+++ b/app/assets/stylesheets/hyku_addons/doi_tab.scss
@@ -1,3 +1,3 @@
-#doi-create-draft-btn {
+#savewidget a {
   color: white !important;
 }


### PR DESCRIPTION
DOI button text was appearing white on white, when DOI Tab was enabled.  
Use an alternate selector to target the button.