### PR TITLE
Dashboard GDS reports

### DIFF
--- a/app/assets/javascripts/hyku_addons/application.js
+++ b/app/assets/javascripts/hyku_addons/application.js
@@ -35,6 +35,7 @@ const hykuAddonsOnLoad = function() {
   // or it might try and trigger an event not being listened to
   new ChangeToggleableListener()
   new RemoveToggleableOnSubmitListener()
+  new UpdateIframeSrcListener()
 
   // Register our events and after event actions
   new Eventable()

--- a/app/assets/javascripts/hyku_addons/update_iframe_src_listener.js
+++ b/app/assets/javascripts/hyku_addons/update_iframe_src_listener.js
@@ -1,0 +1,55 @@
+// It's not possible to update external iframe SRCs once the page has loaded, due to the same-origin policy, so this
+// class will create a new iframe DOM element, copy the existing ifames attributes and replace it in its parent.
+//
+// Example:
+// <% options = { class: "js-reports-trigger form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
+// <%= select_tag :report, options_for_select(@reports), options %>
+class UpdateIframeSrcListener {
+  constructor() {
+    this.eventName = "update_iframe_src"
+    this.iframeId = "iframeId"
+    this.introSelector = "#reports_intro"
+
+    this.registerListeners()
+  }
+
+  registerListeners() {
+    $("body").on(this.eventName, this.onEvent.bind(this))
+  }
+
+  onEvent(_event, target) {
+    let $iframe = $(`#${$(target).data(this.iframeId)}`)
+    this.recreateIframe(target, $iframe)
+  }
+
+  recreateIframe(select, $iframe) {
+    let [height, src] = select.val().split(",")
+
+    // If the user selected the blank option, or they selected the current chart after selecting the blank options
+    if (src === undefined || src == $iframe.attr("src")) {
+      return
+    }
+
+    $(this.introSelector).hide()
+
+    let newIframe = this.buildIframeFromExisting($iframe)
+    let $parent = $iframe.parent()
+    $iframe.remove()
+
+    newIframe.setAttribute("src", src)
+    newIframe.height = `${height}px`
+    newIframe.style.display = "block"
+
+    $parent.append(newIframe)
+  }
+
+  // Build the new iframe dom element and copy over all of the previous iframes attributes
+  buildIframeFromExisting($existing) {
+    let attrs = $existing[0].attributes
+    let newIframe = document.createElement("iframe")
+
+    $(attrs).each(function() { $(newIframe).attr(this.nodeName, this.nodeValue) })
+
+    return newIframe
+  }
+}

--- a/app/assets/stylesheets/hyku_addons/dashboard.scss
+++ b/app/assets/stylesheets/hyku_addons/dashboard.scss
@@ -76,6 +76,7 @@
     max-width: 100%;
   }
 }
+
 .btn {
   &[data-create-type="batch"], &[data-behavior="batch-edit"] {
     display: none;
@@ -112,6 +113,18 @@ ul.listing {
           text-decoration: underline;
         }
       }
+    }
+  }
+}
+
+#reports {
+  #dashaboard_gds_reports {
+    margin: 10px 0 20px;
+  }
+
+  #report {
+    iframe {
+      display: none;
     }
   }
 }

