### PR TITLE
REPO-2124 - Update to the new work type yamls 

### DIFF
--- a/config/metadata/data_management_plan.yaml
+++ b/config/metadata/data_management_plan.yaml
@@ -36,14 +36,14 @@ attributes:
       type: textarea
   resource_type:
     predicate: http://purl.org/dc/terms/type
-    multiple: false
+    multiple: true
     index_keys:
       - resource_type_tesim
       - resource_type_sim
     form:
       required: true
       primary: true
-      multiple: false
+      multiple: true
       type: select
       authority: HykuAddons::ResourceTypesService
       include_blank: true

--- a/config/metadata/grant_record.yaml
+++ b/config/metadata/grant_record.yaml
@@ -25,14 +25,14 @@ attributes:
       type: text
   resource_type:
     predicate: http://purl.org/dc/terms/type
-    multiple: false
+    multiple: true
     index_keys:
       - resource_type_tesim
       - resource_type_sim
     form:
       required: true
       primary: true
-      multiple: false
+      multiple: true
       type: select
       authority: HykuAddons::ResourceTypesService
       include_blank: true

--- a/config/metadata/lab_notebook.yaml
+++ b/config/metadata/lab_notebook.yaml
@@ -25,14 +25,14 @@ attributes:
       type: text
   resource_type:
     predicate: http://purl.org/dc/terms/type
-    multiple: false
+    multiple: true
     index_keys:
       - resource_type_tesim
       - resource_type_sim
     form:
       required: true
       primary: true
-      multiple: false
+      multiple: true
       type: select
       authority: HykuAddons::ResourceTypesService
       include_blank: true

--- a/config/metadata/minute.yaml
+++ b/config/metadata/minute.yaml
@@ -25,14 +25,14 @@ attributes:
       type: text
   resource_type:
     predicate: http://purl.org/dc/terms/type
-    multiple: false
+    multiple: true
     index_keys:
       - resource_type_tesim
       - resource_type_sim
     form:
       required: true
       primary: true
-      multiple: false
+      multiple: true
       type: select
       authority: HykuAddons::ResourceTypesService
       include_blank: true

--- a/config/metadata/open_educational_resource.yaml
+++ b/config/metadata/open_educational_resource.yaml
@@ -25,14 +25,14 @@ attributes:
       type: text
   resource_type:
     predicate: http://purl.org/dc/terms/type
-    multiple: false
+    multiple: true
     index_keys:
       - resource_type_tesim
       - resource_type_sim
     form:
       required: true
       primary: true
-      multiple: false
+      multiple: true
       type: select
       authority: HykuAddons::ResourceTypesService
       include_blank: true


### PR DESCRIPTION
Fixes the issue where the resource types were not saving ([REPO-2124](https://ubiquitypress.atlassian.net/browse/REPO-2124))

[REPO-2124]: https://ubiquitypress.atlassian.net/browse/REPO-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