### PR TITLE
soft delete users with works and files

### DIFF
--- a/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
@@ -10,12 +10,18 @@ module HykuAddons
         @user.destroy
         redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)
       elsif @user.present? && @user.uploaded_files.present? || @user.works_count.positive?
-        @user.roles.clear
-        @user.add_role("inactive", Site.instance)
-        redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)
+        handle_user_with_works(@user)
       else
         redirect_to hyrax.admin_users_path flash: { error: t("hyrax.admin.users.destroy.failure", user: @user) }
       end
+    end
+
+    private
+
+    def handle_user_with_works(user)
+      user.roles.clear
+      user.add_role("inactive", Site.instance)
+      redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: user)
     end
   end
 end

--- a/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
@@ -18,10 +18,10 @@ module HykuAddons
 
     private
 
-    def handle_user_with_works(user)
-      user.roles.clear
-      user.add_role("inactive", Site.instance)
-      redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: user)
-    end
+      def handle_user_with_works(user)
+        user.roles.clear
+        user.add_role("inactive", Site.instance)
+        redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: user)
+      end
   end
 end

--- a/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
@@ -9,7 +9,7 @@ module HykuAddons
       if @user.present? && @user.works_count.zero?
         @user.destroy
         redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)
-      elsif @user.present? && @user.uploaded_files.present? || @user.works_count > 0
+      elsif @user.present? && @user.uploaded_files.present? || @user.works_count.positive?
         @user.roles.clear
         @user.add_role("inactive", Site.instance)
         redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)

--- a/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
@@ -6,22 +6,28 @@ module HykuAddons
 
     # Delete a user from the site
     def destroy
-      if @user.present? && @user.works_count.zero?
-        @user.destroy
-        redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)
-      elsif @user.present? && @user.uploaded_files.present? || @user.works_count.positive?
-        handle_user_with_works(@user)
-      else
-        redirect_to hyrax.admin_users_path flash: { error: t("hyrax.admin.users.destroy.failure", user: @user) }
-      end
+      return handle_users_without_works(@user) if @user.present? && @user.works_count.zero?
+      handle_user_with_works(@user)
     end
 
     private
 
       def handle_user_with_works(user)
-        user.roles.clear
-        user.add_role("inactive", Site.instance)
-        redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: user)
+        if user.present? && user.uploaded_files.present? || @user.works_count.positive?
+          user.roles.clear
+          user.add_role("inactive", Site.instance)
+          redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: user)
+        else
+          redirect_to hyrax.admin_users_path flash: { error: t("hyrax.admin.users.destroy.failure", user: user) }
+        end
+      end
+
+      def handle_users_without_works(user)
+        if user.destroy
+          redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: user)
+        else
+          redirect_to hyrax.admin_users_path flash: { error: t("hyrax.admin.users.destroy.failure", user: user) }
+        end
       end
   end
 end

--- a/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/admin_user_controller_behavior.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module AdminUserControllerBehavior
+    extend ActiveSupport::Concern
+
+    # Delete a user from the site
+    def destroy
+      if @user.present? && @user.works_count.zero?
+        @user.destroy
+        redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)
+      elsif @user.present? && @user.uploaded_files.present? || @user.works_count > 0
+        @user.roles.clear
+        @user.add_role("inactive", Site.instance)
+        redirect_to hyrax.admin_users_path, notice: t("hyrax.admin.users.destroy.success", user: @user)
+      else
+        redirect_to hyrax.admin_users_path flash: { error: t("hyrax.admin.users.destroy.failure", user: @user) }
+      end
+    end
+  end
+end

--- a/app/models/concerns/hyku_addons/user_behavior.rb
+++ b/app/models/concerns/hyku_addons/user_behavior.rb
@@ -74,6 +74,8 @@ module HykuAddons
       def add_default_roles
         return if Account.global_tenant?
 
+        return if guest
+
         add_role :admin, Site.instance unless self.class.joins(:roles).where("roles.name = ?", "admin").any?
         # Role for any given site
         add_role :registered, Site.instance