--- a/app/assets/stylesheets/hyku_addons/dashboard.scss
+++ b/app/assets/stylesheets/hyku_addons/dashboard.scss
@@ -1,3 +1,81 @@
+// Add the boostrap 4 .col-xl- breakpoint to the dashboard as version 3 only has .col-lg
+@media only screen and (min-width: 1600px) {
+  .col-xl-1, .col-xl-2, .col-xl-3, .col-xl-4, .col-xl-5, .col-xl-6, .col-xl-7, .col-xl-8, .col-xl-9, .col-xl-10, .col-xl-11, .col-xl-12, .col-xl,
+  .col-xl-auto {
+    position: relative;
+    width: 100%;
+    padding-right: 15px;
+    padding-left: 15px;
+    float: left;
+  }
+
+  .col-xl-auto {
+    -ms-flex: 0 0 auto;
+    flex: 0 0 auto;
+    width: auto;
+    max-width: 100%;
+  }
+  .col-xl-1 {
+    -ms-flex: 0 0 8.333333%;
+    flex: 0 0 8.333333%;
+    max-width: 8.333333%;
+  }
+  .col-xl-2 {
+    -ms-flex: 0 0 16.666667%;
+    flex: 0 0 16.666667%;
+    max-width: 16.666667%;
+  }
+  .col-xl-3 {
+    -ms-flex: 0 0 25%;
+    flex: 0 0 25%;
+    max-width: 25%;
+  }
+  .col-xl-4 {
+    -ms-flex: 0 0 33.333333%;
+    flex: 0 0 33.333333%;
+    max-width: 33.333333%;
+  }
+  .col-xl-5 {
+    -ms-flex: 0 0 41.666667%;
+    flex: 0 0 41.666667%;
+    max-width: 41.666667%;
+  }
+  .col-xl-6 {
+    -ms-flex: 0 0 50%;
+    flex: 0 0 50%;
+    max-width: 50%;
+  }
+  .col-xl-7 {
+    -ms-flex: 0 0 58.333333%;
+    flex: 0 0 58.333333%;
+    max-width: 58.333333%;
+  }
+  .col-xl-8 {
+    -ms-flex: 0 0 66.666667%;
+    flex: 0 0 66.666667%;
+    max-width: 66.666667%;
+  }
+  .col-xl-9 {
+    -ms-flex: 0 0 75%;
+    flex: 0 0 75%;
+    max-width: 75%;
+  }
+  .col-xl-10 {
+    -ms-flex: 0 0 83.333333%;
+    flex: 0 0 83.333333%;
+    max-width: 83.333333%;
+  }
+  .col-xl-11 {
+    -ms-flex: 0 0 91.666667%;
+    flex: 0 0 91.666667%;
+    max-width: 91.666667%;
+  }
+  .col-xl-12 {
+    -ms-flex: 0 0 100%;
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+}
 .btn {
   &[data-create-type="batch"], &[data-behavior="batch-edit"] {
     display: none;

--- a/app/assets/stylesheets/hyku_addons/dashboard.scss
+++ b/app/assets/stylesheets/hyku_addons/dashboard.scss
@@ -118,8 +118,12 @@ ul.listing {
 }
 
 #reports {
+  label {
+    margin-top: 10px;
+  }
+
   #dashaboard_gds_reports {
-    margin: 10px 0 20px;
+    margin-bottom: 20px;
   }
 
   #report {

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -8,10 +8,19 @@ module HykuAddons
       with_themed_layout "dashboard"
 
       before_action :build_breadcrumbs, only: [:work, :file, :reports]
+      before_action :has_permission?, only: :reports
     end
 
     def reports
       @reports = Site.instance.account.dashboard_gds_charts.lines
+    end
+
+    protected
+
+    def has_permission?
+      return if current_user.has_role?(:admin, Site.instance)
+
+      raise ActionController::RoutingError, "Not found"
     end
   end
 end

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -11,7 +11,7 @@ module HykuAddons
     end
 
     def reports
-      @reports = Site.instance.account.dashboard_gds_charts.split(",").map(&:strip)
+      @reports = Site.instance.account.dashboard_gds_charts.lines
     end
   end
 end

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module StatsControllerBehavior
+    extend ActiveSupport::Concern
+
+    included do
+      with_themed_layout "dashboard"
+
+      before_action :build_breadcrumbs, only: [:work, :file, :reports]
+    end
+
+    def reports
+      @reports = Site.instance.account.dashboard_gds_charts.split(",").map(&:strip)
+    end
+  end
+end

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -12,7 +12,7 @@ module HykuAddons
     end
 
     def reports
-      @reports = account_gds_charts.lines.map do |chart|
+      @reports = account_gds_reports.lines.map do |chart|
         config = chart.split(",").map(&:strip)
 
         # Remove the first item from the array (the title) and return the rest for use in the select
@@ -23,13 +23,13 @@ module HykuAddons
     protected
 
       def permission?
-        return if current_user.has_role?(:admin, Site.instance)
+        return if current_user.has_role?(:admin, Site.instance) && Flipflop.enabled?(:gds_reports)
 
         raise ActionController::RoutingError, "Not found"
       end
 
-      def account_gds_charts
-        Site.instance.account.dashboard_gds_charts || ""
+      def account_gds_reports
+        Site.instance.account.gds_reports || ""
       end
   end
 end

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -8,24 +8,28 @@ module HykuAddons
       with_themed_layout "dashboard"
 
       before_action :build_breadcrumbs, only: [:work, :file, :reports]
-      before_action :has_permission?, only: :reports
+      before_action :permission?, only: :reports
     end
 
     def reports
-      @reports = Site.instance.account.dashboard_gds_charts.lines.map do |chart|
+      @reports = account_gds_charts.lines.map do |chart|
         config = chart.split(",").map(&:strip)
 
-        # Remove the first item from the array (the title) and return the rest
+        # Remove the first item from the array (the title) and return the rest for use in the select
         [config.delete_at(0), config.join(",")]
       end
     end
 
     protected
 
-      def has_permission?
+      def permission?
         return if current_user.has_role?(:admin, Site.instance)
 
         raise ActionController::RoutingError, "Not found"
+      end
+
+      def account_gds_charts
+        Site.instance.account.dashboard_gds_charts || ""
       end
   end
 end

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -12,7 +12,12 @@ module HykuAddons
     end
 
     def reports
-      @reports = Site.instance.account.dashboard_gds_charts.lines
+      @reports = Site.instance.account.dashboard_gds_charts.lines.map do |chart|
+        config = chart.split(",").map(&:strip)
+
+        # Remove the first item from the array (the title) and return the rest
+        [config.delete_at(0), config.join(",")]
+      end
     end
 
     protected

--- a/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/stats_controller_behavior.rb
@@ -22,10 +22,10 @@ module HykuAddons
 
     protected
 
-    def has_permission?
-      return if current_user.has_role?(:admin, Site.instance)
+      def has_permission?
+        return if current_user.has_role?(:admin, Site.instance)
 
-      raise ActionController::RoutingError, "Not found"
-    end
+        raise ActionController::RoutingError, "Not found"
+      end
   end
 end

--- a/app/controllers/hyku_addons/account_settings_controller.rb
+++ b/app/controllers/hyku_addons/account_settings_controller.rb
@@ -37,7 +37,7 @@ module HykuAddons
           settings: [
             :contact_email, :gtm_id, :file_size_limit, :enable_oai_metadata, :locale_name,
             :shared_login, :oai_prefix, :oai_sample_identifier, :oai_admin_email, :allow_signup,
-            :bulkrax_validations, :google_analytics_id, :dashboard_gds_charts,
+            :bulkrax_validations, :google_analytics_id, :gds_reports,
             google_scholarly_work_types: [], email_format: [], weekly_email_list: [], monthly_email_list: [],
             yearly_email_list: [], smtp_settings: HykuAddons::PerTenantSmtpInterceptor.available_smtp_fields,
             hyrax_orcid_settings: [:client_id, :client_secret, :auth_redirect, :environment]

--- a/app/controllers/hyku_addons/account_settings_controller.rb
+++ b/app/controllers/hyku_addons/account_settings_controller.rb
@@ -34,7 +34,7 @@ module HykuAddons
           settings: [
             :contact_email, :gtm_id, :file_size_limit, :enable_oai_metadata, :locale_name,
             :shared_login, :oai_prefix, :oai_sample_identifier, :oai_admin_email, :allow_signup,
-            :bulkrax_validations, :google_analytics_id,
+            :bulkrax_validations, :google_analytics_id, :dashboard_gds_charts,
             google_scholarly_work_types: [], email_format: [], weekly_email_list: [], monthly_email_list: [],
             yearly_email_list: [], smtp_settings: HykuAddons::PerTenantSmtpInterceptor.available_smtp_fields,
             hyrax_orcid_settings: [:client_id, :client_secret, :auth_redirect, :environment]

--- a/app/controllers/hyku_addons/account_settings_controller.rb
+++ b/app/controllers/hyku_addons/account_settings_controller.rb
@@ -20,10 +20,13 @@ module HykuAddons
     end
 
     def update_single
-      @account.settings.merge!(account_params['settings'])
+      @account.settings.merge!(account_params["settings"])
+
       # removes nil keys in the hash
       @account.settings.compact
+
       @account.save if @account.settings_changed?
+
       redirect_to admin_account_settings_path
     end
 
@@ -49,9 +52,9 @@ module HykuAddons
       def map_array_fields
         keys = %w[email_format weekly_email_list monthly_email_list yearly_email_list]
         keys.each do |key|
-          next if params['account']['settings'][key].blank?
+          next if params["account"]["settings"][key].blank?
 
-          params['account']['settings'][key].map! { |str| str.split(' ') }.flatten!
+          params["account"]["settings"][key].map! { |str| str.split(" ") }.flatten!
         end
       end
   end

--- a/app/helpers/hyku_addons/helper_behavior.rb
+++ b/app/helpers/hyku_addons/helper_behavior.rb
@@ -11,5 +11,11 @@ module HykuAddons
     include HykuAddons::NotesTabFormHelper
     include HykuAddons::OrcidHelperBehavior
     include HykuAddons::CrossTenantSharedSearchHelper
+
+    def account_setting_title(setting_name)
+      title_key = "settings.titles.#{setting_name}"
+
+      I18n.exists?(title_key) ? t(title_key) : setting_name.to_s.humanize
+    end
   end
 end

--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -10,16 +10,18 @@ module HykuAddons
     BOOLEAN_SETTINGS = %w[allow_signup shared_login bulkrax_validations].freeze
     HASH_SETTINGS = %w[smtp_settings hyrax_orcid_settings].freeze
     TEXT_SETTINGS = %w[contact_email gtm_id oai_admin_email oai_prefix oai_sample_identifier google_analytics_id].freeze
+    TEXT_AREA_SETTINGS = %w[dashboard_gds_charts].freeze
 
     PRIVATE_SETTINGS = %w[smtp_settings].freeze
 
     included do
       # added forshared search
       scope :full_accounts, -> { where(search_only: false) }
-      has_many :full_account_cross_searches, class_name: 'AccountCrossSearch', dependent: :destroy, foreign_key: 'search_account_id'
-      has_many :full_accounts, class_name: 'Account', through: :full_account_cross_searches
-      has_many :search_account_cross_searches, class_name: 'AccountCrossSearch', dependent: :destroy, foreign_key: 'full_account_id'
-      has_many :search_accounts, class_name: 'Account', through: :search_account_cross_searches
+
+      has_many :full_account_cross_searches, class_name: "AccountCrossSearch", dependent: :destroy, foreign_key: "search_account_id"
+      has_many :full_accounts, class_name: "Account", through: :full_account_cross_searches
+      has_many :search_account_cross_searches, class_name: "AccountCrossSearch", dependent: :destroy, foreign_key: "full_account_id"
+      has_many :search_accounts, class_name: "Account", through: :search_account_cross_searches
       accepts_nested_attributes_for :full_accounts
       accepts_nested_attributes_for :full_account_cross_searches, allow_destroy: true
 
@@ -31,7 +33,7 @@ module HykuAddons
                      :google_scholarly_work_types, :gtm_id, :shared_login, :email_format,
                      :allow_signup, :oai_admin_email, :file_size_limit, :enable_oai_metadata, :oai_prefix,
                      :oai_sample_identifier, :locale_name, :bulkrax_validations, :google_analytics_id, :smtp_settings,
-                     :hyrax_orcid_settings
+                     :hyrax_orcid_settings, :dashboard_gds_charts
 
       after_initialize :initialize_settings
 
@@ -122,15 +124,15 @@ module HykuAddons
     private
 
       def validate_email_format
-        return unless settings['email_format'].present?
+        return unless settings["email_format"].present?
 
-        settings['email_format'].each do |email|
+        settings["email_format"].each do |email|
           errors.add(:email_format) unless email.match?(/@\S*\.\S*/)
         end
       end
 
       def validate_contact_emails
-        ['weekly_email_list', 'monthly_email_list', 'yearly_email_list'].each do |key|
+        ["weekly_email_list", "monthly_email_list", "yearly_email_list"].each do |key|
           next unless settings[key].present?
 
           settings[key].each do |email|
@@ -146,9 +148,9 @@ module HykuAddons
       end
 
       def set_jsonb_allow_signup_default
-        return if settings['allow_signup'].present?
+        return if settings["allow_signup"].present?
 
-        self.allow_signup = 'true'
+        self.allow_signup = "true"
       end
 
       def set_smtp_settings

--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -10,7 +10,7 @@ module HykuAddons
     BOOLEAN_SETTINGS = %w[allow_signup shared_login bulkrax_validations].freeze
     HASH_SETTINGS = %w[smtp_settings hyrax_orcid_settings].freeze
     TEXT_SETTINGS = %w[contact_email gtm_id oai_admin_email oai_prefix oai_sample_identifier google_analytics_id].freeze
-    TEXT_AREA_SETTINGS = %w[dashboard_gds_charts].freeze
+    TEXT_AREA_SETTINGS = %w[gds_reports].freeze
 
     PRIVATE_SETTINGS = %w[smtp_settings].freeze
 
@@ -33,7 +33,7 @@ module HykuAddons
                      :google_scholarly_work_types, :gtm_id, :shared_login, :email_format,
                      :allow_signup, :oai_admin_email, :file_size_limit, :enable_oai_metadata, :oai_prefix,
                      :oai_sample_identifier, :locale_name, :bulkrax_validations, :google_analytics_id, :smtp_settings,
-                     :hyrax_orcid_settings, :dashboard_gds_charts
+                     :hyrax_orcid_settings, :gds_reports
 
       after_initialize :initialize_settings
 

--- a/app/views/hyku_addons/account_settings/edit.html.erb
+++ b/app/views/hyku_addons/account_settings/edit.html.erb
@@ -5,40 +5,41 @@
   <br>
 <% end %>
 
-<%= form_for @account, url: hyku_addons.admin_account_setting_path(@account), html: { class: 'form control' } do |f| %>
+<%= form_for @account, url: hyku_addons.admin_account_setting_path(@account), html: { class: "form control" } do |f| %>
   <% HykuAddons::AccountBehavior::TEXT_SETTINGS.each do |fname| %>
     <div class="col-12">
-      <%= render 'hyku_addons/account_settings/settings/text_field_content',  account: @account, field_name: fname, f: f, display_save_button: false %>
+      <%= render "hyku_addons/account_settings/settings/text_field_content",  account: @account, field_name: fname, f: f, display_save_button: false %>
+    <div>
+  <% end %>
+
+  <% HykuAddons::AccountBehavior::TEXT_AREA_SETTINGS.each do |fname| %>
+    <div class="col-12">
+      <%= render "hyku_addons/account_settings/settings/text_area_content",  account: @account, field_name: fname, f: f, display_save_button: false %>
     <div>
   <% end %>
 
   <% HykuAddons::AccountBehavior::ARRAY_SETTINGS.each do |fname| %>
     <div class="col-12">
-      <%= render 'hyku_addons/account_settings/settings/array_list_content', field_name: fname,  html_name_element: fname, f: f, display_save_button: false %>
+      <%= render "hyku_addons/account_settings/settings/array_list_content", field_name: fname,  html_name_element: fname, f: f, display_save_button: false %>
     <div>
   <% end %>
 
   <% HykuAddons::AccountBehavior::HASH_SETTINGS.each do |settings_hash_key| %>
     <div class="col-12">
-      <%= render 'hyku_addons/account_settings/settings/hash_settings_content', field_name: settings_hash_key, html_name_element: settings_hash_key, f: f, display_save_button: false %>
+      <%= render "hyku_addons/account_settings/settings/hash_settings_content", field_name: settings_hash_key, html_name_element: settings_hash_key, f: f, display_save_button: false %>
     <div>
   <% end %>
 
   <% HykuAddons::AccountBehavior::BOOLEAN_SETTINGS.each do |fname| %>
     <div class="col-12">
-      <%= render 'hyku_addons/account_settings/settings/boolean_field_content', field_name: fname, f: f, display_save_button: false %>
+      <%= render "hyku_addons/account_settings/settings/boolean_field_content", field_name: fname, f: f, display_save_button: false %>
     <div>
   <% end %>
 
   <% fname = "google_scholarly_work_types" %>
   <% options = Site.instance.available_works %>
   <div class="col-12">
-    <%= render 'hyku_addons/account_settings/settings/select_field_content',
-      field_name: fname,
-      f: f,
-      options: options,
-      display_save_button: false
-    %>
+    <%= render "hyku_addons/account_settings/settings/select_field_content", field_name: fname, f: f, options: options, display_save_button: false %>
   <div>
 
   <%= render "hyku_addons/account_settings/settings/submit_buttons", f: f %>

--- a/app/views/hyku_addons/account_settings/index.html.erb
+++ b/app/views/hyku_addons/account_settings/index.html.erb
@@ -10,41 +10,59 @@
   <tbody>
     <% HykuAddons::AccountBehavior::TEXT_SETTINGS.each do |fname| %>
       <tr>
-        <td id="link-<%= fname %>"><b><%= fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-        <td><%= link_to "Edit #{fname.humanize}", hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: 'render_text_fields', field_name: fname), class: "btn btn-xs btn-default", remote: true %></td>
+        <% title_key = "settings.titles.#{fname}" %>
+        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_fields", field_name: fname) %>
+        <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
+      </tr>
+    <% end %>
+
+    <% HykuAddons::AccountBehavior::TEXT_AREA_SETTINGS.each do |fname| %>
+      <tr>
+        <% title_key = "settings.titles.#{fname}" %>
+        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_areas", field_name: fname) %>
+        <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
 
     <% HykuAddons::AccountBehavior::ARRAY_SETTINGS.each do |fname| %>
       <tr>
-        <td id="link-<%= fname %>"><b> <%= fname.humanize %>:</b> <%= @account&.settings[fname]&.to_sentence %></td>
-        <td><%=link_to "Edit #{fname.humanize}", hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: 'render_array_list', field_name: fname), class: "btn btn-xs btn-default", remote: true %></td>
+        <% title_key = "settings.titles.#{fname}" %>
+        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname]&.to_sentence %></td>
+				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_array_list", field_name: fname) %>
+        <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
 
     <% if (settings = HykuAddons::AccountBehavior::HASH_SETTINGS).present? %>
       <% settings.each do|fname| %>
         <tr>
-          <td id="link-<%= fname %>"><b> <%= fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-          <td><%=link_to "Edit #{fname.humanize}", hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: 'render_hash_settings', field_name: fname), class: "btn btn-xs btn-default", remote: true  %></td>
+        <% title_key = "settings.titles.#{fname}" %>
+        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+					<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_hash_settings", field_name: fname) %>
+          <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true  %></td>
         </tr>
       <% end %>
     <% end %>
 
