### PR TITLE
Add missing action name translations

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -300,11 +300,17 @@ en:
         read_and_annotate: Read and annotate
       actions_list:
         header: Select an action
+        delete: Delete
+        download: Download
+        edit: Edit
+        read_and_annotate: Read and annotate
+        versions: Versions
       actions_button:
         delete: Delete
         download: Download
         edit: Edit
         read_and_annotate: Read and annotate
+        versions: Versions
   bulkrax:
     validation_issues:
       attribute: "Attribute"


### PR DESCRIPTION
These translations appear to still be missing unfort.