### PR TITLE
Ensure redis account caching not used in API tenant controller test

### DIFF
--- a/spec/requests/v1/tenant_spec.rb
+++ b/spec/requests/v1/tenant_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe Hyku::API::V1::TenantController, type: :request, clean: true, mul
     end
 
     Apartment::Tenant.switch!(account.tenant) { Site.update(account: account) }
+    
+    # Ensure that if caching has been enabled elsewhere by the test suite it is disabled for this test
+    account.setup_tenant_cache(false)
   end
 
   describe "/tenant/:id" do

--- a/spec/requests/v1/tenant_spec.rb
+++ b/spec/requests/v1/tenant_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyku::API::V1::TenantController, type: :request, clean: true, mul
     end
 
     Apartment::Tenant.switch!(account.tenant) { Site.update(account: account) }
-    
+
     # Ensure that if caching has been enabled elsewhere by the test suite it is disabled for this test
     account.setup_tenant_cache(false)
   end


### PR DESCRIPTION
Ensure redis account caching not used in API tenant controller test