-    <% HykuAddons::AccountBehavior::BOOLEAN_SETTINGS.each do |fname| %>
+		<% HykuAddons::AccountBehavior::BOOLEAN_SETTINGS.each do |fname| %>
       <tr>
-        <td id="link-<%= fname %>"><b><%= fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-        <td><%= link_to "Edit #{fname.humanize}", hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: 'render_single_boolean', field_name: fname), class: "btn btn-xs btn-default", remote: true %></td>
+        <% title_key = "settings.titles.#{fname}" %>
+        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_single_boolean", field_name: fname) %>
+        <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
 
     <% fname = "google_scholarly_work_types" %>
     <% options = Site.instance.available_works %>
     <% current_selection = @account.settings.dig(fname)&.select(&:present?)&.compact&.join(", ") %>
-
+    <% title_key = "settings.titles.#{fname}" %>
     <tr>
-      <td id="link-<%= fname %>"><b><%= fname.humanize %>:</b><br> <%= current_selection %></td>
-      <td><%= link_to "Edit #{fname.humanize}", hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: 'render_select', field_name: fname, options: options), class: "btn btn-xs btn-default", remote: true %></td>
+      <td id="link-<%= fname %>"><b><%=  I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b><br> <%= current_selection %></td>
+			<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_select", field_name: fname, options: options) %>
+      <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
     </tr>
   </tbody>
 </table>

