### PR TITLE
Quiet Redis deprecation warnings

### DIFF
--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -94,7 +94,7 @@ module HykuAddons
         ActionController::Base.perform_caching = is_enabled
 
         if is_enabled
-          redis_config = { url: Redis.current.id, namespace: redis_endpoint.options["namespace"] }
+          redis_config = { url: ENV['REDIS_URL'], namespace: redis_endpoint.options["namespace"] }
           Rails.application.config.cache_store = :redis_cache_store, redis_config
         else
           Rails.application.config.cache_store = :file_store, Settings.cache_filesystem_root

--- a/app/models/concerns/hyku_addons/account_behavior.rb
+++ b/app/models/concerns/hyku_addons/account_behavior.rb
@@ -94,7 +94,7 @@ module HykuAddons
         ActionController::Base.perform_caching = is_enabled
 
         if is_enabled
-          redis_config = { url: ENV['REDIS_URL'], namespace: redis_endpoint.options["namespace"] }
+          redis_config = { url: ENV["REDIS_URL"], namespace: redis_endpoint.options["namespace"] }
           Rails.application.config.cache_store = :redis_cache_store, redis_config
         else
           Rails.application.config.cache_store = :file_store, Settings.cache_filesystem_root

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -12,10 +12,7 @@ RSpec.describe HykuAddons::AccountBehavior, type: :model do
       account.build_redis_endpoint(namespace: "foobaz")
       account.build_datacite_endpoint(mode: :test, prefix: "10.1234", username: "user123", password: "pass123")
       allow(Flipflop).to receive(:enabled?).with(:cache_api).and_return(cache_enabled)
-      allow(Redis.current).to receive(:id).and_return "redis://localhost:6379/0"
-      account.switch!
-    end
-
+      ENV["REDIS_URL"] = "redis://localhost:6379/0"
     after do
       account.reset!
     end

--- a/spec/models/concerns/hyku_addons/account_behavior_spec.rb
+++ b/spec/models/concerns/hyku_addons/account_behavior_spec.rb
@@ -13,6 +13,9 @@ RSpec.describe HykuAddons::AccountBehavior, type: :model do
       account.build_datacite_endpoint(mode: :test, prefix: "10.1234", username: "user123", password: "pass123")
       allow(Flipflop).to receive(:enabled?).with(:cache_api).and_return(cache_enabled)
       ENV["REDIS_URL"] = "redis://localhost:6379/0"
+      account.switch!
+    end
+
     after do
       account.reset!
     end


### PR DESCRIPTION
https://github.com/resque/redis-namespace/issues/189

`Redis.current` is being depreciated, use the URL ENV to remove warnings