### PR TITLE
Fix Repository Space shared search error

### DIFF
--- a/app/views/hyku/api/v1/work/_work.json.jbuilder
+++ b/app/views/hyku/api/v1/work/_work.json.jbuilder
@@ -156,13 +156,9 @@ json.cache! [@account, :works, work.id, work.solr_document[:_version_], work.mem
   json.related_material work.try(:solr_document)&.to_h&.dig("related_material_tesim")
   json.related_url work.try(:solr_document)&.to_h&.dig("related_url_tesim")
 
-  begin
-    repository_space_service = HykuAddons::RepositorySpaceService.new
-    id = work.try(:solr_document)&.to_h&.dig("repository_space_tesim")&.first
-    json.repository_space repository_space_service.label(id) if id.present?
-  rescue ActionView::Template::Error
-    Sentry.capture_message("RepositorySpaceService error", level: "info", extra: { id: id, search_only: @account.search_only? })
-  end
+  repository_space_service = HykuAddons::RepositorySpaceService.new
+  id = work.try(:solr_document)&.to_h&.dig("repository_space_tesim")&.first
+  json.repository_space repository_space_service.label(id) if id.present?
 
   json.time work.try(:solr_document)&.to_h&.dig("time_tesim")
   json.resource_type work.resource_type

--- a/config/authorities/repository_space.yml
+++ b/config/authorities/repository_space.yml
@@ -1,3 +1,5 @@
 terms:
   - id: default
     term: Ubiquity Press Repositories Default
+  - id: anschutz
+    term: University of Colorado Anschutz Medical Campus Strauss Health Sciences Library 


### PR DESCRIPTION
Adds the anschutz id to the default authority because the shared search tenant does not have a locale set