### PR TITLE
Authenticate for existing users

### DIFF
--- a/app/controllers/hyku_addons/sso_controller.rb
+++ b/app/controllers/hyku_addons/sso_controller.rb
@@ -15,10 +15,10 @@ module HykuAddons
           u.password = password
           u.password_confirmation = password
           u.email = profile.email
-
-          sign_in(user)
-          set_jwt_cookies(user)
         end
+
+        set_jwt_cookies(user)
+        sign_in(user)
 
         redirect_to "/dashboard"
       end

--- a/spec/sso/sso_auth_service_spec.rb
+++ b/spec/sso/sso_auth_service_spec.rb
@@ -2,10 +2,6 @@
 
 RSpec.describe HykuAddons::Sso do
   before do
-    ENV["ORGANISATION_ID"] = "org_01GP3QSZ0967S8HZ9KYWT63Y1Y"
-    ENV["WORKOS_CLIENT_ID"] = "client_01GG7DRH9KVK3QNX2S6RGWA3CQ"
-    ENV["WORKOS_API_KEY"] = "sk_test_a2V5XzAxR0c3RFJIOURYM0NSNUdCTjU2Q0VCTkVDLFcxUHliQWkzd3lNOFdtZXVRbWVxT3NjNnM"
-
     described_class.configure do |config|
     end
   end

--- a/spec/sso/sso_call_back_service_spec.rb
+++ b/spec/sso/sso_call_back_service_spec.rb
@@ -6,9 +6,6 @@ RSpec.describe "CallBackService" do
   let(:profile_and_token) { instance_double("profile_and_token", profile: profile, token: token) }
 
   before do
-    ENV["ORGANISATION_ID"] = "org_01GP3QSZ0967S8HZ9KYWT63Y1Y"
-    ENV["WORKOS_CLIENT_ID"] = "client_01GG7DRH9KVK3QNX2S6RGWA3CQ"
-    ENV["WORKOS_API_KEY"] = "sk_test_a2V5XzAxR0c3RFJIOURYM0NSNUdCTjU2Q0VCTkVDLFcxUHliQWkzd3lNOFdtZXVRbWVxT3NjNnM"
     HykuAddons::Sso.configure do |config|
     end
     allow(WorkOS::SSO).to receive(:profile_and_token).and_return(profile_and_token)


### PR DESCRIPTION
This fix moves the sign_in and JWT token outside of the block.
Clean up the use of the keys in the tests. The ENV variables will have
to be added to the CI for the tests to work.