--- a/app/views/hyku_addons/account_settings/index.html.erb
+++ b/app/views/hyku_addons/account_settings/index.html.erb
@@ -11,7 +11,7 @@
     <% HykuAddons::AccountBehavior::TEXT_SETTINGS.each do |fname| %>
       <tr>
         <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
 				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_fields", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
@@ -20,7 +20,7 @@
     <% HykuAddons::AccountBehavior::TEXT_AREA_SETTINGS.each do |fname| %>
       <tr>
         <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
 				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_areas", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
@@ -29,7 +29,7 @@
     <% HykuAddons::AccountBehavior::ARRAY_SETTINGS.each do |fname| %>
       <tr>
         <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname]&.to_sentence %></td>
+        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname]&.to_sentence %></td>
 				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_array_list", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
@@ -39,7 +39,7 @@
       <% settings.each do|fname| %>
         <tr>
         <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
 					<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_hash_settings", field_name: fname) %>
           <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true  %></td>
         </tr>
@@ -49,7 +49,7 @@
 		<% HykuAddons::AccountBehavior::BOOLEAN_SETTINGS.each do |fname| %>
       <tr>
         <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%= I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
+        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
 				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_single_boolean", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
@@ -60,7 +60,7 @@
     <% current_selection = @account.settings.dig(fname)&.select(&:present?)&.compact&.join(", ") %>
     <% title_key = "settings.titles.#{fname}" %>
     <tr>
-      <td id="link-<%= fname %>"><b><%=  I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b><br> <%= current_selection %></td>
+      <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b><br> <%= current_selection %></td>
 			<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_select", field_name: fname, options: options) %>
       <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
     </tr>

--- a/app/views/hyku_addons/account_settings/index.html.erb
+++ b/app/views/hyku_addons/account_settings/index.html.erb
@@ -10,27 +10,24 @@
   <tbody>
     <% HykuAddons::AccountBehavior::TEXT_SETTINGS.each do |fname| %>
       <tr>
-        <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_fields", field_name: fname) %>
+        <td id="link-<%= fname %>"><b><%== account_setting_title(fname) %>:</b> <%= @account&.settings[fname] %></td>
+        <% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_fields", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
 
     <% HykuAddons::AccountBehavior::TEXT_AREA_SETTINGS.each do |fname| %>
       <tr>
-        <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_areas", field_name: fname) %>
+        <td id="link-<%= fname %>"><b><%== account_setting_title(fname) %>:</b> <%= @account&.settings[fname] %></td>
+        <% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_text_areas", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
 
     <% HykuAddons::AccountBehavior::ARRAY_SETTINGS.each do |fname| %>
       <tr>
-        <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname]&.to_sentence %></td>
-				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_array_list", field_name: fname) %>
+        <td id="link-<%= fname %>"><b><%== account_setting_title(fname) %>:</b> <%= @account&.settings[fname]&.to_sentence %></td>
+        <% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_array_list", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
@@ -38,19 +35,17 @@
     <% if (settings = HykuAddons::AccountBehavior::HASH_SETTINGS).present? %>
       <% settings.each do|fname| %>
         <tr>
-        <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-					<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_hash_settings", field_name: fname) %>
+          <td id="link-<%= fname %>"><b><%== account_setting_title(fname) %>:</b> <%= @account&.settings[fname] %></td>
+          <% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_hash_settings", field_name: fname) %>
           <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true  %></td>
         </tr>
       <% end %>
     <% end %>
 
-		<% HykuAddons::AccountBehavior::BOOLEAN_SETTINGS.each do |fname| %>
+    <% HykuAddons::AccountBehavior::BOOLEAN_SETTINGS.each do |fname| %>
       <tr>
-        <% title_key = "settings.titles.#{fname}" %>
-        <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b> <%= @account&.settings[fname] %></td>
-				<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_single_boolean", field_name: fname) %>
+        <td id="link-<%= fname %>"><b><%== account_setting_title(fname) %>:</b> <%= @account&.settings[fname] %></td>
+        <% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_single_boolean", field_name: fname) %>
         <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
       </tr>
     <% end %>
