### PR TITLE
Add missing translation

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -294,6 +294,8 @@ en:
     file_sets:
       actions:
         read_and_annotate: Read and annotate
+      actions_list:
+        header: Select an action
       actions_button:
         delete: Delete
         download: Download


### PR DESCRIPTION
Following user feed back at the Advancing Hyku meeting we noticed a translation is missing from the locales file.
![image](https://user-images.githubusercontent.com/7236943/150136979-f76621d8-8a80-438a-8a8e-386f5e3bfcd0.png)
