### PR TITLE
REPO-2161-Removing unwanted log entries

### DIFF
--- a/app/actors/hyku_addons/actors/creator_profile_visibility_actor.rb
+++ b/app/actors/hyku_addons/actors/creator_profile_visibility_actor.rb
@@ -3,9 +3,7 @@ module HykuAddons
   module Actors
     class CreatorProfileVisibilityActor < Hyrax::Actors::AbstractActor
       def create(env)
-        puts "LOG_CREATE_CreatorProfileVisibilityActor_BEFORE_toggle_visibility #{env.inspect}"
         toggle_visibility(env)
-        puts "LOG_CREATE_CreatorProfileVisibilityActor_AFTER_toggle_visibility #{env.inspect}"
         next_actor.create(env)
       end
 

--- a/app/actors/hyku_addons/actors/date_fields_actor.rb
+++ b/app/actors/hyku_addons/actors/date_fields_actor.rb
@@ -3,9 +3,7 @@ module HykuAddons
   module Actors
     class DateFieldsActor < Hyrax::Actors::AbstractActor
       def create(env)
-        puts "LOG_CREATE_AT_DateFieldsActor_BEFORE_serialize_date_fields #{env.inspect}"
         serialize_date_fields(env) && next_actor.create(env)
-        
       end
 
       def update(env)
@@ -15,16 +13,11 @@ module HykuAddons
       private
 
       def serialize_date_fields(env)
-        puts "LOG_serialize_date_fields_AT_DateFieldsActor_Line_18 #{env.inspect}"
         env.curation_concern.class.date_fields.each do |field|
-          puts "LOG_serialize_date_fields_AT_DateFieldsActor_Line_20_field #{field.inspect}"
           next if env.attributes[field].blank?
 
           env.attributes[field] = Array(env.attributes[field]).collect { |date_hash| transform_date(date_hash, field) }
-          puts "LOG_serialize_date_fields_AT_DateFieldsActor_Line_24_env #{env.inspect}"
           env.attributes[field] = env.attributes[field].first unless env.curation_concern.class.multiple?(field)
-          puts "LOG_serialize_date_fields_AT_DateFieldsActor_Line_26_env_attributes_field #{env.attributes[field].inspect}"
-          puts "LOG_serialize_date_fields_AT_DateFieldsActor_Line_27_env #{env.inspect}"
         end
       end
 

--- a/app/actors/hyku_addons/actors/json_fields_actor.rb
+++ b/app/actors/hyku_addons/actors/json_fields_actor.rb
@@ -3,9 +3,7 @@ module HykuAddons
   module Actors
     class JSONFieldsActor < Hyrax::Actors::AbstractActor
       def create(env)
-        puts "LOG_CREATE_AT_JSONFieldsActor_BEFORE_jsonify_fields #{env.inspect}"
         jsonify_fields(env) && next_actor.create(env)
-        
       end
 
       def update(env)
@@ -15,25 +13,17 @@ module HykuAddons
       private
 
       def jsonify_fields(env)
-        puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_18 #{env.inspect}"
         env.curation_concern.class.json_fields.each do |field|
           # This handles the case when field is a key/value pair coming from the yaml schema
           field = field.first if field.is_a?(Array)
-          puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_22_env #{env.inspect}"
 
-          puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_24_field #{field.inspect}"
           if name_blank?(field, env.attributes[field]) || recursive_blank?(env.attributes[field])
             env.attributes.delete(field)
-            puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_27_env #{env.inspect}"
           else
             env.attributes[field].reject! { |o| name_blank?(field, o) || recursive_blank?(o) } if env.attributes[field].is_a?(Array)
-            puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_30_env #{env.inspect}"
             env.attributes[field] = env.attributes[field].to_json
-            puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_32_env #{env.inspect}"
           end
-          puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_34_env #{env.inspect}"
           ensure_multiple!(env, field)
-          puts "LOG_jsonify_fields_AT_JSONFieldsActor_Line_36_env #{env.inspect}"
         end
       end
 

--- a/app/actors/hyku_addons/actors/member_collection_from_admin_set_actor.rb
+++ b/app/actors/hyku_addons/actors/member_collection_from_admin_set_actor.rb
@@ -4,9 +4,7 @@ module HykuAddons
   module Actors
     class MemberCollectionFromAdminSetActor < Hyrax::Actors::AbstractActor
       def create(env)
-        puts "LOG_CREATE_AT_MemberCollectionFromAdminSetActor_BEFORE_ensure_collection #{env.inspect}"
         ensure_collection!(env) if enabled? && correct_permissions?(env)
-        puts "LOG_CREATE_AT_MemberCollectionFromAdminSetActor_AFTER_ensure_collection #{env.inspect}"
         next_actor.create(env)
       end
 

--- a/app/actors/hyku_addons/actors/note_field_actor.rb
+++ b/app/actors/hyku_addons/actors/note_field_actor.rb
@@ -6,9 +6,7 @@ module HykuAddons
       attr_accessor :email
 
       def create(env)
-        puts "LOG_CREATE_AT_NoteFieldActor_BEFORE_serialize_note_field #{env.inspect}"
         serialize_note_field(env)
-        puts "LOG_CREATE_AT_NoteFieldActor_AFTER_serialize_note_field #{env.inspect}"
         next_actor.create(env)
       end
 

--- a/app/actors/hyku_addons/actors/related_identifier_actor.rb
+++ b/app/actors/hyku_addons/actors/related_identifier_actor.rb
@@ -3,7 +3,6 @@ module HykuAddons
   module Actors
     class RelatedIdentifierActor < Hyrax::Actors::AbstractActor
       def create(env)
-        puts "LOG_CREATE_AT_RelatedIdentifierActor_BEFORE_add_related_identifier_data #{env.inspect}"
         add_related_identifier_data(env) && next_actor.create(env)
       end
 

--- a/app/actors/hyku_addons/actors/task_master/work_actor.rb
+++ b/app/actors/hyku_addons/actors/task_master/work_actor.rb
@@ -6,9 +6,7 @@ module HykuAddons
     module TaskMaster
       class WorkActor < Hyrax::Actors::AbstractActor
         def create(env)
-          puts "LOG_CREATE_AT_WorkActor_BEFORE_upsert #{env.inspect}"
           enqueue_job("upsert", env)
-          puts "LOG_CREATE_AT_WorkActor_AFTER_upsert #{env.inspect}"
           next_actor.create(env)
         end
 


### PR DESCRIPTION
Just removed the log entries we added during the autopopulator investigation so it is easy to work with the autopopulator locally. Will add some of these log entries later if they are necessary.