@@ -58,10 +53,9 @@
     <% fname = "google_scholarly_work_types" %>
     <% options = Site.instance.available_works %>
     <% current_selection = @account.settings.dig(fname)&.select(&:present?)&.compact&.join(", ") %>
-    <% title_key = "settings.titles.#{fname}" %>
     <tr>
-      <td id="link-<%= fname %>"><b><%== I18n.exists?(title_key) ? t(title_key) : fname.humanize %>:</b><br> <%= current_selection %></td>
-			<% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_select", field_name: fname, options: options) %>
+      <td id="link-<%= fname %>"><b><%== account_setting_title(fname) %>:</b><br> <%= current_selection %></td>
+      <% link = hyku_addons.edit_admin_account_setting_path(id: @account, partial_name: "render_select", field_name: fname, options: options) %>
       <td><%= link_to "Edit #{fname.humanize}", link, class: "btn btn-xs btn-default", remote: true %></td>
     </tr>
   </tbody>

--- a/app/views/hyku_addons/account_settings/settings/_partial_for_text_area_fields.html.erb
+++ b/app/views/hyku_addons/account_settings/settings/_partial_for_text_area_fields.html.erb
@@ -14,8 +14,9 @@
             </div>
           <% end %>
 
-          <%= render "hyku_addons/account_settings/settings/text_field_content", field_name: field_name, f: f, display_save_button: true %>
+          <%= render "hyku_addons/account_settings/settings/text_area_content", field_name: field_name, f: f, display_save_button: true %>
       <% end %>
     </div>
   </div>
 </div>
+

--- a/app/views/hyku_addons/account_settings/settings/_text_area_content.html.erb
+++ b/app/views/hyku_addons/account_settings/settings/_text_area_content.html.erb
@@ -2,8 +2,9 @@
   <%= f.fields_for :settings do |ff| %>
     <%= ff.label field_name %><br>
     <%= t("settings.helptexts.#{field_name}") %><br>
-    <%= ff.text_field field_name, value: @account.settings[field_name], class: "form-control", id: field_name %>
+    <%= ff.text_area field_name, value: @account.settings[field_name], class: "form-control", id: field_name %>
   <% end %>
 </div>
 
 <%= render "hyku_addons/account_settings/settings/submit_buttons", f: f if display_save_button %>
+

--- a/app/views/hyku_addons/account_settings/settings/_text_area_content.html.erb
+++ b/app/views/hyku_addons/account_settings/settings/_text_area_content.html.erb
@@ -1,7 +1,7 @@
 <div class="form-group">
   <%= f.fields_for :settings do |ff| %>
     <%= ff.label field_name %><br>
-    <%= t("settings.helptexts.#{field_name}") %><br>
+    <%== t("settings.helptexts.#{field_name}") %><br>
     <%= ff.text_area field_name, value: @account.settings[field_name], class: "form-control", id: field_name %>
   <% end %>
 </div>

--- a/app/views/hyku_addons/account_settings/settings/render_text_areas.js.erb
+++ b/app/views/hyku_addons/account_settings/settings/render_text_areas.js.erb
@@ -1,0 +1,2 @@
+$("#link-<%= @field_name %>").replaceWith("<%= escape_javascript render "hyku_addons/account_settings/settings/partial_for_text_area_fields", account: @account, field_name: @field_name, display_save_button: true %>")
+

--- a/app/views/hyku_addons/account_settings/settings/render_text_fields.js.erb
+++ b/app/views/hyku_addons/account_settings/settings/render_text_fields.js.erb
@@ -1,1 +1,1 @@
-$('#link-<%= @field_name %>').replaceWith("<%= escape_javascript render 'hyku_addons/account_settings/settings/partial_for_text_fields', account: @account, field_name: @field_name, display_save_button: true %>")
+$("#link-<%= @field_name %>").replaceWith("<%= escape_javascript render "hyku_addons/account_settings/settings/partial_for_text_fields", account: @account, field_name: @field_name, display_save_button: true %>")

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -18,7 +18,7 @@
 
     <%= menu.nav_link(HykuAddons::Engine.routes.url_helpers.admin_stats_report_path) do %>
       <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.reports') %></span>
-    <% end if current_user.has_role?(:admin) %>
+    <% end if current_user.has_role?(:admin) && Flipflop.enabled?(:gds_reports) %>
   <% end %>
 </li>
 

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -5,13 +5,19 @@
                                icon_class: "fa fa-line-chart",
                                id: 'collapseRepositoryActivity',
                                open: menu.repository_activity_section? do %>
+
     <%= menu.nav_link(hyrax.dashboard_path) do %>
       <span class="fa fa-dashboard"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.activity_summary') %></span>
     <% end %>
+
     <% if menu.show_admin_menu_items? %>
       <%= menu.nav_link(main_app.status_path) do %>
         <span class="fa fa-flag"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.system_status') %></span>
       <% end %>
+    <% end %>
+
+    <%= menu.nav_link(HykuAddons::Engine.routes.url_helpers.admin_stats_report_path) do %>
+      <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.reports') %></span>
     <% end %>
   <% end %>
 </li>

--- a/app/views/hyrax/dashboard/sidebar/_activity.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_activity.html.erb
@@ -18,7 +18,7 @@
 
     <%= menu.nav_link(HykuAddons::Engine.routes.url_helpers.admin_stats_report_path) do %>
       <span class="fa fa-bar-chart" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('hyrax.admin.sidebar.reports') %></span>
-    <% end %>
+    <% end if current_user.has_role?(:admin) %>
   <% end %>
 </li>
 

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -1,48 +1,48 @@
 <%= content_tag :h1, I18n.t("stats.reports.title"), class: "lower" %>
 
 <div id="reports">
