### PR TITLE
Hide the batch edit button

### DIFF
--- a/app/assets/stylesheets/hyku_addons/dashboard.scss
+++ b/app/assets/stylesheets/hyku_addons/dashboard.scss
@@ -1,5 +1,7 @@
-.btn[data-create-type="batch"] {
-  display: none;
+.btn {
+  &[data-create-type="batch"], &[data-behavior="batch-edit"] {
+    display: none;
+  }
 }
 
 .badge, td.status span.enabled {


### PR DESCRIPTION
The functionality was never ported from Hyku1 and thus has never worked on Hyku2.