### PR TITLE
Work Factory Registers both frontend URLS

### DIFF
--- a/app/lib/hyku_addons/work_factory.rb
+++ b/app/lib/hyku_addons/work_factory.rb
@@ -5,7 +5,8 @@ module HykuAddons
       work = Hyrax::Hirmeos::Client::Work.new
       work.title = resource.title
       work.uri = [{ uri: resource_url(resource) },
-                  { uri: frontend_resource_url(resource) },
+                  { uri: build_scholarly_link(resource) },
+                  { uri: build_non_scholarly_link(resource) },
                   { uri: "urn:uuid:#{resource.id}", canonical: true }]
       work.type = "repository-work"
       work
@@ -13,12 +14,6 @@ module HykuAddons
 
     def self.resource_url(work)
       Rails.application.routes.url_helpers.polymorphic_url(work)
-    end
-
-    def self.frontend_resource_url(work)
-      work_types = current_account.google_scholarly_work_types
-      work_types ||= []
-      work_types.include?(work.model_name.name.to_s) ? build_scholarly_link(work) : build_non_scholarly_link(work)
     end
 
     def self.build_scholarly_link(work)

--- a/spec/lib/work_factory_spec.rb
+++ b/spec/lib/work_factory_spec.rb
@@ -22,6 +22,9 @@ RSpec.describe HykuAddons::WorkFactory do
           uri: "http://localhost:3000/concern/generic_works/#{work.id}"
         },
         {
+          uri: "https://#{account.frontend_url}/work/sc/#{work.id}"
+        },
+        {
           uri: "https://#{account.frontend_url}/work/ns/#{work.id}"
         },
         {


### PR DESCRIPTION
To avoid case of Google Scholar reclassifying works, Rowan asked to register both frontend URL options in HIRMEOS