-	<% if @reports.any? %>
-		<div class="row">
-			<div class="col-lg-3 col-md-4 col-sm-6 col-xs-12 mb-5 form-group">
-				<%= label_tag :dashaboard_gds_reports, "Available Reports", class: "form-label" %>
-				<% options = { id: "dashaboard_gds_reports", class: "form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
-				<%= select_tag :report, options_for_select(@reports), options %>
-			</div>
-		</div>
+  <% if @reports.any? %>
+    <div class="row">
+      <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12 mb-5 form-group">
+        <%= label_tag :dashaboard_gds_reports, "Available Reports", class: "form-label" %>
+        <% options = { id: "dashaboard_gds_reports", class: "form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
+        <%= select_tag :report, options_for_select(@reports), options %>
+      </div>
+    </div>
 
-		<div class="row">
-			<div class="col-lg-12">
-				<div class="panel panel-default">
-					<div id="report" class="panel-body text-center">
-						<div id="reports_intro">
-							<h4><%= t("stats.reports.heading") %></h4>
-							<p><%= t("stats.reports.intro") %></p>
-						</div>
-						<iframe
-								id="container-frame"
-								src=""
-								width="100%"
-								height=""
-								frameborder="0"
-								style="border:0"
-								></iframe>
-					</div>
-				</div>
-			</div>
-		</div>
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="panel panel-default">
+          <div id="report" class="panel-body text-center">
+            <div id="reports_intro">
+              <h4><%= t("stats.reports.heading") %></h4>
+              <p><%= t("stats.reports.intro") %></p>
+            </div>
+            <iframe
+                id="container-frame"
+                src=""
+                width="100%"
+                height=""
+                frameborder="0"
+                style="border:0"
+                ></iframe>
+          </div>
+        </div>
+      </div>
+    </div>
 
-	<% else %>
-		<div class="row">
-			<div class="col-lg-12">
-				<div class="panel panel-default">
-					<div id="report" class="panel-body text-center">
-						<div id="reports_intro">
-							<h4><%= t("stats.reports.heading") %></h4>
-							<p><%= t("stats.reports.no_reports") %></p>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	<% end %>
+  <% else %>
+    <div class="row">
+      <div class="col-lg-12">
+        <div class="panel panel-default">
+          <div id="report" class="panel-body text-center">
+            <div id="reports_intro">
+              <h4><%= t("stats.reports.heading") %></h4>
+              <p><%= t("stats.reports.no_reports") %></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
 </div>

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -4,7 +4,7 @@
   <% if @reports.any? %>
     <div class="row">
       <div class="col-lg-3 col-md-4 col-sm-6 col-xs-12 mb-5 form-group">
-        <%= label_tag :dashaboard_gds_reports, "Available Reports", class: "form-label" %>
+        <%= label_tag :dashaboard_gds_reports, t("stats.reports.label"), class: "form-label" %>
         <% options = { id: "dashaboard_gds_reports", class: "form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
         <%= select_tag :report, options_for_select(@reports), options %>
       </div>

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -1,6 +1,8 @@
 <%= content_tag :h1, I18n.t("stats.reports.title"), class: "lower" %>
 
-<% @reports.each do |url| %>
+<% @reports.each do |report| %>
+  <% width, height, url = report.split(",").map(&:strip) %>
+
   <div class="row">
     <div class="col-md-12">
       <div class="panel panel-default">
@@ -8,8 +10,8 @@
           <iframe
             id="container-frame"
             src="<%= url %>"
-            width="100%"
-            height="800px"
+            width="<%= width %>"
+            height="<%= height %>"
             frameborder="0"
             style="border:0"
           ></iframe>

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -1,22 +1,22 @@
 <%= content_tag :h1, I18n.t("stats.reports.title"), class: "lower" %>
 
-<% @reports.each do |report| %>
-  <% width, height, url = report.split(",").map(&:strip) %>
+<div class="row">
+	<% @reports.each do |report| %>
+		<% height, url = report.split(",").map(&:strip) %>
 
-  <div class="row">
-    <div class="col-md-12">
-      <div class="panel panel-default">
-        <div class="panel-body text-center">
-          <iframe
-            id="container-frame"
-            src="<%= url %>"
-            width="<%= width %>"
-            height="<%= height %>"
-            frameborder="0"
-            style="border:0"
-          ></iframe>
-        </div>
-      </div>
-    </div>
-  </div>
-<% end %>
+		<div class="col-xl-6 col-lg-12">
+			<div class="panel panel-default">
+				<div class="panel-body text-center">
+					<iframe
+							id="container-frame"
+							src="<%= url %>"
+							width="100%"
+							height="<%= height %>"
+							frameborder="0"
+							style="border:0"
+							></iframe>
+				</div>
+			</div>
+		</div>
+	<% end %>
+</div>

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -1,31 +1,48 @@
 <%= content_tag :h1, I18n.t("stats.reports.title"), class: "lower" %>
 
 <div id="reports">
-	<div class="row">
-		<div class="col-lg-3 col-md-4 col-sm-6 col-xs-12 mb-5">
-			<% options = { id: "dashaboard_gds_reports", class: "form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
-			<%= select_tag :report, options_for_select(@reports), options %>
+	<% if @reports.any? %>
+		<div class="row">
+			<div class="col-lg-3 col-md-4 col-sm-6 col-xs-12 mb-5 form-group">
+				<%= label_tag :dashaboard_gds_reports, "Available Reports", class: "form-label" %>
+				<% options = { id: "dashaboard_gds_reports", class: "form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
+				<%= select_tag :report, options_for_select(@reports), options %>
+			</div>
 		</div>
-	</div>
 
-	<div class="row">
-		<div class="col-lg-12">
-			<div class="panel panel-default">
-				<div id="report" class="panel-body text-center">
-					<div id="reports_intro">
-						<h4>Ubiquity Reports</h4>
-						<p>Select a report to display from the dropdown and it will appear here. </p>
+		<div class="row">
+			<div class="col-lg-12">
+				<div class="panel panel-default">
+					<div id="report" class="panel-body text-center">
+						<div id="reports_intro">
+							<h4><%= t("stats.reports.heading") %></h4>
+							<p><%= t("stats.reports.intro") %></p>
+						</div>
+						<iframe
+								id="container-frame"
+								src=""
+								width="100%"
+								height=""
+								frameborder="0"
+								style="border:0"
+								></iframe>
 					</div>
-					<iframe
-						id="container-frame"
-						src=""
-						width="100%"
-						height=""
-						frameborder="0"
-						style="border:0"
-					></iframe>
 				</div>
 			</div>
 		</div>
-	</div>
+
+	<% else %>
+		<div class="row">
+			<div class="col-lg-12">
+				<div class="panel panel-default">
+					<div id="report" class="panel-body text-center">
+						<div id="reports_intro">
+							<h4><%= t("stats.reports.heading") %></h4>
+							<p><%= t("stats.reports.no_reports") %></p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	<% end %>
 </div>

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -1,0 +1,20 @@
+<%= content_tag :h1, I18n.t("stats.reports.title"), class: "lower" %>
+
+<% @reports.each do |url| %>
+  <div class="row">
+    <div class="col-md-12">
+      <div class="panel panel-default">
+        <div class="panel-body text-center">
+          <iframe
+            id="container-frame"
+            src="<%= url %>"
+            width="100%"
+            height="800px"
+            frameborder="0"
+            style="border:0"
+          ></iframe>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/hyrax/stats/reports.html.erb
+++ b/app/views/hyrax/stats/reports.html.erb
@@ -1,22 +1,31 @@
 <%= content_tag :h1, I18n.t("stats.reports.title"), class: "lower" %>
 
-<div class="row">
-	<% @reports.each do |report| %>
-		<% height, url = report.split(",").map(&:strip) %>
+<div id="reports">
+	<div class="row">
+		<div class="col-lg-3 col-md-4 col-sm-6 col-xs-12 mb-5">
+			<% options = { id: "dashaboard_gds_reports", class: "form-control", data: { "on-change" => "update_iframe_src", iframe_id: "container-frame" }, include_blank: "Please Select..." } %>
+			<%= select_tag :report, options_for_select(@reports), options %>
+		</div>
+	</div>
 
-		<div class="col-xl-6 col-lg-12">
+	<div class="row">
+		<div class="col-lg-12">
 			<div class="panel panel-default">
-				<div class="panel-body text-center">
+				<div id="report" class="panel-body text-center">
+					<div id="reports_intro">
+						<h4>Ubiquity Reports</h4>
+						<p>Select a report to display from the dropdown and it will appear here. </p>
+					</div>
 					<iframe
-							id="container-frame"
-							src="<%= url %>"
-							width="100%"
-							height="<%= height %>"
-							frameborder="0"
-							style="border:0"
-							></iframe>
+						id="container-frame"
+						src=""
+						width="100%"
+						height=""
+						frameborder="0"
+						style="border:0"
+					></iframe>
 				</div>
 			</div>
 		</div>
-	<% end %>
+	</div>
 </div>

--- a/config/features.rb
+++ b/config/features.rb
@@ -36,11 +36,16 @@ Flipflop.configure do
   feature :cross_tenant_shared_search,
           default: true,
           description: "Turns on cross tenant shared search."
-  
+
   feature :annotation,
           default: false,
           description: "Turns on links to hypothes.is PDF viewer"
+
   feature :inline_doi,
           default: false,
           description: "Toggle layout between a DOI Tab and use of sidebar"
+
+  feature :gds_reports,
+          default: false,
+          description: "Add Google Data Studio reports to the dashaboard"
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -253,7 +253,13 @@ en:
       locale_name: |
         The name of the tenant specific locale suffix added to their locale.yml files. Only alphabetic characters should be added, no symbols or numbers, these will then be capitalised.
       oai_admin_email: OAI endpoint contact email address
-      dashboard_gds_charts: List comma delimited Google Data Studio chart URL's to be displayed on the Dashboard
+      dashboard_gds_charts: |
+        List comma delimited Google Data Studio chart URL's to be displayed on the Dashboard. The format is important, i.e.<br><br>
+
+        600, 450, https://datastudio.google.com/embed/reporting/...,<br>
+        800, 450, https://datastudio.google.com/embed/reporting/...,<br><br>
+
+        Please note the trailing comma after each item. They are grouped one chart per line.
 
   hyrax:
     notifications:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,10 +254,10 @@ en:
         The name of the tenant specific locale suffix added to their locale.yml files. Only alphabetic characters should be added, no symbols or numbers, these will then be capitalised.
       oai_admin_email: OAI endpoint contact email address
       dashboard_gds_charts: |
-        List comma delimited Google Data Studio chart URL's to be displayed on the Dashboard. The format is important, i.e.<br><br>
+        List comma delimited Google Data Studio chart height and URL's to be displayed on the Dashboard. The format is important, i.e.<br><br>
 
-        600, 450, https://datastudio.google.com/embed/reporting/...,<br>
-        800, 450, https://datastudio.google.com/embed/reporting/...,<br><br>
+        450, https://datastudio.google.com/embed/reporting/...,<br>
+        450, https://datastudio.google.com/embed/reporting/...,<br><br>
 
         Please note the trailing comma after each item. They are grouped one chart per line.
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -242,7 +242,7 @@ en:
 
   settings:
     titles:
-      dashboard_gds_charts: Dashboard GDS Charts
+      gds_reports: Dashboard GDS Charts
     helptexts:
       gtm_id: The ID of your Google Tag Manager account
       contact_email: Email recipient of messages sent via the contact form
@@ -257,7 +257,7 @@ en:
       locale_name: |
         The name of the tenant specific locale suffix added to their locale.yml files. Only alphabetic characters should be added, no symbols or numbers, these will then be capitalised.
       oai_admin_email: OAI endpoint contact email address
-      dashboard_gds_charts: |
+      gds_reports: |
         List of Google Data Studio charts title, height and URL's to be displayed in the Dashboard. One report per line, comma seperated values, i.e.<br><br>
 
         Title, height in pixels, URL for Goggle Data Studio report

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -239,6 +239,7 @@ en:
       heading: Ubiquity Reports
       intro: Select a report to display from the dropdown and it will appear here.
       no_reports: No reports have been added yet.
+      label: Available Reports
 
   settings:
     titles:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -254,13 +254,11 @@ en:
         The name of the tenant specific locale suffix added to their locale.yml files. Only alphabetic characters should be added, no symbols or numbers, these will then be capitalised.
       oai_admin_email: OAI endpoint contact email address
       dashboard_gds_charts: |
-        List comma delimited Google Data Studio chart height and URL's to be displayed on the Dashboard. The format is important, i.e.<br><br>
+        List of Google Data Studio charts title, height and URL's to be displayed in the Dashboard. One report per line, comma seperated values, i.e.<br><br>
 
-        450, https://datastudio.google.com/embed/reporting/...,<br>
-        450, https://datastudio.google.com/embed/reporting/...,<br><br>
-
-        Please note the trailing comma after each item. They are grouped one chart per line.
-
+        Title, height in pixels, URL for Goggle Data Studio report
+        Users and Works, 850, https://datastudio.google.com/embed/reporting/...<br>
+        Most Cited Works, 850, https://datastudio.google.com/embed/reporting/...<br><br>
   hyrax:
     notifications:
         workflow:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -236,6 +236,10 @@ en:
   stats:
     reports:
       title: Google Data Studio Chart
+      heading: Ubiquity Reports
+      intro: Select a report to display from the dropdown and it will appear here.
+      no_reports: No reports have been added yet.
+
   settings:
     titles:
       dashboard_gds_charts: Dashboard GDS Charts

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -233,7 +233,12 @@ en:
         label: Type of alternate identifier
         placeholder: ""
         help_text: State the type of alternate identifier.
+  stats:
+    reports:
+      title: Google Data Studio Chart
   settings:
+    titles:
+      dashboard_gds_charts: Dashboard GDS Charts
     helptexts:
       gtm_id: The ID of your Google Tag Manager account
       contact_email: Email recipient of messages sent via the contact form
@@ -248,6 +253,7 @@ en:
       locale_name: |
         The name of the tenant specific locale suffix added to their locale.yml files. Only alphabetic characters should be added, no symbols or numbers, these will then be capitalised.
       oai_admin_email: OAI endpoint contact email address
+      dashboard_gds_charts: List comma delimited Google Data Studio chart URL's to be displayed on the Dashboard
 
   hyrax:
     notifications:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,6 @@ HykuAddons::Engine.routes.draw do
   get "/importers/:id/validation", to: "/hyku_addons/importer_validations#show", as: :importer_validation
 
   get "/pdf_viewer(/:download_id)", to: "/hyku_addons/pdf_viewer#pdf", as: :pdf_viewer
+
+  get "/admin/reports", to: "/hyrax/stats#reports", as: :admin_stats_report
 end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -579,6 +579,7 @@ module HykuAddons
       ::NilEndpoint.prepend HykuAddons::NilEndpointOverride
       ::Hyrax::CollectionIndexer.prepend HykuAddons::CollectionIndexerOverride
       ::Hyrax::CollectionPresenter.prepend HykuAddons::CollectionPresenterOverride
+      Hyrax::StatsController.include HykuAddons::StatsControllerBehavior
 
       User.class_eval do
         def mailboxer_email(_obj)

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Hyrax::StatsController, type: :controller do
+  routes { HykuAddons::Engine.routes }
+
+  let(:user) { create(:admin) }
+  let(:account) { create(:account) }
+  let(:site) { Site.new(account: account) }
+
+  before do
+    allow(Site).to receive(:instance).and_return(site)
+  end
+
+  describe "GET #reports" do
+    render_views
+
+    before do
+      allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
+      sign_in(user)
+    end
+
+    context "when the user is an admin" do
+      it "renders a partial" do
+        get :reports
+
+        expect(response).to render_template(:reports)
+      end
+    end
+
+    context "when the user is a non-admin" do
+      let(:user) { create(:user) }
+
+      it "renders a partial" do
+        expect { get :reports }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Hyrax::StatsController, type: :controller do
       context "when the user is a non-admin" do
         let(:enabled) { false }
 
-        it "renders a partial" do
+        it "returns an error" do
           expect { get :reports }.to raise_error(ActionController::RoutingError)
         end
       end
@@ -80,7 +80,7 @@ RSpec.describe Hyrax::StatsController, type: :controller do
     context "when the user is a non-admin" do
       let(:user) { create(:user) }
 
-      it "renders a partial" do
+      it "returns an error" do
         expect { get :reports }.to raise_error(ActionController::RoutingError)
       end
     end

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Hyrax::StatsController, type: :controller do
   let(:user) { create(:admin) }
   let(:account) { create(:account) }
   let(:site) { Site.new(account: account) }
+  let(:gds_fixture) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "csv", "gds_chart_fixture.csv")) }
 
   before do
     allow(Site).to receive(:instance).and_return(site)
@@ -18,14 +19,43 @@ RSpec.describe Hyrax::StatsController, type: :controller do
 
     before do
       allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
+      allow(account).to receive(:dashboard_gds_charts).and_return(gds_fixture)
+
       sign_in(user)
     end
 
     context "when the user is an admin" do
-      it "renders a partial" do
+      before do
         get :reports
+      end
 
+      it "renders a partial" do
+        expect(response).to have_http_status(:ok)
         expect(response).to render_template(:reports)
+      end
+
+      context "when there is data" do
+        it "displays the content" do
+          expect(response.body).to include(I18n.t("stats.reports.title"))
+          expect(response.body).to include(I18n.t("stats.reports.intro"))
+        end
+
+        it "displays the select" do
+          expect(response.body).to have_selector("#dashaboard_gds_reports")
+
+          reports = response.body.scan(/<option.*>(.*)<\/option>/).flatten
+          titles = gds_fixture.lines.map { |line| line.split(",").map(&:strip).delete_at(0) }
+          expect(reports).to match_array(titles)
+        end
+      end
+
+      context "when no data has been entered" do
+        let(:gds_fixture) { nil }
+
+        it "does not display the content" do
+          expect(response.body).to include(I18n.t("stats.reports.title"))
+          expect(response.body).to include(I18n.t("stats.reports.no_reports"))
+        end
       end
     end
 

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -42,9 +42,12 @@ RSpec.describe Hyrax::StatsController, type: :controller do
 
         it "displays the select" do
           expect(response.body).to have_selector("#dashaboard_gds_reports")
+        end
 
+        it "displays the correct report titles in the select" do
           reports = response.body.scan(/<option.*>(.*)<\/option>/).flatten
           titles = gds_fixture.lines.map { |line| line.split(",").map(&:strip).delete_at(0) }
+
           expect(reports).to match_array(titles)
         end
       end

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe Hyrax::StatsController, type: :controller do
   routes { HykuAddons::Engine.routes }
 
   let(:user) { create(:admin) }
-  let(:account) { create(:account) }
+  let(:account) { build_stubbed(:account) }
   let(:site) { Site.new(account: account) }
   let(:gds_fixture) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "csv", "gds_chart_fixture.csv")) }
   let(:enabled) { true }

