### PR TITLE
migrate una_archival_item work type to use schema.yaml

### DIFF
--- a/app/forms/hyrax/una_archival_item_form.rb
+++ b/app/forms/hyrax/una_archival_item_form.rb
@@ -1,42 +1,11 @@
 # frozen_string_literal: true
 module Hyrax
   class UnaArchivalItemForm < Hyrax::Forms::WorkForm
-    include ::HykuAddons::WorkForm
-
-    self.model_class = ::UnaArchivalItem
-    add_terms %i[title resource_type creator alt_email abstract
-                 keyword subject date_published alternate_identifier
-                 library_of_congress_classification dewey related_identifier
-                 adapted_from additional_links related_material related_url source
-                 isbn issn eissn publisher place_of_publication citation funder
-                 project_name fndr_project_ref funding_description event_title
-                 event_location event_date related_exhibition related_exhibition_venue
-                 related_exhibition_date license rights_holder rights_statement
-                 rights_statement_text contributor medium extent duration is_format_of
-                 language prerequisites location longitude latitude georeferenced
-                 time irb_number irb_status add_info]
-
-    self.required_fields = %i[title resource_type creator]
-    include Hyrax::DOI::DOIFormBehavior
     include Hyrax::DOI::DataCiteDOIFormBehavior
 
-    def primary_terms
-      %i[title resource_type creator alt_email abstract keyword subject date_published] | super
-    end
+    include ::HykuAddons::Schema::WorkForm
+    include Hyrax::FormFields(:una_archival_item)
 
-    def self.build_permitted_params
-      super.tap do |permitted_params|
-        permitted_params << common_fields
-        permitted_params << [:title, :resource_type, :creator, :alt_email, :abstract, :keyword, :subject,
-                             :date_published, :alternate_identifier, :library_of_congress_classification, :dewey,
-                             :related_identifier, :adapted_from, :additional_links, :related_material, :related_url,
-                             :source, :isbn, :issn, :eissn, :publisher, :place_of_publication, :citation, :funder,
-                             :project_name, :fndr_project_ref, :funding_description, :event_title, :event_location,
-                             :event_date, :related_exhibition, :related_exhibition_date, :license, :rights_holder,
-                             :rights_statement, :rights_statement_text, :contributor, :medium, :extent, :duration,
-                             :is_format_of, :language, :prerequisites, :location, :longitude, :latitude,
-                             :georeferenced, :time, :irb_number, :irb_status, :related_exhibition_venue, :add_info]
-      end
-    end
+    self.model_class = ::UnaArchivalItem
   end
 end

--- a/app/indexers/una_archival_item_indexer.rb
+++ b/app/indexers/una_archival_item_indexer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 class UnaArchivalItemIndexer < Hyrax::WorkIndexer
+  include Hyrax::Indexer(:una_archival_item)
   # This indexes the default metadata. You can remove it if you want to
   # provide your own metadata and indexing.
   include Hyrax::IndexesBasicMetadata

--- a/app/models/concerns/hyku_addons/array_field_to_single_field.rb
+++ b/app/models/concerns/hyku_addons/array_field_to_single_field.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module ArrayFieldToSingleField
+    extend ActiveSupport::Concern
+    class_methods do
+      def override_array_field_accessor(*fields)
+        fields.each do |field|
+          class_eval(
+            "def #{field}
+              super&.first || ''
+            end"
+          )
+        end
+      end
+    end
+  end
+end

--- a/app/models/una_archival_item.rb
+++ b/app/models/una_archival_item.rb
@@ -1,144 +1,34 @@
 # frozen_string_literal: true
 class UnaArchivalItem < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
-  # Adds behaviors for hyrax-doi plugin.
-  include Hyrax::DOI::DOIBehavior
+
   # Adds behaviors for DataCite DOIs via hyrax-doi plugin.
   include Hyrax::DOI::DataCiteDOIBehavior
-  include ::HykuAddons::WorkBase
-  include ::HykuAddons::AddInfoSingular
 
