### PR TITLE
Ensure redis account caching not used in API specs

### DIFF
--- a/spec/requests/api_v1_collection_spec.rb
+++ b/spec/requests/api_v1_collection_spec.rb
@@ -25,6 +25,9 @@ RSpec.describe Hyku::API::V1::CollectionController, type: :request, clean: true,
       Site.update(account: account)
       collection
     end
+
+    # Ensure that if caching has been enabled elsewhere by the test suite it is disabled for this test
+    account.setup_tenant_cache(false)
   end
 
   context "when repository has content" do

--- a/spec/requests/api_v1_work_spec.rb
+++ b/spec/requests/api_v1_work_spec.rb
@@ -143,6 +143,9 @@ RSpec.describe Hyku::API::V1::WorkController, type: :request, clean: true, multi
       Site.update(account: account)
       work
     end
+
+    # Ensure that if caching has been enabled elsewhere by the test suite it is disabled for this test
+    account.setup_tenant_cache(false)
   end
 
   describe "/work/:id" do


### PR DESCRIPTION
Ensure two more API specs also do not access the cache to avoid errors about leaking doubles