--- a/spec/controllers/hyrax/stats_controller_spec.rb
+++ b/spec/controllers/hyrax/stats_controller_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Hyrax::StatsController, type: :controller do
   let(:account) { create(:account) }
   let(:site) { Site.new(account: account) }
   let(:gds_fixture) { File.read(HykuAddons::Engine.root.join("spec", "fixtures", "csv", "gds_chart_fixture.csv")) }
+  let(:enabled) { true }
 
   before do
     allow(Site).to receive(:instance).and_return(site)
@@ -18,23 +19,27 @@ RSpec.describe Hyrax::StatsController, type: :controller do
     render_views
 
     before do
+      allow(Flipflop).to receive(:enabled?).and_call_original
+      allow(Flipflop).to receive(:enabled?).with(:gds_reports).and_return(enabled)
       allow(controller.current_ability).to receive(:can?).with(any_args).and_return(true)
-      allow(account).to receive(:dashboard_gds_charts).and_return(gds_fixture)
+      allow(account).to receive(:gds_reports).and_return(gds_fixture)
 
       sign_in(user)
     end
 
     context "when the user is an admin" do
-      before do
-        get :reports
-      end
-
       it "renders a partial" do
+        get :reports
+
         expect(response).to have_http_status(:ok)
         expect(response).to render_template(:reports)
       end
 
       context "when there is data" do
