### PR TITLE
Default worktype for Preprint

### DIFF
--- a/app/actors/hyrax/actors/preprint_actor.rb
+++ b/app/actors/hyrax/actors/preprint_actor.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+# Generated via
+#  `rails generate hyrax:work TemplateWork`
+module Hyrax
+  module Actors
+    class PreprintActor < Hyrax::Actors::BaseActor
+    end
+  end
+end

--- a/app/controllers/hyku_addons/sso_controller.rb
+++ b/app/controllers/hyku_addons/sso_controller.rb
@@ -22,17 +22,15 @@ module HykuAddons
         user = User.find_for_database_authentication(email: user.email)
         sign_in user
 
-        #TODO create jwt token
-        #set_jwt_cookies(user)
+        # TODO create jwt token
+        # set_jwt_cookies(user)
 
-       
         handled = true
-
       end
 
       raise HykuAddons::Sso::Error, "Failed to handle workos code #{params[:code]}" unless handled
 
-      redirect_to '/dashboard'
+      redirect_to "/dashboard"
       # Use the information in `profile` for further business logic.
     end
   end

--- a/app/controllers/hyrax/preprints_controller.rb
+++ b/app/controllers/hyrax/preprints_controller.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class PreprintsController < ApplicationController
+    include Hyrax::WorksControllerBehavior
+    include Hyrax::BreadcrumbsForWorks
+    include ::HykuAddons::WorksControllerBehavior
+
+    self.curation_concern_type = ::Preprint
+    self.show_presenter = Hyrax::PreprintPresenter
+  end
+end

--- a/app/forms/hyrax/preprint_form.rb
+++ b/app/forms/hyrax/preprint_form.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class PreprintForm < Hyrax::Forms::WorkForm
+    include Hyrax::DOI::DataCiteDOIFormBehavior
+
+    include ::HykuAddons::Schema::WorkForm
+    include Hyrax::FormFields(:preprint)
+
+    self.model_class = ::Preprint
+  end
+end

--- a/app/indexers/preprint_indexer.rb
+++ b/app/indexers/preprint_indexer.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class PreprintIndexer < Hyrax::WorkIndexer
+  include Hyrax::Indexer(:preprint)
+  include Hyrax::IndexesBasicMetadata
+  include Hyrax::IndexesLinkedMetadata
+end

--- a/app/models/preprint.rb
+++ b/app/models/preprint.rb
@@ -10,4 +10,9 @@ class Preprint < ActiveFedora::Base
   include Hyrax::BasicMetadata
 
   self.indexer = ::PreprintIndexer
+
+  validates :title, presence: { message: "Your work must have a title." }
+  def doi_registrar_opts
+    {}
+  end
 end

--- a/app/models/preprint.rb
+++ b/app/models/preprint.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+class Preprint < ActiveFedora::Base
+  include Hyrax::WorkBehavior
+  include Hyrax::DOI::DataCiteDOIBehavior
+
+  include HykuAddons::Schema::WorkBase
+  include Hyrax::Schema(:preprint)
+
+  # Included after other field definitions
+  include Hyrax::BasicMetadata
+
+  self.indexer = ::PreprintIndexer
+end

--- a/app/presenters/hyrax/preprint_presenter.rb
+++ b/app/presenters/hyrax/preprint_presenter.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Hyrax
+  class PreprintPresenter < Hyrax::WorkShowPresenter
+    include ::HykuAddons::Schema::Presenter(:preprint)
+    include ::HykuAddons::WorkPresenterBehavior
+    include ::HykuAddons::PresenterDelegatable
+  end
+end

--- a/config/initializers/hyrax.rb
+++ b/config/initializers/hyrax.rb
@@ -35,6 +35,7 @@ Hyrax.config do |config|
   config.register_curation_concern :pacific_presentation
   config.register_curation_concern :pacific_text_work
   config.register_curation_concern :pacific_uncategorized
+  config.register_curation_concern :preprint
   config.register_curation_concern :redlands_article
   config.register_curation_concern :redlands_book
   config.register_curation_concern :redlands_chapters_and_book_section

