### PR TITLE
Repo 2032 add connetion_id to accounts

### DIFF
--- a/app/controllers/hyku_addons/sso_controller.rb
+++ b/app/controllers/hyku_addons/sso_controller.rb
@@ -10,7 +10,8 @@ module HykuAddons
     end
 
     def callback
-      service = HykuAddons::Sso::CallBackService.new(code: params[:code])
+
+      service = HykuAddons::Sso::CallBackService.new(code: params[:code],host: request.host)
 
       handled = false
 

--- a/db/migrate/20230317071542_add_workos_connection_id_to_accounts.rb
+++ b/db/migrate/20230317071542_add_workos_connection_id_to_accounts.rb
@@ -1,0 +1,5 @@
+class AddWorkosConnectionIdToAccounts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :accounts, :work_os_connection_id, :string
+  end
+end

--- a/lib/hyku_addons/sso.rb
+++ b/lib/hyku_addons/sso.rb
@@ -51,7 +51,7 @@ module HykuAddons
         account = Account.find_by cname: @host
           
         WorkOS::SSO.authorization_url(
-          client_id: Sso.configuration.client_id,
+          client_id: account.nil? Sso.configuration.client_id : account.work_os_connection_id
           organization: account.nil? ? Sso.configuration.work_os_orgntion : account.work_os_orgnaisation,
           redirect_uri: redirect_uri
         )
@@ -60,14 +60,19 @@ module HykuAddons
 
     # The call back service handles the repsose back from workos
     class CallBackService
-      def initialize(code:)
+      def initialize(code:,host:)
         @code = code
+        @host = host
       end
 
       def handle
+
+
+        account = Account.find_by cname: @host
+
         profile_and_token = WorkOS::SSO.profile_and_token(
           code: @code,
-          client_id: Sso.configuration.client_id
+          client_id: account.nil? ? Sso.configuration.client_id : account.work_os_connection_id
         )
 
         password = SecureRandom.hex(10)

--- a/lib/tasks/hyku_addons/sso.rake
+++ b/lib/tasks/hyku_addons/sso.rake
@@ -4,9 +4,9 @@ namespace :hyku_addons do
 
   namespace :sso do
     desc "Enable sso for a tenant"
-    task :enable, [:cname,:organisation_id] => [:environment] do |_cmd, args|
+    task :enable, [:cname,:organisation_id,:connection_id] => [:environment] do |_cmd, args|
       Account.find_by(cname: args[:cname])
-             .update(enable_sso: true, work_os_orgnaisation: args[:organisation_id])
+             .update(enable_sso: true, work_os_orgnaisation: args[:organisation_id], work_os_connection_id: args[:connection_id])
 
       puts "SSO Enabled for " + args[:cname]
     end


### PR DESCRIPTION
Move connection id to accounts. this change makes SSO trully multi tenanted . 