+        before do
+          get :reports
+        end
+
         it "displays the content" do
           expect(response.body).to include(I18n.t("stats.reports.title"))
           expect(response.body).to include(I18n.t("stats.reports.intro"))
@@ -56,8 +61,18 @@ RSpec.describe Hyrax::StatsController, type: :controller do
         let(:gds_fixture) { nil }
 
         it "does not display the content" do
+          get :reports
+
           expect(response.body).to include(I18n.t("stats.reports.title"))
           expect(response.body).to include(I18n.t("stats.reports.no_reports"))
+        end
+      end
+
+      context "when the user is a non-admin" do
+        let(:enabled) { false }
+
+        it "renders a partial" do
+          expect { get :reports }.to raise_error(ActionController::RoutingError)
         end
       end
     end

--- a/spec/fixtures/csv/gds_chart_fixture.csv
+++ b/spec/fixtures/csv/gds_chart_fixture.csv
@@ -1,0 +1,2 @@
+Users and Works, 850, https://datastudio.google.com/embed/reporting/1111-2222-3333-4444/page/Nnd2B
+Most Cited Works, 850, https://datastudio.google.com/embed/reporting/5555-6666-7777-8888/page/Nnd2B

--- a/spec/system/hyku_addons/hyku_addons_account_settings_spec.rb
+++ b/spec/system/hyku_addons/hyku_addons_account_settings_spec.rb
@@ -5,6 +5,7 @@ require "rails_helper"
 RSpec.describe "AccountSettings", type: :system do
   let(:user) { FactoryBot.create(:admin) }
   let!(:account) { create(:account) }
+
   before do
     driven_by(:rack_test)
     login_as(user, scope: :user)


### PR DESCRIPTION
MVP for displaying Google Data Studio reports on a new page in the dashboard. 

![image](https://user-images.githubusercontent.com/1199977/149961284-987fb104-711a-4160-82c6-5b97b51c2be2.png)

Config is saved within the account setting section as a formatted list of chart URLs to iterate over in the view. 

![image](https://user-images.githubusercontent.com/1199977/149961371-0aff1b6c-4eca-4f3d-9ddd-dcf00b33885f.png)

The option can be enabled with the Feature Flipper. 

![image](https://user-images.githubusercontent.com/1199977/149968496-fb708896-5772-4f81-938b-1f978233d1e2.png)