--- a/config/locales/preprint.en.yml
+++ b/config/locales/preprint.en.yml
@@ -1,0 +1,8 @@
+en:
+  hyrax:
+    icons:
+      preprint: "fa fa-file-text-o"
+    select_type:
+      preprint:
+        description: "Preprints"
+        name: "Preprint"

--- a/config/metadata/preprint.yaml
+++ b/config/metadata/preprint.yaml
@@ -1,0 +1,315 @@
+attributes:
+  title:
+    type: string
+    predicate: http://purl.org/dc/terms/title
+    multiple: true
+    index_keys:
+      - title_tesim
+      - title_sim
+    form:
+      required: true
+      primary: true
+      multiple: true
+      type: text
+      input: single_multi_value
+  alt_title:
+    type: string
+    predicate: http://purl.org/dc/terms/alternative
+    multiple: true
+    index_keys:
+      - alt_title_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+  resource_type:
+    predicate: http://purl.org/dc/terms/type
+    multiple: true
+    index_keys:
+      - resource_type_tesim
+      - resource_type_sim
+    form:
+      required: true
+      primary: true
+      multiple: true
+      type: select
+      authority: HykuAddons::ResourceTypesService
+      include_blank: true
+      input: single_multi_value_select
+  creator:
+    predicate: http://purl.org/dc/elements/1.1/creator
+    multiple: true
+    index_keys:
+      - creator_tesim
+    form:
+      required: true
+      primary: true
+      multiple: true
+      type: text
+    subfields:
+      creator_name_type:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: select
+          authority: HykuAddons::NameTypeService
+      creator_family_name:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: text
+          display_for:
+            - Personal
+      creator_given_name:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: text
+          display_for:
+            - Personal
+      creator_middle_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Personal
+      creator_suffix:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Personal
+      creator_orcid:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Personal
+      creator_institutional_relationship:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: select
+          authority: HykuAddons::InstitutionalRelationshipService
+          attributes:
+            multiple: multiple
+          display_for:
+            - Personal
+      creator_organization_name:
+        type: string
+        form:
+          required: true
+          multiple: false
+          type: text
+          display_for:
+            - Organizational
+      creator_ror:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Organizational
+      creator_grid:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Organizational
+      creator_wikidata:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Organizational
+      creator_isni:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          display_for:
+            - Personal
+            - Organizational
+      creator_profile_visibility:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: hidden
+          display_for:
+            - Personal
+  abstract:
+    type: text
+    predicate: http://purl.org/dc/terms/abstract
+    multiple: false
+    index_keys:
+      - abstract_tesim
+    form:
+      required: false
+      primary: true
+      multiple: false
+      type: textarea
+  keyword:
+    predicate: http://purl.org/dc/elements/1.1/relation
+    multiple: true
+    index_keys:
+      - keyword_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+  subject:
+    predicate: http://purl.org/dc/elements/1.1/subject
+    multiple: true
+    index_keys:
+      - subject_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: select
+      authority: HykuAddons::SubjectService
+  preprint_doi:
+    type: text
+    predicate: http://purl.org/dc/terms/identifier
+    multiple: true
+    index_keys:
+      - preprint_doi_tesim
+    form:
+      required: false
+      multiple: false
+      type: text
+      authority: null
+      primary: true    
+  doi:
+    type: string
+    predicate: http://purl.org/ontology/bibo/doi
+    multiple: true
+    index_keys:
+      - doi_ssi
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+  license:
+    predicate: http://purl.org/dc/terms/rights
+    multiple: true
+    index_keys:
+      - license_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: select
+      authority: HykuAddons::LicenseService
+  rights_holder:
+    type: string
+    predicate: http://purl.org/dc/terms/rightsHolder
+    multiple: true
+    index_keys:
+      - rights_holder_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+  rights_statement:
+    predicate: http://www.europeana.eu/schemas/edm/rights
+    multiple: false
+    index_keys:
+      - rights_statement_tesim
+    form:
+      required: false
+      primary: true
+      multiple: false
+      type: select
+      authority: HykuAddons::RightsStatementService
+  add_info:
+    type: string
+    predicate: http://purl.org/ontology/bibo/Note
+    multiple: false
+    index_keys:
+      - add_info_tesim
+    form:
+      required: false
+      primary: true
+      multiple: false
+      type: textarea
+  language:
+    predicate: http://purl.org/dc/elements/1.1/language
+    multiple: true
+    index_keys:
+      - language_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: select
+      authority: HykuAddons::LanguageService
+  funder:
+    type: string
+    predicate: http://id.loc.gov/vocabulary/relators/fnd
+    multiple: true
+    index_keys:
+      - funder_tesim
+    form:
+      required: false
+      primary: true
+      multiple: true
+      type: text
+    subfields:
+      funder_name:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+          input: controlled_vocabulary
+          attributes:
+            data:
+              field_name: ubiquity_funder_name
+              autocomplete-url: /authorities/search/crossref/funders
+              autocomplete: funder
+      funder_doi:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+      funder_isni:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+      funder_ror:
+        type: string
+        form:
+          required: false
+          multiple: false
+          type: text
+      funder_award:
+        type: string
+        form:
+          required: false
+          multiple: true
+          type: text

