### PR TITLE
return multiple banners & logos in collection api

### DIFF
--- a/app/services/hyku_addons/collection_branding_fetcher.rb
+++ b/app/services/hyku_addons/collection_branding_fetcher.rb
@@ -12,15 +12,21 @@ module HykuAddons
     def url_for(role)
       return unless ["banner", "logo"].include? role
 
-      format_url(fetch_collection_branding(role))
+      format_url(fetch_collection_branding(role)&.first)
     end
 
     def alt_text_for(role)
-      fetch_collection_branding(role)&.alt_text
+      fetch_collection_branding(role)&.first&.alt_text
     end
 
     def target_url_for(role)
-      fetch_collection_branding(role)&.target_url
+      fetch_collection_branding(role)&.first&.target_url
+    end
+
+    def get_details_for(role)
+      fetch_collection_branding(role).each_with_index.map do |record, index|
+        { "target_url": record.target_url, "alt_text": record.alt_text, "url": format_url(record), positions: index }
+      end
     end
 
     private
@@ -30,7 +36,7 @@ module HykuAddons
         return if @cname.nil?
 
         AccountElevator.switch!(cname)
-        CollectionBrandingInfo.where(collection_id: @collection_id.to_s, role: role)&.first
+        CollectionBrandingInfo.where(collection_id: @collection_id.to_s, role: role)
       end
 
       # Build component for collection json

--- a/app/views/hyku/api/v1/collection/_collection.json.jbuilder
+++ b/app/views/hyku/api/v1/collection/_collection.json.jbuilder
@@ -39,6 +39,9 @@ json.cache! [@account, :collections, collection.id, collection.solr_document[:_v
   json.collection_logo_url branding_fetcher.url_for("logo")
   json.collection_logo_alt_text branding_fetcher.alt_text_for("logo")
   json.collection_logo_target_url branding_fetcher.target_url_for("logo")
+
+  json.collection_logo branding_fetcher.get_details_for("logo")
+  json.collection_banner branding_fetcher.get_details_for("banner")
 end
 
 if local_assigns[:include_works]

--- a/spec/requests/api_v1_collection_spec.rb
+++ b/spec/requests/api_v1_collection_spec.rb
@@ -24,6 +24,24 @@ RSpec.describe Hyku::API::V1::CollectionController, type: :request, clean: true,
                     height: "", width: "")
   end
 
+  let(:logo_2) do
+    instance_double(CollectionBrandingInfo,
+                    collection_id: collection.id, role: "logo",
+                    local_path: "/fake/path/to/logo2.png",
+                    alt_text: "second logo",
+                    target_url: "http://example-images.com/",
+                    height: "", width: "")
+  end
+
+  let(:api_multiple_collection_logo) do
+    [{ "target_url" => "http://example.com/", "alt_text" => "This is the logo", "url" => "http://#{cname}/fake/path/to/logo.png", "positions" => 0 },
+     { "target_url" => "http://example-images.com/", "alt_text" => "second logo", "url" => "http://#{cname}/fake/path/to/logo2.png", "positions" => 1 }]
+  end
+
+  let(:api_multiple_collection_banner) do
+    [{ "target_url" => "http://example.com/", "alt_text" => "This is the banner", "url" => "http://#{cname}/fake/path/to/banner.png", "positions" => 0 }]
+  end
+
   let(:json_response) { JSON.parse(response.body) }
 
   let(:results) do
@@ -32,6 +50,8 @@ RSpec.describe Hyku::API::V1::CollectionController, type: :request, clean: true,
       "collection_logo_url" => "http://#{cname}/fake/path/to/logo.png",
       "collection_logo_alt_text" => "This is the logo",
       "collection_logo_target_url" => "http://example.com/",
+      "collection_logo" => api_multiple_collection_logo,
+      "collection_banner" => api_multiple_collection_banner,
       "date_created" => "1992-12-31",
       "date_published" => nil,
       "description" => "This is a test collection",
@@ -71,8 +91,8 @@ RSpec.describe Hyku::API::V1::CollectionController, type: :request, clean: true,
     before do
       collection_branding_list = class_double(CollectionBrandingInfo)
       collection_logo_list = class_double(CollectionBrandingInfo)
-      allow(CollectionBrandingInfo).to receive(:where).with(collection_id: collection.id, role: "banner") { collection_branding_list }
-      allow(CollectionBrandingInfo).to receive(:where).with(collection_id: collection.id, role: "logo") { collection_logo_list }
+      allow(CollectionBrandingInfo).to receive(:where).with(collection_id: collection.id, role: "banner") { [banner] }
+      allow(CollectionBrandingInfo).to receive(:where).with(collection_id: collection.id, role: "logo") { [logo, logo_2] }
       allow(collection_branding_list).to receive(:first).and_return(banner)
       allow(collection_logo_list).to receive(:first).and_return(logo)
     end


### PR DESCRIPTION
Adds the ability to return multiple logos and banners in the collection api endpoint.