### PR TITLE
Skip retry in reindexmodeljob

### DIFF
--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -34,7 +34,7 @@ module HykuAddons
     private
 
       def mint_doi(work)
-        return if can_mint_for?(work)
+        return unless can_mint_for?(work)
 
         Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
 
@@ -46,7 +46,7 @@ module HykuAddons
       def can_mint_for?(work)
         state = workflow_state(work)
 
-        (work.creator.blank? || work.doi.present? || work.visibility != "open" || ["deposited", nil].exclude?(state&.workflow_state_name))
+        work.creator.present? && work.doi.blank? && work.visibility == "open" && ["deposited", nil].include?(state&.workflow_state_name)
       end
 
       def workflow_state(work)

--- a/app/jobs/hyku_addons/reindex_model_job.rb
+++ b/app/jobs/hyku_addons/reindex_model_job.rb
@@ -34,7 +34,7 @@ module HykuAddons
     private
 
       def mint_doi(work)
-        return unless cant_mint_for(work)
+        return if can_mint_for?(work)
 
         Rails.logger.debug "=== about to mint doi for #{work.title} ==== "
 
@@ -43,11 +43,10 @@ module HykuAddons
         work.update(doi: [register_doi.identifier])
       end
 
-      def cant_mint_for(work)
+      def can_mint_for?(work)
         state = workflow_state(work)
-        cannot_use_workflow_state = ["deposited", nil].exclude?(state&.workflow_state_name)
 
-        !(work.creator.blank? || work.doi.present? || work.visibility != "open" || cannot_use_workflow_state)
+        (work.creator.blank? || work.doi.present? || work.visibility != "open" || ["deposited", nil].exclude?(state&.workflow_state_name))
       end
 
       def workflow_state(work)


### PR DESCRIPTION
During minting of doi when exceptions are raised, the work is re-queued. The exception will still be handled but without retries.
Also if a work is sent for doi minting and it has no creator as was the case for some imported works, the minting will fail but in Datacite it will create a draft doi that is not attached to any work. We want to avoid that, by not minting doi for works that have no creator.