--- a/config/metadata/preprint.yaml
+++ b/config/metadata/preprint.yaml
@@ -188,14 +188,14 @@ attributes:
       type: select
       authority: HykuAddons::SubjectService
   preprint_doi:
-    type: text
+    type: string
     predicate: http://purl.org/dc/terms/identifier
     multiple: true
     index_keys:
       - preprint_doi_tesim
     form:
       required: false
-      multiple: false
+      multiple: true
       type: text
       authority: null
       primary: true    

--- a/config/metadata/ubiquity_template_work.yaml
+++ b/config/metadata/ubiquity_template_work.yaml
@@ -282,6 +282,18 @@ attributes:
       primary: true
       multiple: false
       type: date
+  preprint_doi:
+    type: text
+    predicate: http://purl.org/dc/terms/identifier
+    multiple: true
+    index_keys:
+      - preprint_doi_tesim
+    form:
+      required: false
+      multiple: false
+      type: text
+      authority: null
+      primary: true
   doi:
     type: string
     predicate: http://purl.org/ontology/bibo/doi

--- a/spec/features/preprint_form_spec.rb
+++ b/spec/features/preprint_form_spec.rb
@@ -1,0 +1,174 @@
+# frozen_string_literal: true
+
+require HykuAddons::Engine.root.join("spec", "support", "fill_in_fields.rb").to_s
+require HykuAddons::Engine.root.join("spec", "support", "work_form_helpers.rb").to_s
+
+RSpec.feature "Create a Preprint", js: true, slow: true do
+  let(:work_type) { "preprint" }
+  let(:work) { work_type.classify.constantize.find(work_uuid_from_url) }
+
+  let(:model) { work_type.classify.constantize }
+  let(:field_config) { "hyrax/#{work_type}_form".classify.constantize.field_configs }
+  let(:user) { User.new(email: "test@example.com") { |u| u.save(validate: false) } }
+  let(:admin_set_id) { AdminSet.find_or_create_default_admin_set_id }
+  let(:permission_template) { Hyrax::PermissionTemplate.find_or_create_by!(source_id: admin_set_id) }
+  let(:workflow) { Sipity::Workflow.create!(active: true, name: "test-workflow", permission_template: permission_template) }
+  let(:new_work_path) { "concern/#{work_type.to_s.pluralize}/new" }
+  let(:permission_options) do
+    { permission_template_id: permission_template.id, agent_type: "user", agent_id: user.user_key, access: "deposit" }
+  end
+  let(:headers) do
+    {
+      "Accept" => "application/json",
+      "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+      "User-Agent" => "Faraday v0.17.5"
+    }
+  end
+
+  # The organisation option changes depending on the local, so we need to use this to ensure we select the right one
+  let(:title) { "Preprint Item" }
+  let(:alt_title) { ["Alt Title 1", "Alt Title 2"] }
+  # The order of the items in each hash must match the order of the fields in the work form
+  let(:creator) do
+    [
+      {
+        creator_name_type: "Personal",
+        creator_family_name: "Smithy",
+        creator_given_name: "Johnny",
+        creator_middle_name: "J.",
+        creator_suffix: "Mr",
+        creator_orcid: "0000-0000-1111-2222",
+        creator_institutional_relationship: "Research associate",
+        creator_isni: "56273930281",
+        # This is a hidden field set in the form, but we want to be able to check its value is set
+        creator_profile_visibility: User::PROFILE_VISIBILITY[:closed]
+      },
+      {
+        creator_name_type: organisation_option["label"],
+        creator_organization_name: "A Test Company Name",
+        creator_ror: "ror.org/123456",
+        creator_grid: "grid.org/098765",
+        creator_wikidata: "wiki.com/123",
+        creator_isni: "1234567890"
+      }
+    ]
+  end
+  let(:preprint_doi) { "978-3-16-148410-0" }
+  let(:doi) { "10.1521/soco.23.1.118.59197" }
+  let(:resource_type) { HykuAddons::ResourceTypesService.new(model: model).active_elements.sample(1) }
+  let(:keyword) { ["keyword1", "keyword2"] }
+  let(:license_options) { HykuAddons::LicenseService.new(model: model).active_elements.sample(2) }
+  let(:rights_statement_options) { HykuAddons::RightsStatementService.new(model: model).active_elements.sample(1) }
+  let(:subject_options) { HykuAddons::SubjectService.new(model: model).active_elements.sample(2) }
+  let(:language_options) { HykuAddons::LanguageService.new(model: model).active_elements.sample(2) }
+  let(:abstract) { "This is the abstract text" }
+  let(:funder) do
+    [
+      {
+        funder_name: "A funder",
+        funder_doi: "doi.org/123456",
+        funder_isni: "0987654321",
+        funder_ror: "ror.org/123456678",
+        funder_award: ["Award1"]
+      },
+      {
+        funder_name: "Another funder",
+        funder_doi: "doi.org/098765",
+        funder_isni: "1234567890",
+        funder_ror: "ror.org/345678976543",
+        funder_award: ["Award2"]
+      }
+    ]
+  end
+  let(:rights_holder) { ["Holder1", "Holder2"] }
+  let(:add_info) { "Some additional information" }
+
+  before do
+    Sipity::WorkflowAction.create!(name: "submit", workflow: workflow)
+    Hyrax::PermissionTemplateAccess.create!(permission_options)
+
+    stub_request(:get, "http://api.crossref.org/funders?query=A%20funder")
+      .with(headers: headers)
+      .to_return(status: 200, body: "", headers: {})
+
+    stub_request(:get, "http://api.crossref.org/funders?query=Another%20funder")
+      .with(headers: headers)
+      .to_return(status: 200, body: "", headers: {})
+
+    login_as user
+    visit new_work_path
+  end
+
+  context "when the form is filled out" do
+    before do
+      click_link "Descriptions"
+      click_on "Additional fields"
+
+      # Required fields
+      fill_in_text_field(:title, title)
+      fill_in_text_field(:preprint_doi, preprint_doi)
+      fill_in_text_field(:doi, doi)
+      fill_in_multiple_text_fields(:alt_title, alt_title)
+      fill_in_select(:resource_type, resource_type.map { |h| h["label"] }.first)
+      fill_in_cloneable(:creator, creator)
+
+      # Additional fields
+      fill_in_multiple_text_fields(:keyword, keyword)
+      fill_in_multiple_selects(:license, license_options.map { |h| h["label"] })
+      fill_in_select(:rights_statement, rights_statement_options.map { |h| h["label"] }.first)
+      fill_in_multiple_selects(:subject, subject_options.map { |h| h["label"] })
+      fill_in_multiple_selects(:language, language_options.map { |h| h["label"] })
+      fill_in_textarea(:abstract, abstract)
+      fill_in_cloneable(:funder, funder)
+      fill_in_multiple_text_fields(:rights_holder, rights_holder)
+      fill_in_textarea(:add_info, add_info)
+      fill_in_text_field(:rights_statement_text, rights_statement_text)
+    end
+
+    describe "submitting the form" do
+      before do
+        add_visibility
+        add_agreement
+        submit
+      end
+
+      it "redirects to the work show page" do
+        # Ensure the basic data is being prenented and we're on the right page
+        aggregate_failures "testing the saved data" do
+          expect(page).to have_selector("h1", text: work_type.titleize, wait: 20)
+          expect(page).to have_selector("h2", text: title, wait: 20)
+          expect(page).to have_selector("span", text: "Public")
+          expect(page).to have_content("Your files are being processed by Hyku in the background.")
+
+          expect(page).to have_content(resource_type.map { |h| h["id"] }.first)
+          alt_title.each { |at| expect(page).to have_content(at) }
+          expect(page).to have_content("#{creator.first.dig(:creator_family_name)}, #{creator.first.dig(:creator_given_name)}")
+          expect(page).to have_content("#{contributor.first.dig(:contributor_family_name)}, #{contributor.first.dig(:contributor_given_name)}")
+          %i[published accepted submitted].each { |d| expect(page).to have_content(normalize_date(send("date_#{d}".to_sym)).first) }
+          duration.each { |at| expect(page).to have_content(at) }
+          description.each { |at| expect(page).to have_content(at) }
+          expect(page).to have_content("https://doi.org/#{doi}")
+
+          expect(work.title).to eq([title])
+          expect(work.preprint_doi).to eq([preprint_doi])
+          expect(work.doi).to eq([doi])
+          expect(work.resource_type).to eq(resource_type.map { |h| h["id"] })
+          # Cloneable fields use the label to select the option, but save the id to the work
+          expect(work.creator).to eq([creator.to_json.gsub(organisation_option["label"], organisation_option["id"])])
+          expect(work.keyword).to eq(keyword)
+          expect(work.license).to eq(license_options.map { |h| h["id"] })
+          expect(work.rights_statement).to eq(rights_statement_options.map { |h| h["id"] })
+          expect(work.subject).to eq(subject_options.map { |h| h["id"] })
+          expect(work.language).to eq(language_options.map { |h| h["id"] })
+          expect(work.abstract).to eq(abstract)
+          expect(work.funder).to eq([funder.to_json])
+          # We need to test the first item or an ActiveTripple::Relation is returned
+          expect(work.rights_holder).to eq(rights_holder)
+          expect(work.add_info).to eq(add_info)
+          expect(work.subject_text).to eq(subject_text)
+          expect(work.rights_statement_text).to eq(rights_statement_text)
+        end
+      end
+    end
+  end
+end

