### PR TITLE
Fix the nill code issue

### DIFF
--- a/app/controllers/hyku_addons/sso_controller.rb
+++ b/app/controllers/hyku_addons/sso_controller.rb
@@ -7,7 +7,7 @@ module HykuAddons
     end
 
     def callback
-      service = HykuAddons::Sso::CallBackService.new(params: { code: params["code"] })
+      service = HykuAddons::Sso::CallBackService.new(code: params[:code])
 
       service.handle do |_profile, _password|
         user = User.find_or_create_by(email: profile.email).tap do |u|

--- a/lib/hyku_addons/sso.rb
+++ b/lib/hyku_addons/sso.rb
@@ -58,13 +58,13 @@ module HykuAddons
 
     # The call back service handles the repsose back from workos
     class CallBackService
-      def initialize(params:)
-        @params = params
+      def initialize(code:)
+        @code = code
       end
 
       def handle
         profile_and_token = WorkOS::SSO.profile_and_token(
-          code: @params["code"],
+          code: @code,
           client_id: Sso.configuration.client_id
         )
 


### PR DESCRIPTION
When the callback methods is called. workos passes a code which is then turned into a profile and token, this fix captures that code correctly