### PR TITLE
Change description to abstract as its causing issues with generate_solr_document

### DIFF
--- a/config/metadata/ubiquity_template_work.yaml
+++ b/config/metadata/ubiquity_template_work.yaml
@@ -912,7 +912,7 @@ attributes:
     predicate: http://purl.org/dc/terms/description
     multiple: true
     index_keys:
-    - abstract_tesim
+    - description_tesim
     form:
       required: false
       primary: false

--- a/lib/hyrax/simple_schema_loader.rb
+++ b/lib/hyrax/simple_schema_loader.rb
@@ -59,13 +59,13 @@ module Hyrax
       ##
       # @return [Hash{Symbol => Object}]
       def form_options
-        config.fetch('form', {}).symbolize_keys
+        config.fetch("form", {}).symbolize_keys
       end
 
       ##
       # @return [Enumerable<Symbol>]
       def index_keys
-        config.fetch('index_keys', []).map(&:to_sym)
+        config.fetch("index_keys", []).map(&:to_sym)
       end
     end
 
@@ -77,7 +77,7 @@ module Hyrax
       # @param [#to_s] schema_name
       # @return [Enumerable<AttributeDefinition]
       def definitions(schema_name)
-        schema_config(schema_name)['attributes'].map do |name, config|
+        schema_config(schema_name)["attributes"].map do |name, config|
           AttributeDefinition.new(name, config)
         end
       end


### PR DESCRIPTION
This was a strange one that i don't properly understand, but @BertZZ  pointed me in the right direction. 

It seems that the solr keys need to only ever be implemented once and that they are then shared amongst the different schemas, so "abstract" and "description" cannot both use "abstract_tesim", only "abstract" can and "description" should use its own "description_tesim" index.