--- a/app/models/concerns/hyku_addons/user_behavior.rb
+++ b/app/models/concerns/hyku_addons/user_behavior.rb
@@ -8,9 +8,15 @@ module HykuAddons
 
     included do
       before_save :toggle_display_profile
+      before_create :add_default_roles
 
       validate :email_format
 
+      # added so we can soft delete a user with a file by setting the user to inactive
+      has_many :uploaded_files, class_name: "Hyrax::UploadedFile"
+
+      # copied from hyku models/users to ensure inactive users are not in users page
+      scope :for_repository, -> { joins(:roles).where.not(roles: { name: "inactive" }) }
       scope :with_public_profile, -> { where(display_profile: true) }
     end
 
@@ -21,6 +27,27 @@ module HykuAddons
 
     def display_profile_visibility
       PROFILE_VISIBILITY[display_profile ? :open : :closed]
+    end
+
+    # overrides a devise method. devise gem checks for this method before sign_in a user
+    # used to prevent signin by user with role inactive, that is soft deleted user
+    def active_for_authentication?
+      super && (inactive? != true)
+    end
+
+    # from devise gem
+    # message a soft deleted user attempts to sign_in
+    def inactive_message
+      inactive? ? super : "Please contact your adminstrator"
+    end
+
+    # check if a user has been soft deleted
+    def inactive?
+      roles.map(&:name).include? "inactive"
+    end
+
+    def works_count
+      ActiveFedora::SolrService.count("depositor_ssim:#{email} AND has_model_ssim:*")
     end
 
     protected
@@ -39,6 +66,17 @@ module HykuAddons
         return unless display_profile_changed?
 
         HykuAddons::ToggleDisplayProfileJob.perform_later(email, display_profile_visibility)
+      end
+
+      # copied over from hyku models/user.rb
+      # If this user is the first user on the tenant, they become its admin
+      # unless we are in the global tenant
+      def add_default_roles
+        return if Account.global_tenant?
+
+        add_role :admin, Site.instance unless self.class.joins(:roles).where("roles.name = ?", "admin").any?
+        # Role for any given site
+        add_role :registered, Site.instance
       end
   end
 end

--- a/app/presenters/concerns/hyku_addons/admin_user_presenter_override.rb
+++ b/app/presenters/concerns/hyku_addons/admin_user_presenter_override.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module HykuAddons
+  module AdminUserPresenterOverride
+    extend ActiveSupport::Concern
+
+    private
+
+      # copied from Hyku main branch, we are currently on an older branch
+      # https://github.com/samvera/hyku/blob/main/app/presenters/hyrax/admin/users_presenter.rb
+      # Returns a list of users excluding the system users and guest_users
+      def search
+        ::User.registered.for_repository.without_system_accounts.uniq
+      end
+  end
+end

--- a/lib/hyku_addons/engine.rb
+++ b/lib/hyku_addons/engine.rb
@@ -139,7 +139,7 @@ module HykuAddons
       ::Hyrax::StatsController.include HykuAddons::StatsControllerBehavior
       Hyrax::GenericWorkPresenter.include HykuAddons::GenericWorkPresenterBehavior
       Hyrax::ImagePresenter.include HykuAddons::GenericWorkPresenterBehavior
-
+      ::Admin::UsersController.prepend HykuAddons::AdminUserControllerBehavior
       # DOI
       Hyrax::DOI::DataCiteRegistrar.prepend HykuAddons::DOI::DataCiteRegistrarBehavior
 
@@ -191,6 +191,7 @@ module HykuAddons
       Hyrax::CollectionPresenter.include HykuAddons::CollectionPresenterBehavior
       Hyrax::Renderers::LicenseAttributeRenderer.prepend Hyrax::Renderers::LicenseAttributeRendererBehavior
       ::Hyrax::CollectionPresenter.prepend HykuAddons::CollectionPresenterOverride
