### PR TITLE
Add missing partial for Preprint work type

### DIFF
--- a/app/views/hyrax/preprints/_preprint.html.erb
+++ b/app/views/hyrax/preprints/_preprint.html.erb
@@ -1,0 +1,2 @@
+<%# This is a search result view %>
+<%= render 'catalog/document', document: preprint, document_counter: preprint_counter  %>


### PR DESCRIPTION
Add missing partial for Preprint work type to fix the issue related to search on the vanilla front end