### PR TITLE
Resolve issues with the note field for schema works

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ expect(work.license).to eq(license_options.map { |h| h["id"] })
 
 #### The Note fields
 
-One thing to note is that the `note` field should not be included in the schema. This is because it resides outside of the form fields block in its own tab and because of this should be added to a work/form by including the concerns:
+One thing to note is that the `note` field should not be included in the works schema YAML. This is because it resides outside of the form fields content in its own tab and because of this should be added to a work/form by including the concerns:
 
 ```ruby
 # Model class
@@ -389,7 +389,6 @@ module Hyrax
   class UvaWorkForm < Hyrax::Forms::WorkForm
     # ...
     include HykuAddons::NoteFormBehavior
-
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -372,6 +372,26 @@ fill_in_multiple_selects(:license, license_options.map { |h| h["label"] })
 # Confirm that the IDs were saved to the work record
 expect(work.license).to eq(license_options.map { |h| h["id"] })
 ```
+
+#### The Note fields
+
+One thing to note is that the `note` field should not be included in the schema. This is because it resides outside of the form fields block in its own tab and because of this should be added to a work/form by including the concerns:
+
+```ruby
+# Model class
+class UvaWork < ActiveFedora::Base
+  include Hyrax::WorkBehavior
+  # ...
+  include HykuAddons::NoteBehavior
+
+# Form class
+module Hyrax
+  class UvaWorkForm < Hyrax::Forms::WorkForm
+    # ...
+    include HykuAddons::NoteFormBehavior
+
+```
+
 ## Development
 
 The rails server will be running at http://hyku.docker and tenants will be subdomains like http://tenant1.hyku.docker.

--- a/app/controllers/concerns/hyku_addons/note_form_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/note_form_behavior.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module NoteFormBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      self.terms += [:note]
+
+      delegate :note, to: :model
+    end
+
+    class_methods do
+      def build_permitted_params
+        super.tap { |permitted_params| permitted_params << [:note] }
+      end
+    end
+  end
+end

--- a/app/forms/hyrax/nsu_generic_work_form.rb
+++ b/app/forms/hyrax/nsu_generic_work_form.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 module Hyrax
   # Generated form for NsuGenericWork
   class NsuGenericWorkForm < Hyrax::Forms::WorkForm

--- a/app/forms/hyrax/uva_work_form.rb
+++ b/app/forms/hyrax/uva_work_form.rb
@@ -4,6 +4,7 @@ module Hyrax
   class UvaWorkForm < Hyrax::Forms::WorkForm
     include Hyrax::DOI::DOIFormBehavior
     include Hyrax::DOI::DataCiteDOIFormBehavior
+    include HykuAddons::NoteFormBehavior
 
     include ::HykuAddons::Schema::WorkForm
     include Hyrax::FormFields(:uva_work)

--- a/app/helpers/hyku_addons/notes_tab_form_helper.rb
+++ b/app/helpers/hyku_addons/notes_tab_form_helper.rb
@@ -1,19 +1,15 @@
 # frozen_string_literal: true
+
 module HykuAddons
   module NotesTabFormHelper
     def form_tabs_for(form:)
-      if Flipflop.enabled?(:notes_tab_form) && form.model.respond_to?(:notes)
-        super + ["notes"]
-      else
-        super
-      end
+      return super unless Flipflop.enabled?(:notes_tab_form) && form.model.respond_to?(:note)
+
+      super + ["notes"]
     end
 
-    def sort_note_hash(note_attribute)
-      note_hash_ary = note_attribute.map do |note|
-        JSON.parse(note)
-      end
-      note_hash_ary.sort_by { |note_hash| DateTime.parse(note_hash["timestamp"]).to_i }
+    def sort_note_hash(note_attr)
+      note_attr.map { |json| JSON.parse(json) }.sort_by { |hash| DateTime.parse(hash["timestamp"]).to_i }
     end
   end
 end

--- a/app/helpers/hyku_addons/notes_tab_form_helper.rb
+++ b/app/helpers/hyku_addons/notes_tab_form_helper.rb
@@ -2,7 +2,7 @@
 module HykuAddons
   module NotesTabFormHelper
     def form_tabs_for(form:)
-      if Flipflop.enabled?(:notes_tab_form)
+      if Flipflop.enabled?(:notes_tab_form) && form.model.respond_to?(:notes)
         super + ["notes"]
       else
         super

--- a/app/models/concerns/hyku_addons/note_behavior.rb
+++ b/app/models/concerns/hyku_addons/note_behavior.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module NoteBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      property :note, predicate: ::RDF::Vocab::MODS.note, multiple: true do |index|
+        index.as :stored_searchable
+      end
+    end
+  end
+end

--- a/app/models/uva_work.rb
+++ b/app/models/uva_work.rb
@@ -13,5 +13,5 @@ class UvaWork < ActiveFedora::Base
 
   self.indexer = UbiquityTemplateWorkIndexer
 
-  validates :title, presence: { message: 'Your work must have a title.' }
+  validates :title, presence: { message: "Your work must have a title." }
 end

--- a/app/models/uva_work.rb
+++ b/app/models/uva_work.rb
@@ -4,6 +4,7 @@ class UvaWork < ActiveFedora::Base
   include Hyrax::WorkBehavior
   include Hyrax::DOI::DOIBehavior
   include Hyrax::DOI::DataCiteDOIBehavior
+  include HykuAddons::NoteBehavior
 
   include HykuAddons::Schema::WorkBase
   include Hyrax::Schema(:uva_work)

--- a/app/views/hyrax/base/_form_notes.html.erb
+++ b/app/views/hyrax/base/_form_notes.html.erb
@@ -12,4 +12,4 @@
 </div>
 
 <br>
-<%= f.input :note, label: 'New Note', as: :text, input_html: { value: '', rows: '5' } %>
+<%= f.input :note, label: "New Note", as: :text, input_html: { value: "", rows: "5" } %>

--- a/app/views/hyrax/base/_form_notes.html.erb
+++ b/app/views/hyrax/base/_form_notes.html.erb
@@ -1,5 +1,3 @@
-<% return unless curation_concern.respond_to?(:note) %>
-
 <div class="previous_notes">
   <% sorted_hash_by_timestamp = sort_note_hash(curation_concern.note)%>
   <% sorted_hash_by_timestamp.each do |note_hash| %>

--- a/config/metadata/ubiquity_template_work.yaml
+++ b/config/metadata/ubiquity_template_work.yaml
@@ -1245,17 +1245,6 @@ attributes:
       primary: false
       multiple: false
       type: textarea
-  note:
-    type: string
-    predicate: http://www.loc.gov/mods/rdf/v1#note
-    multiple: true
-    index_keys:
-    - note_tesim
-    form:
-      required: false
-      primary: false
-      multiple: true
-      type: text
   advisor:
     type: string
     predicate: http://bibframe.org/vocab/Person


### PR DESCRIPTION
Because the note field had its symbol added to the permitted params via the normal method, but was included in a seperate tab, it cannot be included in the schema YAML as the other fields are. This is the case for all special case fields, Hyrax-DOI fields, Notes, etc that need their own form tabs. If they are included in the schema definition, those values with override the field within the tab and vice versa.  