-  property :issn, predicate: ::RDF::Vocab::BIBO.issn, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :irb_status, predicate: ::RDF::Vocab::BF2.Status, multiple: false do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :irb_number, predicate: ::RDF::Vocab::BIBO.identifier, multiple: false do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :isbn, predicate: ::RDF::Vocab::BIBO.isbn, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :adapted_from, predicate: ::RDF::Vocab::DC11.source, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :eissn, predicate: ::RDF::Vocab::BIBO.eissn, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :place_of_publication, predicate: ::RDF::Vocab::BF2.term(:Place) do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :funder, predicate: ::RDF::Vocab::MARCRelators.fnd do |index|
-    index.as :stored_searchable
-  end
-
-  property :medium, predicate: ::RDF::Vocab::DC.medium do |index|
-    index.as :stored_searchable
-  end
-
-  property :extent, predicate: ::RDF::Vocab::DC.extent, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :time, predicate: ::RDF::Vocab::DC.temporal, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :additional_links, predicate: ::RDF::Vocab::SCHEMA.significantLinks, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :related_material, predicate: ::RDF::Vocab::BF2.term(:relatedTo), multiple: false do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :citation, predicate: ::RDF::Vocab::DC.term(:bibliographicCitation) do |index|
-    index.as :stored_searchable
-  end
-
-  property :funding_description, predicate: ::RDF::Vocab::MARCRelators.spn do |index|
-    index.as :stored_searchable
-  end
-
-  property :georeferenced, predicate: ::RDF::Vocab::OGC.boolean_str, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :longitude, predicate: ::RDF::Vocab::SCHEMA.longitude, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :location, predicate: ::RDF::Vocab::BF2.physicalLocation, multiple: false do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :latitude, predicate: ::RDF::Vocab::SCHEMA.latitude, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :alt_email, predicate: ::RDF::Vocab::SCHEMA.email, multiple: true do |index|
-    index.as :stored_searchable
-  end
-
-  property :event_title, predicate: ::RDF::Vocab::BF2.term(:Event) do |index|
-    index.as :stored_searchable, :facetable
-  end
-
-  property :event_location, predicate: ::RDF::Vocab::Bibframe.eventPlace do |index|
-    index.as :stored_searchable
-  end
-
-  property :event_date, predicate: ::RDF::Vocab::Bibframe.eventDate do |index|
-    index.as :stored_searchable
-  end
-
-  property :related_exhibition, predicate: ::RDF::Vocab::SCHEMA.term(:ExhibitionEvent) do |index|
-    index.as :stored_searchable
-  end
-
-  property :related_exhibition_date, predicate: ::RDF::Vocab::SCHEMA.term(:Date) do |index|
-    index.as :stored_searchable
-  end
-
-  property :related_exhibition_venue, predicate: ::RDF::Vocab::SCHEMA.EventVenue, multiple: true do |index|
-    index.as :stored_searchable
-  end
-
-  property :rights_statement_text, predicate: ::RDF::Vocab::DC11.rights, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :duration, predicate: ::RDF::Vocab::BF2.duration, multiple: true do |index|
-    index.as :stored_searchable
-  end
-
-  property :is_format_of, predicate: ::RDF::Vocab::DC.isFormatOf, multiple: true do |index|
-    index.as :stored_searchable
-  end
-
-  property :prerequisites, predicate: ::RDF::Vocab::CC.Requirement, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  property :fndr_project_ref, predicate: ::RDF::Vocab::BF2.awards, multiple: false do |index|
-    index.as :stored_searchable
-  end
-
-  self.date_fields += %i[event_date related_exhibition_date]
-  self.indexer = UnaArchivalItemIndexer
-  # Change this to restrict which works can be added as a child.
-  # self.valid_child_concerns = []
-  validates :title, presence: { message: "Your work must have a title." }
-
+  include HykuAddons::Schema::WorkBase
+  include Hyrax::Schema(:una_archival_item)
   # This must be included at the end, because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
