### PR TITLE
Update Gemfile.lock from inside the linux container

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -533,7 +533,6 @@ GEM
       googleauth (>= 0.16.2, < 2.a)
       mini_mime (~> 1.0)
     google-protobuf (3.19.1)
-    google-protobuf (3.19.1-x86_64-linux)
     google_drive (3.0.7)
       google-apis-drive_v3 (>= 0.5.0, < 1.0.0)
       google-apis-sheets_v4 (>= 0.4.0, < 1.0.0)
@@ -553,9 +552,6 @@ GEM
       os (>= 0.9, < 2.0)
       signet (~> 0.15)
     grpc (1.42.0)
-      google-protobuf (~> 3.18)
-      googleapis-common-protos-types (~> 1.0)
-    grpc (1.42.0-x86_64-linux)
       google-protobuf (~> 3.18)
       googleapis-common-protos-types (~> 1.0)
     grpc-google-iam-v1 (1.0.0)
@@ -1263,6 +1259,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   lograge
   mods (~> 2.4)
+  parser (~> 2.5.3)
   pg
   puma (~> 4.3)
   rack-test (= 0.7.0)
@@ -1274,6 +1271,8 @@ DEPENDENCIES
   rspec
   rspec-rails (>= 3.6.0)
   rspec_junit_formatter
+  rubocop (~> 0.50, <= 0.52.1)
+  rubocop-rspec (~> 1.22, <= 1.22.2)
   ruby-prof
   sass-rails (~> 5.0)
   scss_lint


### PR DESCRIPTION
Whenever the `bundle install` is run from outside of the container, the Google Gems are compiled for the Host OS, then when the `bundle install` in run from inside the containers it compiles for native linux. We need to only ever bundle install from inside of the container and if you do bundle install from your host machine, those changes should not be committed. 