--- a/spec/features/ubiquity_template_work_form_spec.rb
+++ b/spec/features/ubiquity_template_work_form_spec.rb
@@ -55,6 +55,7 @@ RSpec.feature "Create a UbiquityTemplateWork", js: true, slow: true do
       }
     ]
   end
+  let(:preprint_doi) { "978-3-16-148410-0" }
   let(:doi) { "10.1521/soco.23.1.118.59197" }
   let(:contributor) do
     [
@@ -280,6 +281,7 @@ RSpec.feature "Create a UbiquityTemplateWork", js: true, slow: true do
 
       # Required fields
       fill_in_text_field(:title, title)
+      fill_in_text_field(:preprint_doi, preprint_doi)
       fill_in_text_field(:doi, doi)
       fill_in_multiple_text_fields(:alt_title, alt_title)
       fill_in_select(:resource_type, resource_type.map { |h| h["label"] }.first)
@@ -412,6 +414,7 @@ RSpec.feature "Create a UbiquityTemplateWork", js: true, slow: true do
           expect(page).to have_content("https://doi.org/#{doi}")
 
           expect(work.title).to eq([title])
+          expect(work.preprint_doi).to eq([preprint_doi])
           expect(work.doi).to eq([doi])
           expect(work.resource_type).to eq(resource_type.map { |h| h["id"] })
           expect(work.date_published).to eq(normalize_date(date_published).first)


### PR DESCRIPTION
This work will add a default work type for preprints, including a custom field called Preprint DOI. 
It also adds the new field, Preprint DOI to the ubiquity template work type yaml file and the feature tests.