-  include ::Hyrax::BasicMetadata
+  include Hyrax::BasicMetadata
+
+  self.indexer = UnaArchivalItemIndexer
+
+  validates :title, presence: { message: "Your work must have a title." }
+
+  # Ensures old data will not return active_triples in edit forms
+  # since the old data  existed before the forms was changed to
+  # accetpt single value for aray or multi-value fields
+  ARRAYTURNEDSINGLEFIELD = %i[
+    duration is_format_of language license rights_holder event_title event_date
+    event_location library_of_congress_classification related_exhibition_date
+    related_exhibition_venue related_exhibition_date related_exhibition
+    related_url source publisher place_of_publication citation subject
+  ].freeze
+
+  include HykuAddons::ArrayFieldToSingleField
+  override_array_field_accessor(*ARRAYTURNEDSINGLEFIELD)
+
+  def doi_registrar_opts
+    {}
+  end
 end

--- a/app/presenters/hyrax/una_archival_item_presenter.rb
+++ b/app/presenters/hyrax/una_archival_item_presenter.rb
@@ -2,19 +2,8 @@
 
 module Hyrax
   class UnaArchivalItemPresenter < Hyrax::WorkShowPresenter
+    include ::HykuAddons::Schema::Presenter(:una_archival_item)
     include ::HykuAddons::WorkPresenterBehavior
-
-    def self.delegated_methods
-      %i[title resource_type creator alt_email abstract
-         keyword subject date_published journal_title alternative_journal_title
-         journal_frequency volume issue pagination article_number version_number
-         official_link alternate_identifier library_of_congress_classification
-         dewey related_identifier adapted_from additional_links related_material
-         related_url issn eissn publisher place_of_publication citation
-         funder project_name fndr_project_ref funding_description license date_accepted
-         date_submitted location longitude latitude georeferenced time
-         refereed irb_number irb_status add_info].freeze
-    end
     include ::HykuAddons::PresenterDelegatable
   end
 end

--- a/app/views/records/edit_fields/_default_date.html.erb
+++ b/app/views/records/edit_fields/_default_date.html.erb
@@ -11,7 +11,7 @@
     <div class="form-group <%= "#{template}_#{key}_year" %>">
       <% opts = { start_year: (Date.today.year + 6), end_year: (Date.today.year - 159), prompt: t("simple_form.date_fields.year.label") } %>
       <% params = { id: "#{template}_#{key}__#{key}_year", name: "#{template}[#{key}][][#{key}_year]", class: "form-control ubiquity-date-input", required: required } %>
-      <%= select_year(date_value[0].to_i, opts, params) %>
+      <%= select_year(date_value&.flatten[0]&.to_i, opts, params) %>
     </div>
 
     <div class="form-group <%= "#{template}_#{key}_month" %>">
@@ -71,6 +71,7 @@
     </div>
 
   <% else %>
-    <% date_fields.call(dates.split("-"), required) %>
+    <% split_dates = dates.respond_to?(:split) ? dates.split("-") : dates.first.split("-") %>
+    <% date_fields.call(split_dates, required) %>
   <% end %>
 </div>

--- a/config/authorities/subject-UNA.yml
+++ b/config/authorities/subject-UNA.yml
@@ -50,11 +50,11 @@ terms:
  - id: Music
    term: Music
    active: true
- - id: Performing arts
-   term: Performing arts
-   active: true
  - id: Optometry/Visual sciences
    term: Optometry/Visual sciences
+   active: true
+ - id: Performing arts
+   term: Performing arts
    active: true
  - id: Philosophy
    term: Philosophy

--- a/config/locales/en-UNA.yml
+++ b/config/locales/en-UNA.yml
@@ -60,7 +60,7 @@ en-UNA:
       defaults:
         alt_title: Alternative Title
         alt_email: Alternative Email
-        resource_type: Document Type
+        resource_type: Resource Type
         keyword: Keywords
         adapted_from: Adapted From
         additional_links: Additional Links
@@ -77,7 +77,7 @@ en-UNA:
         refereed: Peer reviewed?
         citation: Bibliographic Citation
         medium: Format(s)
