### PR TITLE
REPO-1866 - Fix for the issue where search is not working for non admin users

### DIFF
--- a/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
+++ b/app/controllers/concerns/hyku_addons/catalog_controller_behavior.rb
@@ -19,6 +19,8 @@ module HykuAddons
       append_before_action :routing_error_unless_feature_enabled, only: :oai
 
       configure_blacklight do |config|
+        # Configure Blacklight to use POST instead of GET to prevent Solr from producing 414 error for large queries
+        config.http_method = :post
         # Re-configure facet fields
         config.facet_fields = {}
         config.add_facet_field solr_name("resource_type", :facetable), label: "Resource Type", limit: 5


### PR DESCRIPTION
This will fix the issue [REPO-1866](https://ubiquitypress.atlassian.net/browse/REPO-1866). 

- This is a Configuration change to use POST instead of GET when querying Solr. This is to accommodate large sets of query params and it will prevent Solr from producing 414 error for large queries. 
- Reference [Solr reporting "URI is too large >8192" for bookmarks request](https://github.com/projectblacklight/blacklight/issues/1324)

[REPO-1866]: https://ubiquitypress.atlassian.net/browse/REPO-1866?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