### PR TITLE
Use single quotes for delimiter

### DIFF
--- a/app/parsers/concerns/hyku_addons/collection_behavior.rb
+++ b/app/parsers/concerns/hyku_addons/collection_behavior.rb
@@ -68,7 +68,7 @@ module HykuAddons
       end
 
       def collection_delimiter
-        Bulkrax.field_mappings["HykuAddons::CsvParser"]&.dig("collection", :split) || "\|"
+        Regexp.new(Bulkrax.field_mappings["HykuAddons::CsvParser"]&.dig("collection", :split) || %r{\|})
       end
 
       def collection_prefix

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -211,7 +211,7 @@ module HykuAddons
           "part_of" => { split: '\|' },
           "qualification_subject_text" => { split: '\|' },
           "related_url" => { split: '\|' },
-          "collection" => { split: "\|" }
+          "collection" => { split: '\|' }
         }
       end
 


### PR DESCRIPTION
Minor correction to use single quotes in line with all the other delimiters