### PR TITLE
Alter CSS Class for DOI Button

### DIFF
--- a/app/assets/stylesheets/hyku_addons/doi_tab.scss
+++ b/app/assets/stylesheets/hyku_addons/doi_tab.scss
@@ -1,3 +1,3 @@
-#savewidget a {
+#savewidget .list-group-item a {
   color: white !important;
 }


### PR DESCRIPTION
DOI button text was appearing white on white, when DOI Tab was enabled.  CSS update affected another part of the layout, this makes the change more specific.