-        extent: Content Length or Size
+        extent: Content length or Size
         language: Language(s)
         org_unit: Department
         version_number: Document Version

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -93,7 +93,7 @@ en:
         label: Role
         placeholder: " "
       creator_institutional_email:
-        label: Creator Institutional Email
+        label: Creator institutional email
         placeholder: " "
         help_text: Enter the institutional email associated with this creator
     contributor:

--- a/config/metadata/una_archival_item.yaml
+++ b/config/metadata/una_archival_item.yaml
@@ -1,0 +1,868 @@
+---
+attributes:
+  title:
+    type: string
+    predicate: http://purl.org/dc/terms/title
+    multiple: true
+    index_keys:
+    - title_tesim
+    - title_sim
+    form:
+      required: true
+      primary: true
+      multiple: true
+      type: text
+      input: single_multi_value
+  resource_type:
+    predicate: http://purl.org/dc/terms/type
+    multiple: true
+    index_keys:
+    - resource_type_tesim
+    - resource_type_sim
+    form:
+      required: true
+      primary: true
+      multiple: false
+      type: select
+      authority: HykuAddons::ResourceTypesService
+      include_blank: true
+      input: single_multi_value_select
+  creator:
+    predicate: http://purl.org/dc/elements/1.1/creator
+    multiple: true
+    index_keys:
+    - creator_tesim
+    form:
+      required: true
+      primary: true
+      multiple: true
+      type: text
+    subfields:
+      creator_name_type:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: select
+          authority: HykuAddons::NameTypeService
+      creator_family_name:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      creator_given_name:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      creator_middle_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      creator_suffix:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      creator_orcid:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      creator_profile_visibility:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: hidden
+          display_for:
+          - Personal
+      creator_institutional_relationship:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: select
+          authority: HykuAddons::InstitutionalRelationshipService
+          attributes:
+            multiple: multiple
+          display_for:
+          - Personal
+      creator_institutional_email:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      creator_organization_name:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      creator_ror:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      creator_grid:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      creator_wikidata:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      creator_isni:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+          - Organizational
+  alt_email:
+    type: string
+    predicate: http://schema.org/email
+    multiple: true
+    index_keys:
+    - alt_email_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+  abstract:
+    type: text
+    predicate: http://purl.org/dc/terms/abstract
+    multiple: false
+    index_keys:
+    - abstract_tesim
+    form:
+      required: false
+      primary: true
+      multiple: false
+      type: textarea
+  keyword:
+    predicate: http://purl.org/dc/elements/1.1/relation
+    multiple: true
+    index_keys:
+    - keyword_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+  subject:
+    predicate: http://purl.org/dc/elements/1.1/subject
+    multiple: true
+    index_keys:
+    - subject_tesim
+    form:
+      required: false
+      primary: true
+      multiple: false
+      type: select
+      authority: HykuAddons::SubjectService
+  date_published:
+    type: string
+    predicate: http://purl.org/dc/terms/available
+    multiple: false
+    index_keys:
+    - date_published_tesim
+    form:
+      required: true
+      primary: true
+      multiple: false
+      type: date
+  alternate_identifier:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/Local
+    multiple: true
+    index_keys:
+    - alternate_identifier_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+    subfields:
+      alternate_identifier:
+        type: string
+        form:
+          multiple: false
+          required: false
+          type: text
+      alternate_identifier_type:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+  library_of_congress_classification:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/ClassificationLcc
+    multiple: true
+    index_keys:
+    - library_of_congress_classification_tesim
+    - library_of_congress_classification_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  dewey:
+    type: string
+    predicate: http://schema.org/CategoryCode
+    multiple: false
+    index_keys:
+    - dewey_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  related_identifier:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/identifiedBy
+    multiple: true
+    index_keys:
+    - related_identifier_tesim
+    form:
+      required: false
+      primary: false
+      multiple: true
+      type: text
+    subfields:
+      related_identifier:
+        type: string
+        form:
+          multiple: false
+          required: false
+          type: text
+      related_identifier_type:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: select
+          authority: HykuAddons::RelatedIdentifierTypeService
+          include_blank: true
+      relation_type:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: select
+          authority: HykuAddons::RelationTypeService
+          include_blank: true
+  adapted_from:
+    type: string
+    predicate: http://purl.org/dc/elements/1.1/source
+    multiple: false
+    index_keys:
+    - adapted_from_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  additional_links:
+    type: string
+    predicate: http://schema.org/significantLinks
+    multiple: false
+    index_keys:
+    - additional_links_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  related_material:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/relatedTo
+    multiple: false
+    index_keys:
+    - related_material_tesim
+    - related_material_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  related_url:
+    predicate: http://www.w3.org/2000/01/rdf-schema#seeAlso
+    multiple: true
+    index_keys:
+    - related_url_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  source:
+    predicate: http://purl.org/dc/terms/source
+    multiple: true
+    index_keys:
+    - source_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  isbn:
+    type: string
+    predicate: http://purl.org/ontology/bibo/isbn
+    multiple: false
+    index_keys:
+    - isbn_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  issn:
+    type: string
+    predicate: http://purl.org/ontology/bibo/issn
+    multiple: false
+    index_keys:
+    - issn_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  eissn:
+    type: string
+    predicate: http://purl.org/ontology/bibo/eissn
+    multiple: false
+    index_keys:
+    - eissn_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  publisher:
+    predicate: http://purl.org/dc/elements/1.1/publisher
+    multiple: true
+    index_keys:
+    - publisher_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  place_of_publication:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/Place
+    multiple: true
+    index_keys:
+    - place_of_publication_tesim
+    - place_of_publication_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  citation:
+    type: string
+    predicate: http://purl.org/dc/terms/bibliographicCitation
+    multiple: false
+    index_keys:
+    - citation_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  funder:
+    type: string
+    predicate: http://id.loc.gov/vocabulary/relators/fnd
+    multiple: true
+    index_keys:
+    - funder_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+    subfields:
+      funder_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          input: controlled_vocabulary
+          attributes:
+            data:
+              field_name: ubiquity_funder_name
+              autocomplete-url: "/authorities/search/crossref/funders"
+              autocomplete: funder
+      funder_doi:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+      funder_isni:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+      funder_ror:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+      funder_award:
+        type: string
+        form:
+          required: false
+          multiple: true
+          type: text
+  project_name:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/CollectiveTitle
+    multiple: true
+    index_keys:
+    - project_name_tesim
+    form:
+      required: false
+      primary: false
+      multiple: true
+      type: text
+  fndr_project_ref:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/awards
+    multiple: false
+    index_keys:
+    - fndr_project_ref_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  funding_description:
+    type: string
+    predicate: http://id.loc.gov/vocabulary/relators/spn
+    multiple: false
+    index_keys:
+    - funding_description_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  event_title:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/Event
+    multiple: true
+    index_keys:
+    - event_title_tesim
+    - event_title_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  event_location:
+    type: string
+    predicate: http://bibframe.org/vocab/eventPlace
+    multiple: true
+    index_keys:
+    - event_location_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  event_date:
+    type: string
+    predicate: http://bibframe.org/vocab/eventDate
+    multiple: true
+    index_keys:
+    - event_date_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: date
+  related_exhibition:
+    type: string
+    predicate: http://schema.org/ExhibitionEvent
+    multiple: true
+    index_keys:
+    - related_exhibition_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  related_exhibition_venue:
+    type: string
+    predicate: http://schema.org/EventVenue
+    multiple: true
+    index_keys:
+    - related_exhibition_venue_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  related_exhibition_date:
+    type: string
+    predicate: http://schema.org/Date
+    multiple: true
+    index_keys:
+    - related_exhibition_date_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: date
+  license:
+    predicate: http://purl.org/dc/terms/rights
+    multiple: true
+    index_keys:
+    - license_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: select
+      authority: HykuAddons::LicenseService
+      include_blank: true
+  rights_holder:
+    type: string
+    predicate: http://purl.org/dc/terms/rightsHolder
+    multiple: true
+    index_keys:
+    - rights_holder_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  rights_statement:
+    predicate: http://www.europeana.eu/schemas/edm/rights
+    multiple: true
+    index_keys:
+    - rights_statement_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: select
+      include_blank: false
+      authority: HykuAddons::RightsStatementService
+  rights_statement_text:
+    type: string
+    predicate: http://purl.org/dc/elements/1.1/rights
+    multiple: false
+    index_keys:
+    - rights_statement_text_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  contributor:
+    predicate: http://purl.org/dc/elements/1.1/contributor
+    multiple: true
+    index_keys:
+    - contributor_tesim
+    form:
+      required: false
+      primary: false
+      multiple: true
+      type: text
+    subfields:
+      contributor_name_type:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: select
+          authority: HykuAddons::NameTypeService
+      contributor_family_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      contributor_given_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      contributor_orcid:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+      contributor_institutional_relationship:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: select
+          authority: HykuAddons::ContributorInstitutionalRelationshipService
+          attributes:
+            multiple: multiple
+          display_for:
+          - Personal
+      contributor_organization_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      contributor_ror:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      contributor_grid:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      contributor_wikidata:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Organizational
+      contributor_isni:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+          - Personal
+          - Organizational
+  medium:
+    type: string
+    predicate: http://purl.org/dc/terms/medium
+    multiple: true
+    index_keys:
+    - medium_tesim
+    form:
+      required: false
+      primary: false
+      multiple: true
+      type: text
+  extent:
+    type: string
+    predicate: http://purl.org/dc/terms/extent
+    multiple: false
+    index_keys:
+    - extent_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  duration:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/duration
+    multiple: true
+    index_keys:
+    - duration_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  is_format_of:
+    type: string
+    predicate: http://purl.org/dc/terms/isFormatOf
+    multiple: true
+    index_keys:
+    - is_format_of_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  language:
+    predicate: http://purl.org/dc/elements/1.1/language
+    multiple: true
+    index_keys:
+    - language_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: select
+      authority: HykuAddons::LanguageService
+      include_blank: true
+  prerequisites:
+    type: string
+    predicate: http://creativecommons.org/ns#Requirement
+    multiple: false
+    index_keys:
+    - prerequisites_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  location:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/physicalLocation
+    multiple: false
+    index_keys:
+    - location_tesim
+    - location_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  longitude:
+    type: string
+    predicate: http://schema.org/longitude
+    multiple: false
+    index_keys:
+    - longitude_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  latitude:
+    type: string
+    predicate: http://schema.org/latitude
+    multiple: false
+    index_keys:
+    - latitude_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  georeferenced:
+    type: string
+    predicate: http://ogp.me/ns/class#boolean_str
+    multiple: false
+    index_keys:
+    - georeferenced_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  time:
+    type: string
+    predicate: http://purl.org/dc/terms/temporal
+    multiple: false
+    index_keys:
+    - time_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  irb_number:
+    type: string
+    predicate: http://purl.org/ontology/bibo/identifier
+    multiple: false
+    index_keys:
+    - irb_number_tesim
+    - irb_number_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  irb_status:
+    type: string
+    predicate: http://id.loc.gov/ontologies/bibframe/Status
+    multiple: false
+    index_keys:
+    - irb_status_tesim
+    - irb_status_sim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: text
+  add_info:
+    type: string
+    predicate: http://purl.org/ontology/bibo/Note
+    multiple: false
+    index_keys:
+    - add_info_tesim
+    form:
+      required: false
+      primary: false
+      multiple: false
+      type: textarea
+  doi:
+    doi:
+    type: string
+    predicate: http://purl.org/ontology/bibo/doi
+    multiple: true
+    index_keys:
+    - doi_ssi
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text

