### PR TITLE
ensure tenant is switched before query is ran

### DIFF
--- a/app/services/hyku_addons/collection_branding_fetcher.rb
+++ b/app/services/hyku_addons/collection_branding_fetcher.rb
@@ -7,10 +7,10 @@ module HykuAddons
       @_collection_banner ||= collection_branding_info(id).where(role: 'banner')
     end
 
-    private_class_method
+    private
 
-    def collection_branding_info(id)
-      @_collection_branding_info ||= CollectionBrandingInfo.where(collection_id: id.to_s)
-    end
+      def collection_branding_info(id)
+        CollectionBrandingInfo.where(collection_id: id.to_s)
+      end
   end
 end

--- a/app/services/hyku_addons/collection_branding_fetcher.rb
+++ b/app/services/hyku_addons/collection_branding_fetcher.rb
@@ -2,14 +2,14 @@
 
 module HykuAddons
   class CollectionBrandingFetcher
-    def self.collection_banner(id, cname)
+    def collection_banner(id, cname)
       AccountElevator.switch!(cname)
       @_collection_banner ||= collection_branding_info(id).where(role: 'banner')
     end
 
     private_class_method
 
-    def self.collection_branding_info(id)
+    def collection_branding_info(id)
       @_collection_branding_info ||= CollectionBrandingInfo.where(collection_id: id.to_s)
     end
   end

--- a/app/services/hyku_addons/collection_branding_fetcher.rb
+++ b/app/services/hyku_addons/collection_branding_fetcher.rb
@@ -2,7 +2,8 @@
 
 module HykuAddons
   class CollectionBrandingFetcher
-    def self.collection_banner(id)
+    def self.collection_banner(id, cname)
+      AccountElevator.switch!(cname)
       @_collection_banner ||= collection_branding_info(id).where(role: 'banner')
     end
 

--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -33,7 +33,7 @@ json.cache! [@account, :collections, collection.id, collection.solr_document[:_v
   json.volumes nil
   json.total_works @total_works
 
-  banner = ::HykuAddons::CollectionBrandingFetcher.collection_banner(collection.id, @account.cname)
+  banner = ::HykuAddons::CollectionBrandingFetcher.new.collection_banner(collection.id, @account.cname)
   if banner.present?
     components = {
       scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'),

--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -33,7 +33,7 @@ json.cache! [@account, :collections, collection.id, collection.solr_document[:_v
   json.volumes nil
   json.total_works @total_works
 
-  banner = ::HykuAddons::CollectionBrandingFetcher.collection_banner(collection.id)
+  banner = ::HykuAddons::CollectionBrandingFetcher.collection_banner(collection.id, @account.cname)
   if banner.present?
     components = {
       scheme: Rails.application.routes.default_url_options.fetch(:protocol, 'http'),


### PR DESCRIPTION
Collection banner url was not being returned in the api response because it was  wrongly assumed that the account tenant was already switched higher up in the request cycle so we did not need to do another switch at the point of running the query for collection_banner_info.

The test did not catch this because in the test we were switching tenant, so the fix was just to switch tenant before running the query.