### PR TITLE
Port ImportWorkCollectionJob from old version of Bulkrax

### DIFF
--- a/app/jobs/hyku_addons/import_work_collection_job.rb
+++ b/app/jobs/hyku_addons/import_work_collection_job.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  class ImportWorkCollectionJob < ApplicationJob
+    queue_as :import
+
+    # rubocop:disable Rails/SkipsModelValidations
+    def perform(*args)
+      entry = Bulkrax::Entry.find(args[0])
+      begin
+        entry.build
+        entry.save
+        add_user_to_permission_template!(entry)
+        Bulkrax::ImporterRun.find(args[1]).increment!(:processed_collections)
+        Bulkrax::ImporterRun.find(args[1]).decrement!(:enqueued_records)
+      rescue => e
+        Bulkrax::ImporterRun.find(args[1]).increment!(:failed_collections)
+        Bulkrax::ImporterRun.find(args[1]).decrement!(:enqueued_records)
+        raise e
+      end
+    end
+    # rubocop:enable Rails/SkipsModelValidations
+
+    private
+
+      def add_user_to_permission_template!(entry)
+        user                = ::User.find(entry.importerexporter.user_id)
+        collection          = entry.factory.find
+        permission_template = Hyrax::PermissionTemplate.find_or_create_by!(source_id: collection.id)
+
+        Hyrax::PermissionTemplateAccess.find_or_create_by!(
+          permission_template_id: permission_template.id,
+          agent_id: user.user_key,
+          agent_type: 'user',
+          access: 'manage'
+        )
+
+        collection.reset_access_controls!
+      end
+  end
+end

--- a/app/parsers/concerns/hyku_addons/collection_behavior.rb
+++ b/app/parsers/concerns/hyku_addons/collection_behavior.rb
@@ -41,7 +41,7 @@ module HykuAddons
         new_entry = find_or_create_entry(item_entry_class, item_id, 'Bulkrax::Importer', item_metadata)
 
         begin
-          Bulkrax::ImportWorkCollectionJob.perform_now(new_entry.id, current_run.id)
+          HykuAddons::ImportWorkCollectionJob.perform_now(new_entry.id, current_run.id)
         rescue StandardError => e
           new_entry.status_info(e)
         end


### PR DESCRIPTION
Port old version of ImportWorkCollectionJob from Bulkrax and call it directly from CollectionBehavior.
During testing on AH it became apparent that repeatedly running the same import causes odd errors to arise and causes collection titles to be overwritten with IDs.  This appears to solve those issues locally, however if it works we would still need to know why...