+      ::Hyrax::Admin::UsersPresenter.prepend HykuAddons::AdminUserPresenterOverride
 
       # Service Endpoints
       ::SolrEndpoint.prepend HykuAddons::SolrEndpointOverride

--- a/spec/requests/hyku/admin/users_controller_spec.rb
+++ b/spec/requests/hyku/admin/users_controller_spec.rb
@@ -5,7 +5,11 @@ RSpec.describe Admin::UsersController, type: :controller do
   context "as an admin user" do
     let(:account) { create(:account) }
     let(:user) { create(:user, email: "abc@test.com", invitation_accepted_at: DateTime.now.utc) }
+    let(:user_with_work) { create(:user, email: "bbb@test.com", invitation_accepted_at: DateTime.now.utc) }
+    let(:user_with_work_file) { create(:user, email: "ddd@test.com", invitation_accepted_at: DateTime.now.utc) }
     let(:admin_user) { create(:user, email: "admin@test.com", invitation_accepted_at: DateTime.now.utc) }
+    let(:work_with_file) { create(:work_with_one_file, visibility: "open", user: user_with_work_file) }
+    let(:work) { create(:work, visibility: "open", user: user_with_work) }
     let(:main_app) { Rails.application.routes.url_helpers }
 
     before do
@@ -15,24 +19,66 @@ RSpec.describe Admin::UsersController, type: :controller do
 
       Apartment::Tenant.switch!(account.tenant) do
         Site.update(account: account)
-        user
+        user.add_role("registered", Site.instance)
+        user_with_work.add_role("registered", Site.instance)
+        user_with_work_file.add_role("registered", Site.instance)
         admin_user.add_role("admin", Site.instance)
+        work
+        work_with_file
         sign_in admin_user
       end
     end
 
     describe "DELETE #destroy" do
-      before do
-        delete :destroy, params: { id: user.email }
+      context "User with no works" do
+        before do
+          delete :destroy, params: { id: user.email }
+        end
+
+        it "can delete via /admin/users/ for users with no work" do
+          expect(response).to redirect_to("/admin/users?locale=en")
+        end
+
+        it "flashes a success message" do
+          expect(response.request.flash[:notice]).not_to be_nil
+          expect(response.request.flash[:notice]).to match(/User "#{user.email}" has been successfully deleted./)
+        end
       end
 
-      it "can delete via /admin/users/" do
-        expect(response).to redirect_to("/admin/users?locale=en")
+      context "Soft deletes User with a work" do
+        before do
+          delete :destroy, params: { id: user_with_work.email }
+        end
+
+        it "can delete via /admin/users/ soft deletes users with works" do
+          expect(response).to redirect_to("/admin/users?locale=en")
+        end
+
+        it "flashes a success message" do
+          expect(response.request.flash[:notice]).to match(/User "#{user_with_work.email}" has been successfully deleted./)
+        end
+
+        it "soft deleted user can not sign_in" do
+          expect(user_with_work.reload.active_for_authentication?).to be_falsey
+        end
       end
 
-      it "flashes a success message" do
-        expect(response.request.flash[:notice]).not_to be_nil
-        expect(response.request.flash[:notice]).to match(/User "#{user.email}" has been successfully deleted./)
+      context "Soft with deletes User with work and file" do
+        before do
+          delete :destroy, params: { id: user_with_work_file.email }
+        end
+
+        it "can delete via /admin/users/  soft deletes user" do
+          expect(response).to redirect_to("/admin/users?locale=en")
+        end
+
+        it "flashes a success message" do
+          expect(response.request.flash[:notice]).to match(/User "#{user_with_work_file.email}" has been successfully deleted./)
+        end
+
+        it "soft deleted user should not be active for devise authentication" do
+          expect(user_with_work_file.reload.active_for_authentication?).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
In order to soft delete a user who has works and files in the system, we assign them a role of inactive while deleting any previous roles. Furthermore, we override devise gem **active_for_authentication?** and  **inactive_message** methods to ensure a soft deleted user is unable to login and gets a custom message when that user attempts to login.