--- a/spec/features/una_archival_item_form_spec.rb
+++ b/spec/features/una_archival_item_form_spec.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+require HykuAddons::Engine.root.join("spec", "support", "fill_in_fields.rb").to_s
+require HykuAddons::Engine.root.join("spec", "support", "work_form_helpers.rb").to_s
+
+RSpec.feature "Create a UnaArchivalItem", js: true, slow: true do
+  let(:work_type) { "una_archival_item" }
+  let(:work) { work_type.classify.constantize.find(work_uuid_from_url) }
+
+  let(:model) { work_type.classify.constantize }
+  let(:field_config) { "hyrax/#{work_type}_form".classify.constantize.field_configs }
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
+  let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+  let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
+  let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
+  let(:permission_options) do
+    { permission_template_id: permission_template.id, agent_type: "user", agent_id: user.user_key, access: "deposit" }
+  end
+  let(:headers) do
+    {
+      "Accept" => "application/json",
+      "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "User-Agent" => "Faraday v0.17.4"
+    }
+  end
+
+  let(:title) { "UNA Archival Item" }
+  # The organisation option changes depending on the local, so we need to use this to ensure we select the right one
+  let(:organisation_option) { HykuAddons::NameTypeService.new(model: model).active_elements.last }
+  # The order of the items in each hash must match the order of the fields in the work form
+  let(:creator) do
+    [
+      {
+        creator_name_type: "Personal",
+        creator_family_name: "Johnny",
+        creator_given_name: "Smithy",
+        creator_middle_name: "J.",
+        creator_suffix: "Mr",
+        creator_orcid: "0000-0000-1111-2222",
+        # This is a hidden field set in the form, but we want to be able to check its value is set
+        creator_profile_visibility: User::PROFILE_VISIBILITY[:closed],
+        creator_institutional_relationship: "Research associate",
+        creator_institutional_email: "test@test.com",
+        creator_isni: "56273930281"
+      },
+      {
+        creator_name_type: organisation_option["label"],
+        creator_organization_name: "A Test Company Name",
+        creator_ror: "ror.org/123456",
+        creator_grid: "grid.org/098765",
+        creator_wikidata: "wiki.com/123",
+        creator_isni: "1234567890"
+      }
+    ]
+  end
+  let(:resource_type) { HykuAddons::ResourceTypesService.new(model: model).active_elements.sample(1) }
+  let(:abstract) { "This is the abstract text" }
+  let(:license_options) { HykuAddons::LicenseService.new(model: model).active_elements.sample(2) }
+  let(:publisher) { ["publisher1", "publisher2"] }
+  let(:keyword) { ["keyword1", "keyword2"] }
+  let(:doi) { "10.1521/soco.23.1.118.59197" }
+  let(:contributor) do
+    [
+      {
+        contributor_name_type: "Personal",
+        contributor_family_name: "Smithy",
+        contributor_given_name: "Johnny",
+        contributor_orcid: "0000-1111-2222-3333",
+        contributor_institutional_relationship: "Staff member",
+        contributor_isni: "1234567890"
+      },
+      {
+        contributor_name_type: "Organisational",
+        contributor_organization_name: "A Test Company Name",
+        contributor_ror: "ror.org/1234",
+        contributor_grid: "grid.com/1234",
+        contributor_wikidata: "wikidata.org/1234",
+        contributor_isni: "1234567890"
+      }
+    ]
+  end
+  let(:language_options) { HykuAddons::LanguageService.new(model: model).active_elements.sample(2) }
+  let(:date_published) { { year: "2020", month: "02", day: "02" } }
+  let(:funder) do
+    [
+      {
+        funder_name: "A funder",
+        funder_doi: "doi.org/123456",
+        funder_isni: "0987654321",
+        funder_ror: "ror.org/123456678",
+        funder_award: ["Award1"]
+      },
+      {
+        funder_name: "Another funder",
+        funder_doi: "doi.org/098765",
+        funder_isni: "1234567890",
+        funder_ror: "ror.org/345678976543",
+        funder_award: ["Award2"]
+      }
+    ]
+  end
+  let(:add_info) { "Some additional information" }
+  let(:source_data) { ["source 1", "Source 2"] }
+  let(:related_url) { ["http://test.com", "https://www.test123.com"] }
+
+  before do
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
+    Hyrax::PermissionTemplateAccess.create!(permission_options)
+
+    stub_request(:get, "http://api.crossref.org/funders?query=A%20funder")
+      .with(headers: headers)
+      .to_return(status: 200, body: "", headers: {})
+
+    stub_request(:get, "http://api.crossref.org/funders?query=Another%20funder")
+      .with(headers: headers)
+      .to_return(status: 200, body: "", headers: {})
+
+    login_as user
+    visit new_work_path
+  end
+
+  context "when the form is filled out" do
+    before do
+      click_link "Descriptions"
+      click_on "Additional fields"
+
+      fill_in_text_field(:title, title)
+      fill_in_text_field(:doi, doi)
+      fill_in_cloneable(:creator, creator)
+      fill_in_select(:resource_type, resource_type.map { |h| h["label"] }.first)
+      fill_in_textarea(:abstract, abstract)
+      fill_in_select(:license, license_options.map { |h| h["label"] }&.first)
+      fill_in_text_field(:publisher, publisher)
+      fill_in_multiple_text_fields(:keyword, keyword)
+      fill_in_cloneable(:contributor, contributor)
+      fill_in_select(:language, language_options.map { |h| h["label"] }&.first)
+      fill_in_date(:date_published, date_published)
+      fill_in_cloneable(:funder, funder)
+      fill_in_textarea(:add_info, add_info)
+    end
+
+    describe "submitting the form" do
+      before do
+        add_visibility
+        add_agreement
+        submit
+      end
+
+      it "redirects to the work show page" do
+        aggregate_failures "testing the saved data" do
+          # Ensure the basic data is being prenented and we're on the right page
+          expect(page).to have_selector("h1", text: work_type.titleize, wait: 20)
+          expect(page).to have_selector("h2", text: title, wait: 20)
+          expect(page).to have_selector("span", text: "Public")
+          expect(page).to have_content("Your files are being processed by Hyku in the background.")
+
+          expect(page).to have_content(resource_type.map { |h| h["id"] }.first)
+          expect(page).to have_content("#{creator.first.dig(:creator_family_name)}, #{creator.first.dig(:creator_given_name)}")
+          expect(page).to have_content("#{contributor.first.dig(:contributor_family_name)}, #{contributor.first.dig(:contributor_given_name)}")
+          expect(page).to have_content(normalize_date(date_published).first)
+          expect(page).to have_content("https://doi.org/#{doi}")
+          expect(work.title).to eq([title])
+          expect(work.doi).to eq([doi])
+          expect(work.creator).to eq([creator.to_json.gsub(organisation_option["label"], organisation_option["id"])])
+          expect(work.resource_type).to eq(resource_type.map { |h| h["id"] })
+          expect(work.abstract).to eq(abstract)
+          expect(work.keyword).to eq(keyword)
+          expect(work.contributor).to eq([contributor.to_json.gsub(organisation_option["label"], organisation_option["id"])])
+          expect(work.funder).to eq([funder.to_json])
+          expect(work.add_info).to eq(add_info)
+        end
+      end
+    end
+  end
+end

--- a/spec/models/concerns/hyku_addons/array_field_to_single_field_spec.rb
+++ b/spec/models/concerns/hyku_addons/array_field_to_single_field_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+
+RSpec.describe HykuAddons::ArrayFieldToSingleField do
+  describe "UnaArchivalItem" do
+    context "can return array field as single" do
+      subject(:una_archival_item) { UnaArchivalItem.new }
+
+      UnaArchivalItem::ARRAYTURNEDSINGLEFIELD.each do |field|
+        it "returns #{field} as string" do
+          expect(una_archival_item.send(field)).to eq ""
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- migrate una_archival_item work type to use schema.yaml
- In the UI change the following fields to single even though they are still stored as array because old existing data
- Override the getters  in the model so that each array property will return them as single
