### PR TITLE
Ensure that the job does not find filesets

### DIFF
--- a/app/jobs/hyku_addons/toggle_display_profile_job.rb
+++ b/app/jobs/hyku_addons/toggle_display_profile_job.rb
@@ -3,7 +3,7 @@
 module HykuAddons
   class ToggleDisplayProfileJob < ApplicationJob
     def perform(email, display_profile)
-      query_string = "(creator_tesim:\"*#{email}*\")"
+      query_string = "generic_type_sim:Work AND (creator_tesim:\"*#{email}*\")"
       works = ActiveFedora::SolrService.get(query_string, rows: 1_000_000).dig("response", "docs")
                                        .map { |doc| ActiveFedora::SolrHit.new(doc).reify }
 


### PR DESCRIPTION
The original job was finding filesets that do not have the creator field as JSON 

` #<FileSet id: "452f45c4-d849-4fa4-ad0b-5bc10c966a2b", head: [], tail: [], depositor: "bertie.wooles@ubiquitypress.com", title: ["Yoohyeon.jpg"], date_uploaded: "2021-10-18 10:54:48", date_modified: "2021-10-18 10:54:48", label: "Yoohyeon.jpg", relative_path: nil, import_url: nil, resource_type: [], creator: ["bertie.wooles@ubiquitypress.com"]`

Therefore trying to parse the creator of the filesets was causing the error, this change ensures only Works are returned