### PR TITLE
Fix Flaky Account Settings tests

### DIFF
--- a/spec/requests/hyku_addons/pdf_viewer_controller_spec.rb
+++ b/spec/requests/hyku_addons/pdf_viewer_controller_spec.rb
@@ -18,6 +18,11 @@ RSpec.describe "::HykuAddons::PdfViewerController", type: :request, js: true do
       block.call
     end
     host! account.cname
+    default_url_options[:host] = "http://#{account.cname}"
+  end
+
+  after do
+    default_url_options[:host] = nil
   end
 
   describe "GET pdf_viewer" do

--- a/spec/requests/hyku_addons/pdf_viewer_controller_spec.rb
+++ b/spec/requests/hyku_addons/pdf_viewer_controller_spec.rb
@@ -18,11 +18,6 @@ RSpec.describe "::HykuAddons::PdfViewerController", type: :request, js: true do
       block.call
     end
     host! account.cname
-    default_url_options[:host] = "http://#{account.cname}"
-  end
-
-  after do
-    account.reset!
   end
 
   describe "GET pdf_viewer" do

--- a/spec/requests/hyku_addons/pdf_viewer_controller_spec.rb
+++ b/spec/requests/hyku_addons/pdf_viewer_controller_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe "::HykuAddons::PdfViewerController", type: :request, js: true do
   end
 
   after do
-    default_url_options[:host] = nil
+    default_url_options.except!(:host)
   end
 
   describe "GET pdf_viewer" do


### PR DESCRIPTION
Ensure that the `:host` parameter is removed from `default_url_options` to prevent Account objects created in one test leaking into others.